### PR TITLE
Update fast.ai to 2.7.9 and matching stars

### DIFF
--- a/TripletLossTutorial.ipynb
+++ b/TripletLossTutorial.ipynb
@@ -29,16 +29,6 @@
     "\n",
     "Beyond identifying Uncle Al and Aunt Betty in a photo library, re-identification is a common problem for wildlife biologists. Many species have photographic catalogs taken over years and decades, and many species have some distinctive features that can be used to identify individuals. \n",
     "\n",
-    "### Some animals and how they may be re-identified\n",
-    "\n",
-    "| Species | &nbsp | &nbsp |\n",
-    "| --- | --- | --- |\n",
-    "| Humpback Whales | tk | tk |\n",
-    "| Tigers | tk | tk | \n",
-    "| Dolphins | tk | tk | \n",
-    "| Manta Rays | tk | tk | \n",
-    "\n",
-    "\n",
     "## Create the Python environment \n",
     "\n",
     "I developed this tutorial on Ubuntu 20.04, Cuda 10.2, PyTorch 1.7, FastAI 2.3. I have to admit that the rigmarole of exactly recreating a GPU-enabled virtual environment is a little beyond me, but I _think_ you have to install CUDA manually and then when you run the `conda create` command below, I _think_ it will download properly-configured versions of the various libraries. \n",
@@ -94,81 +84,35 @@
    "id": "70695725",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T13:57:56.754180Z",
-     "iopub.status.busy": "2022-08-16T13:57:56.753425Z",
-     "iopub.status.idle": "2022-08-16T13:57:58.619255Z",
-     "shell.execute_reply": "2022-08-16T13:57:58.618532Z",
-     "shell.execute_reply.started": "2022-08-16T13:57:56.754114Z"
+     "iopub.execute_input": "2022-08-16T14:41:46.460512Z",
+     "iopub.status.busy": "2022-08-16T14:41:46.460222Z",
+     "iopub.status.idle": "2022-08-16T14:41:48.380698Z",
+     "shell.execute_reply": "2022-08-16T14:41:48.379912Z",
+     "shell.execute_reply.started": "2022-08-16T14:41:46.460440Z"
     },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "#from fastai.vision import *\n",
-    "#from fastai.basics import *\n",
     "from fastai.vision.all import *\n",
     "\n",
-    "\n",
-    "#from fastai.vision.augment import *\n",
-    "#from fastai.vision.learner import cnn_learner\n",
-    "#from fastai.vision.models import resnet34\n",
-    "#from fastai.metrics import accuracy\n",
-    "from fastai.data.core import DataLoaders"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "cf0f774d",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-08-16T13:58:06.977403Z",
-     "iopub.status.busy": "2022-08-16T13:58:06.976857Z",
-     "iopub.status.idle": "2022-08-16T13:58:06.981038Z",
-     "shell.execute_reply": "2022-08-16T13:58:06.980002Z",
-     "shell.execute_reply.started": "2022-08-16T13:58:06.977383Z"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
     "import torch\n",
-    "import torchvision\n",
     "import torch.nn as nn\n",
-    "from loss_functions.triplet_loss import TripletLoss"
+    "from loss_functions.triplet_loss import TripletLoss\n",
+    "from scipy import spatial"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "ba5fc5c8",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-08-16T13:58:07.600191Z",
-     "iopub.status.busy": "2022-08-16T13:58:07.599534Z",
-     "iopub.status.idle": "2022-08-16T13:58:07.603257Z",
-     "shell.execute_reply": "2022-08-16T13:58:07.602459Z",
-     "shell.execute_reply.started": "2022-08-16T13:58:07.600171Z"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "from scipy import spatial\n",
-    "import logging"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 2,
    "id": "5eee8960",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T13:58:09.852438Z",
-     "iopub.status.busy": "2022-08-16T13:58:09.852111Z",
-     "iopub.status.idle": "2022-08-16T13:58:09.996708Z",
-     "shell.execute_reply": "2022-08-16T13:58:09.995856Z",
-     "shell.execute_reply.started": "2022-08-16T13:58:09.852393Z"
+     "iopub.execute_input": "2022-08-16T14:41:48.382302Z",
+     "iopub.status.busy": "2022-08-16T14:41:48.381680Z",
+     "iopub.status.idle": "2022-08-16T14:41:48.524368Z",
+     "shell.execute_reply": "2022-08-16T14:41:48.523616Z",
+     "shell.execute_reply.started": "2022-08-16T14:41:48.382282Z"
     },
     "tags": []
    },
@@ -195,15 +139,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 3,
    "id": "6db7e95b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T13:58:11.269917Z",
-     "iopub.status.busy": "2022-08-16T13:58:11.269216Z",
-     "iopub.status.idle": "2022-08-16T13:58:11.276243Z",
-     "shell.execute_reply": "2022-08-16T13:58:11.275306Z",
-     "shell.execute_reply.started": "2022-08-16T13:58:11.269896Z"
+     "iopub.execute_input": "2022-08-16T14:41:48.527268Z",
+     "iopub.status.busy": "2022-08-16T14:41:48.526898Z",
+     "iopub.status.idle": "2022-08-16T14:41:48.534295Z",
+     "shell.execute_reply": "2022-08-16T14:41:48.533289Z",
+     "shell.execute_reply.started": "2022-08-16T14:41:48.527224Z"
     },
     "tags": []
    },
@@ -214,7 +158,7 @@
        "'2.7.9'"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -226,15 +170,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 4,
    "id": "2f72706c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T13:58:12.201549Z",
-     "iopub.status.busy": "2022-08-16T13:58:12.200727Z",
-     "iopub.status.idle": "2022-08-16T13:58:12.207786Z",
-     "shell.execute_reply": "2022-08-16T13:58:12.206300Z",
-     "shell.execute_reply.started": "2022-08-16T13:58:12.201528Z"
+     "iopub.execute_input": "2022-08-16T14:41:48.535813Z",
+     "iopub.status.busy": "2022-08-16T14:41:48.535647Z",
+     "iopub.status.idle": "2022-08-16T14:41:48.542632Z",
+     "shell.execute_reply": "2022-08-16T14:41:48.541746Z",
+     "shell.execute_reply.started": "2022-08-16T14:41:48.535794Z"
     },
     "tags": []
    },
@@ -245,7 +189,7 @@
        "True"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -256,15 +200,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 5,
    "id": "a6a0b375",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T13:58:13.054026Z",
-     "iopub.status.busy": "2022-08-16T13:58:13.053484Z",
-     "iopub.status.idle": "2022-08-16T13:58:13.062453Z",
-     "shell.execute_reply": "2022-08-16T13:58:13.061350Z",
-     "shell.execute_reply.started": "2022-08-16T13:58:13.054007Z"
+     "iopub.execute_input": "2022-08-16T14:41:48.543545Z",
+     "iopub.status.busy": "2022-08-16T14:41:48.543392Z",
+     "iopub.status.idle": "2022-08-16T14:41:48.551252Z",
+     "shell.execute_reply": "2022-08-16T14:41:48.550088Z",
+     "shell.execute_reply.started": "2022-08-16T14:41:48.543525Z"
     },
     "tags": []
    },
@@ -292,15 +236,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "id": "0963c65b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T13:58:16.174960Z",
-     "iopub.status.busy": "2022-08-16T13:58:16.174746Z",
-     "iopub.status.idle": "2022-08-16T13:58:16.445157Z",
-     "shell.execute_reply": "2022-08-16T13:58:16.444409Z",
-     "shell.execute_reply.started": "2022-08-16T13:58:16.174931Z"
+     "iopub.execute_input": "2022-08-16T14:41:48.552891Z",
+     "iopub.status.busy": "2022-08-16T14:41:48.552479Z",
+     "iopub.status.idle": "2022-08-16T14:41:48.883831Z",
+     "shell.execute_reply": "2022-08-16T14:41:48.882796Z",
+     "shell.execute_reply.started": "2022-08-16T14:41:48.552842Z"
     },
     "tags": []
    },
@@ -320,15 +264,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 7,
    "id": "1dc11dfc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T13:58:18.230571Z",
-     "iopub.status.busy": "2022-08-16T13:58:18.230354Z",
-     "iopub.status.idle": "2022-08-16T13:58:21.768404Z",
-     "shell.execute_reply": "2022-08-16T13:58:21.767684Z",
-     "shell.execute_reply.started": "2022-08-16T13:58:18.230555Z"
+     "iopub.execute_input": "2022-08-16T14:41:48.884648Z",
+     "iopub.status.busy": "2022-08-16T14:41:48.884506Z",
+     "iopub.status.idle": "2022-08-16T14:41:52.562095Z",
+     "shell.execute_reply": "2022-08-16T14:41:52.561389Z",
+     "shell.execute_reply.started": "2022-08-16T14:41:48.884629Z"
     },
     "tags": []
    },
@@ -337,7 +281,7 @@
     "# The proper label for an image is the name of the directory it's in. e.g., \"1\" is the proper label for `1/1.png`\n",
     "def label_func(x): return x.parent.name\n",
     "\n",
-    "dls = ImageDataLoaders.from_path_func(mnist, fnames, label_func, bs=512)"
+    "dls = ImageDataLoaders.from_path_func(mnist, fnames, label_func)"
    ]
   },
   {
@@ -354,15 +298,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 8,
    "id": "0653e678",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T13:58:21.769391Z",
-     "iopub.status.busy": "2022-08-16T13:58:21.769260Z",
-     "iopub.status.idle": "2022-08-16T13:58:21.773339Z",
-     "shell.execute_reply": "2022-08-16T13:58:21.772276Z",
-     "shell.execute_reply.started": "2022-08-16T13:58:21.769376Z"
+     "iopub.execute_input": "2022-08-16T14:41:52.563406Z",
+     "iopub.status.busy": "2022-08-16T14:41:52.563166Z",
+     "iopub.status.idle": "2022-08-16T14:41:52.568242Z",
+     "shell.execute_reply": "2022-08-16T14:41:52.567215Z",
+     "shell.execute_reply.started": "2022-08-16T14:41:52.563390Z"
     },
     "tags": []
    },
@@ -382,35 +326,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 9,
    "id": "c7b0afd0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T13:59:26.951698Z",
-     "iopub.status.busy": "2022-08-16T13:59:26.951310Z",
-     "iopub.status.idle": "2022-08-16T13:59:27.224980Z",
-     "shell.execute_reply": "2022-08-16T13:59:27.224104Z",
-     "shell.execute_reply.started": "2022-08-16T13:59:26.951669Z"
+     "iopub.execute_input": "2022-08-16T14:41:52.569629Z",
+     "iopub.status.busy": "2022-08-16T14:41:52.569192Z",
+     "iopub.status.idle": "2022-08-16T14:41:52.899501Z",
+     "shell.execute_reply": "2022-08-16T14:41:52.898579Z",
+     "shell.execute_reply.started": "2022-08-16T14:41:52.569598Z"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/jav/miniconda3/envs/fastai.v5/lib/python3.10/site-packages/torchvision/models/_utils.py:208: UserWarning: The parameter 'pretrained' is deprecated since 0.13 and will be removed in 0.15, please use 'weights' instead.\n",
+      "  warnings.warn(\n",
+      "/home/jav/miniconda3/envs/fastai.v5/lib/python3.10/site-packages/torchvision/models/_utils.py:223: UserWarning: Arguments other than a weight enum or `None` for 'weights' are deprecated since 0.13 and will be removed in 0.15. The current behavior is equivalent to passing `weights=ResNet34_Weights.IMAGENET1K_V1`. You can also use `weights=ResNet34_Weights.DEFAULT` to get the most up-to-date weights.\n",
+      "  warnings.warn(msg)\n"
+     ]
+    }
+   ],
    "source": [
-    "#learn = vision_learner(dls, resnet34, metrics=accuracy, loss_func=TripletLoss(device))\n",
     "learn = vision_learner(dls, resnet34, metrics=[], loss_func=TripletLoss(device))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 10,
    "id": "b53ba4fd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T13:59:30.815924Z",
-     "iopub.status.busy": "2022-08-16T13:59:30.815753Z",
-     "iopub.status.idle": "2022-08-16T13:59:30.822858Z",
-     "shell.execute_reply": "2022-08-16T13:59:30.821996Z",
-     "shell.execute_reply.started": "2022-08-16T13:59:30.815909Z"
+     "iopub.execute_input": "2022-08-16T14:41:52.900878Z",
+     "iopub.status.busy": "2022-08-16T14:41:52.900577Z",
+     "iopub.status.idle": "2022-08-16T14:41:52.908761Z",
+     "shell.execute_reply": "2022-08-16T14:41:52.907350Z",
+     "shell.execute_reply.started": "2022-08-16T14:41:52.900847Z"
     },
     "tags": []
    },
@@ -434,7 +388,7 @@
        ")"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -454,15 +408,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 11,
    "id": "aab61b3e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T13:59:32.038280Z",
-     "iopub.status.busy": "2022-08-16T13:59:32.038095Z",
-     "iopub.status.idle": "2022-08-16T13:59:32.043105Z",
-     "shell.execute_reply": "2022-08-16T13:59:32.042223Z",
-     "shell.execute_reply.started": "2022-08-16T13:59:32.038264Z"
+     "iopub.execute_input": "2022-08-16T14:41:52.910987Z",
+     "iopub.status.busy": "2022-08-16T14:41:52.910086Z",
+     "iopub.status.idle": "2022-08-16T14:41:52.918685Z",
+     "shell.execute_reply": "2022-08-16T14:41:52.917211Z",
+     "shell.execute_reply.started": "2022-08-16T14:41:52.910957Z"
     },
     "tags": []
    },
@@ -478,15 +432,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 12,
    "id": "2428d5fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T13:59:32.886293Z",
-     "iopub.status.busy": "2022-08-16T13:59:32.886113Z",
-     "iopub.status.idle": "2022-08-16T13:59:32.905455Z",
-     "shell.execute_reply": "2022-08-16T13:59:32.904730Z",
-     "shell.execute_reply.started": "2022-08-16T13:59:32.886277Z"
+     "iopub.execute_input": "2022-08-16T14:41:52.922975Z",
+     "iopub.status.busy": "2022-08-16T14:41:52.922062Z",
+     "iopub.status.idle": "2022-08-16T14:41:52.936124Z",
+     "shell.execute_reply": "2022-08-16T14:41:52.935125Z",
+     "shell.execute_reply.started": "2022-08-16T14:41:52.922946Z"
     },
     "tags": []
    },
@@ -494,7 +448,6 @@
    "source": [
     "layers = learn.model[1]\n",
     "learn.model[1] = nn.Sequential(\n",
-    "#    layers[0], layers[1], layers[2], layers[3], nn.Linear(in_features=1024, out_features=output_embedding_length, bias=False), L2_norm()\n",
     "    layers[0], layers[1], layers[2], layers[3], layers[4], layers[5], layers[6], layers[7], \n",
     "    nn.Linear(in_features=512, out_features=output_embedding_length, bias=False), L2_norm()\n",
     ").to(device)\n",
@@ -503,15 +456,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 13,
    "id": "5a6c7671",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T13:59:34.422847Z",
-     "iopub.status.busy": "2022-08-16T13:59:34.422603Z",
-     "iopub.status.idle": "2022-08-16T13:59:34.428400Z",
-     "shell.execute_reply": "2022-08-16T13:59:34.427427Z",
-     "shell.execute_reply.started": "2022-08-16T13:59:34.422817Z"
+     "iopub.execute_input": "2022-08-16T14:41:52.938439Z",
+     "iopub.status.busy": "2022-08-16T14:41:52.937975Z",
+     "iopub.status.idle": "2022-08-16T14:41:52.951000Z",
+     "shell.execute_reply": "2022-08-16T14:41:52.949617Z",
+     "shell.execute_reply.started": "2022-08-16T14:41:52.938383Z"
     },
     "tags": []
    },
@@ -536,7 +489,7 @@
        ")"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -569,15 +522,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 14,
    "id": "df59ac88",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T13:59:40.465505Z",
-     "iopub.status.busy": "2022-08-16T13:59:40.465293Z",
-     "iopub.status.idle": "2022-08-16T13:59:54.911629Z",
-     "shell.execute_reply": "2022-08-16T13:59:54.910289Z",
-     "shell.execute_reply.started": "2022-08-16T13:59:40.465475Z"
+     "iopub.execute_input": "2022-08-16T14:41:52.952649Z",
+     "iopub.status.busy": "2022-08-16T14:41:52.952360Z",
+     "iopub.status.idle": "2022-08-16T14:42:00.482668Z",
+     "shell.execute_reply": "2022-08-16T14:42:00.481022Z",
+     "shell.execute_reply.started": "2022-08-16T14:41:52.952627Z"
     },
     "tags": []
    },
@@ -622,16 +575,16 @@
     {
      "data": {
       "text/plain": [
-       "SuggestedLRs(valley=0.005248074419796467)"
+       "SuggestedLRs(valley=0.009120108559727669)"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAELCAYAAADDZxFQAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAAqeElEQVR4nO3deXwV9b3/8dfnZGXfkrAlrCIQBAQjLrhjRa0s0l9FL1btz6r3V5cuV1u93lpLa23vte29WpfaK221Vi7S5eKKG4it1RJEUGQVQcIa9n1J8vn9cSZwjCchgUzmJHk/H4/zyDnfmTnzPkPI58x8Z+Zr7o6IiEhVsagDiIhIalKBEBGRpFQgREQkKRUIERFJSgVCRESSUoEQEZGkQisQZjbFzDaZ2YfVTDcze9DMVpjZQjMbnjDtWjNbHjyuDSujiIhUz8K6DsLMzgF2A0+6+0lJpl8K3ApcCpwG/Je7n2ZmHYFioAhwYB5wirtvq2l9OTk53qtXr/r9ECIiTdy8efM2u3tusmnpYa3U3eeYWa8aZhlHvHg48I6ZtTezrsB5wKvuvhXAzF4FLgaeqWl9vXr1ori4uF6yi4g0F2a2urppUfZBdAfWJLwuCdqqaxcRkQbUqDupzexGMys2s+LS0tKo44iINClRFoi1QEHC6/ygrbr2z3H3x929yN2LcnOTHkITEZFjFFofRC3MAG4xs6nEO6l3uPt6M5sJ/NjMOgTzXQTcFVVIEWkaDh06RElJCfv37486SiSys7PJz88nIyOj1suEViDM7BniHc45ZlYCfB/IAHD3x4AXiZ/BtALYC3w1mLbVzH4IzA3eanJlh7WIyLEqKSmhTZs29OrVCzOLOk6Dcne2bNlCSUkJvXv3rvVyYZ7FdNVRpjtwczXTpgBTwsglIs3T/v37m2VxADAzOnXqRF37aqM8xJQSDpSV8+bSUtLTjLRYjPSYkRYzMtKM9FiMtJjFp5lhZlS4U1bulFc4zpFrSAzDDGLBL1+FV87zWZW/mmbxZSqfV1X5XpXzxSxYxuJZ0mLxaYmXsbjD59dYs6NdBlN1crLrZir/w9ln2mp+38rtVTVLsm1a9f1q+x/cOLINa5qn8kniv2HlshjEEv4tYmbEzEiPGbFY8/tD09g1x+JQ6Vg+e7MvELv2l3HjU/OijiGNUMz4zJeIjLQYGcHPzLQYrbLSaZMdf7TKSqdFRhotM9Nom51BXtsscttkkdcmm9w2WXRqlUl6WqM+qVDqWevWrdm9ezerVq3isssu48MPk96UIlTNvkC0a5HBC7edRXmFc6jcKSuviD+viD8vq3AqKjz+0/3wH4S0WPxbfSX3+F5DhQM4Mauc58hMld+O3Y98c/fDy/vhCu8en9OD96v8Zh1/Ht8zKatI/KYd/Ay++db2i4J75V5J8vYj7//ZGazK5078bIltNa238vN99n2P5E+c5zNzVfPejn8mp+OH36PC/XOfITHz4c9weLvHl0n8Wbn9K18fqvw9KXfKKyrivzsVFZSVOwfLKzhQVsGeA2Xs3l/Gqs172XOwjH0Hy9l7sJx9h8o/l8UMOrXKol9eawq7tWVg17b0zmlFt/bZ5LXJJk17Kw1v4TR4fTLsKIF2+TDqHhhyRdSpGlSzLxAZaTEGdWsXdQxpRg6UlVO66wCluw6wKfhZuusAG3bsZ8nGXfz+ndUcKKs4PH9azOjWPpueHVvRs1NLeue0YkCXtgzs2oZOrbMi/CRN2MJp8NxtcGhf/PWONfHXcMxF4s4776SgoICbb453vd57772kp6cza9Ystm3bxqFDh/jRj37EuHHjqn2P8vJy7rzzTmbPns2BAwe4+eabuemmm7jmmmuYMGEC48ePB2DSpElcccUVNb5XbTT7AiHS0LLS08jv0JL8Di2TTi8rr2DVlr2s2bqXdTv2sW77Pkq27WPVlr288MF6tu89dHje3DZZDM1vz7Ae7RlW0J6hBe1plaX/1sft9clHikOlQ/vi7cdYICZOnMg3v/nNwwVi2rRpzJw5k9tuu422bduyefNmTj/9dMaOHVttf8ETTzxBu3btmDt3LgcOHGDkyJFcdNFFXH/99fziF79g/Pjx7Nixg7fffpvf/e53x5QzkX6TRFJMelqME/Jac0Je66TTt+w+wJINu1i8ficfrdvJ+2u289rijUB8b2NQt7YU9ezIGX07cWbfTioYx2JHSd3aa2HYsGFs2rSJdevWUVpaSocOHejSpQvf+ta3mDNnDrFYjLVr17Jx40a6dOmS9D1eeeUVFi5cyPTp0+Nxduxg+fLlXHTRRXz961+ntLSUP/7xj3zpS18iPf34/931myPSyHRqncXIE7IYeULO4bbtew8yf8123lu9jbmrtvL0u6uZ8rdPyEyLcWrvDpx3Yh4XDMyjb27yoiNVtMuPH1ZK1n4cvvzlLzN9+nQ2bNjAxIkTefrppyktLWXevHlkZGTQq1evGi/kc3ceeughRo8e/blp11xzDb///e+ZOnUqv/nNb44rZyUVCJEmoH3LTM7vn8f5/fMAOFhWQfHqrby5tJTZS0u578XF3PfiYnrntOILhZ35+nl9ad8yM+LUKWzUPZ/tgwDIaBFvPw4TJ07khhtuYPPmzbz55ptMmzaNvLw8MjIymDVrFqtXV3tjVQBGjx7No48+ygUXXEBGRgbLli2je/futGrViuuuu44RI0bQpUsXCgsLjytnJRUIkSYoMz3GmX1zOLNvDnddOpC12/fxxuKNvL5kE1P++gkvLFzP709bTe/3f9asz9KpVuV2qOezmAYNGsSuXbvo3r07Xbt2ZdKkSYwZM4bBgwdTVFTEgAEDalz+a1/7GqtWrWL48OG4O7m5ufzlL38BoHPnzgwcOPBwR3V9CG3AoIZWVFTkGg9C5OgWrNnOn5/8Bd85+Agt7eCRCRktYMyDTbZILF68mIEDB0YdIzR79+5l8ODBvPfee7Rrl/zMzGTbwMzmuXtRsvl1ZY5IMzO0oD33tJj+2eIAR87SkUbntddeY+DAgdx6663VFodjoUNMIs1QbGfSO+gf11k6Ep0LL7zwqP0Xx0J7ECLNUTVn41S01eCNcoQKhEhzNOqeeJ9Dgr2eyX9xFXsPlkUUKnxNpc/1WBzLZ1eBEGmOhlwR75BuVwAYtCtg2Yj7eKh0GDc8Wcz+JPeLauyys7PZsmVLsywSleNBZGdn12k5ncUkIof96b0Svj1tARcMyOOxq08hM73pfIfUiHLJR5Sr6SwmdVKLyGEThuez92A5//aXD7n5D+/xwP8ZSruWtR+iMpVlZGTUaTQ10SEmEani6tN78v0xhbyxZBMX/uJNZi7aEHUkiYgKhIh8zldH9uZ/bx5JTussbnpqHrc+M58DZU2vX0JqpgIhIkmd1L0dM24ZyTdG9eO5Bev4n7lJbl4nTZoKhIhUKyMtxjcv7MepvTrw8KwVTfLsJqleqAXCzC42s6VmtsLM7kwyvaeZvW5mC81stpnlJ0z7dzNbZGaLzexBa86jjYtEyMz41oUnsnHnAZ75x6dRx5EGFFqBMLM04GHgEqAQuMrMqt6D9gHgSXcfAkwG7g+WPRMYCQwBTgJOBc4NK6uI1OyMvp04rXdHHpn9sfYimpEw9yBGACvcfaW7HwSmAlUHSC0E3giez0qY7kA2kAlkARnAxhCzikgNzIxvfeFESncd4Ol3tRfRXIRZILoDib1aJUFbogXAhOD55UAbM+vk7n8nXjDWB4+Z7r44xKwichSn9+nEGX068ejsj9l3UHsRzUHUndS3A+ea2Xzih5DWAuVmdgIwEMgnXlQuMLOzqy5sZjeaWbGZFZeWljZkbpFm6VtfOJHNuw/wxF9XRh1FGkCYBWItUJDwOj9oO8zd17n7BHcfBtwdtG0nvjfxjrvvdvfdwEvAGVVX4O6Pu3uRuxfl5uaG9DFEpNKI3h25eFAXfjlrBWu27o06joQszAIxF+hnZr3NLBO4EpiROIOZ5ZhZZYa7gCnB80+J71mkm1kG8b0LHWISSQH3jCkkZsYPnvso6igSstAKhLuXAbcAM4n/cZ/m7ovMbLKZjQ1mOw9YambLgM7AfUH7dOBj4APi/RQL3P25sLKKSO11a9+Cb4zqx2uLN/LaRzp3pCnT3VxFpM4OlVdw6X+9xb5D5bz6rXNpkZkWdSQ5RhqTWkTqVUZajB+OP4mSbft4ZPaKqONISFQgROSYnN6nE+NO7sbjc1ZSsk0d1k2RCoSIHLPvXjwAM/jpy0ujjiIhUIEQkWPWrX0LbjqnL88tWMe81VujjiP1TAVCRI7LTef2oUvbbCY/9xEVFU3jpBeJU4EQkePSMjOd717SnwUlO/jL+2uPvoA0GioQInLcxg3tztCC9vzkpSXsPlAWdRypJyoQInLcYjHj+2MK2bTrAA/P0mmvTYUKhIjUi+E9OvCl4fk88dYnfLJ5T9RxpB6oQIhIvfnuxf3JTI/xo+d1n6amQAVCROpNXttsbht1Aq8v2cSsJZuijiPHSQVCROrVdWf2pk9OKyY//xGHyiuijiPHQQVCROpVZnqM714ygE827+H1xbrba2OmAiEi9W7UgDy6tM1m6tw1R59ZUpYKhIjUu/S0GF8uyufNZaWs274v6jhyjFQgRCQUVxQV4A7PFpdEHUWOkQqEiISioGNLzjohh2nFa3SPpkZKBUJEQjPx1ALWbt/H3z7eHHUUOQYqECISmosGdaZ9ywx1VjdSKhAiEpqs9DQuH9adVxZtYOueg1HHkTpSgRCRUF15ag8OlTvTirUX0diEWiDM7GIzW2pmK8zsziTTe5rZ62a20Mxmm1l+wrQeZvaKmS02s4/MrFeYWUUkHP27tOGMPp343durdGV1IxNagTCzNOBh4BKgELjKzAqrzPYA8KS7DwEmA/cnTHsS+A93HwiMAHRjF5FG6v+e1Zv1O/Yzc9GGqKNIHYS5BzECWOHuK939IDAVGFdlnkLgjeD5rMrpQSFJd/dXAdx9t7vvDTGriIRo1IA8enZqyRN//STqKFIHYRaI7kDiQceSoC3RAmBC8PxyoI2ZdQJOBLab2Z/MbL6Z/UewRyIijVAsZnz1zF7M/3Q77326Leo4UktRd1LfDpxrZvOBc4G1QDmQDpwdTD8V6ANcV3VhM7vRzIrNrLi0tLTBQotI3X25qIA22elM0V5EoxFmgVgLFCS8zg/aDnP3de4+wd2HAXcHbduJ7228HxyeKgP+AgyvugJ3f9zdi9y9KDc3N5xPISL1olVWOleeWsBLH27Q/ZkaiTALxFygn5n1NrNM4EpgRuIMZpZjZpUZ7gKmJCzb3swq/+pfAGiIKpFG7toze+HuPP3u6qijSC2EViCCb/63ADOBxcA0d19kZpPNbGww23nAUjNbBnQG7guWLSd+eOl1M/sAMODXYWUVkYaR36ElI0/I4eUPdTZTY5Ae5pu7+4vAi1Xa7kl4Ph2YXs2yrwJDwswnIg1v1IA87n3uIz7ZvIfeOa2ijiM1iLqTWkSamVEDOwNotLlGQAVCRBpUQceWDOjShtdUIFKeCoSINLhRA/OYu2obO/YeijqK1EAFQkQa3KiBnSmvcGYv0x10UpkKhIg0uJPz25PTOpPXFqtApDIVCBFpcLGYccGAPGYv3aQ7vKYwFQgRicSogZ3Ztb+MuZ9sjTqKVEMFQkQicXa/HDLTY7yqs5lSlgqEiESiZWY6Z52QwyuLNlJR4VHHkSRUIEQkMmOGdmXt9n0Ur9YtwFORCoSIROaiwi60yEjjz/NLoo4iSahAiEhkWmWlc/FJXXh+4Xr2HyqPOo5UoQIhIpG6fFh3du0vY9YSXRORalQgRCRSZ/btRG6bLP40f+3RZ5YGpQIhIpFKT4sxbmg3Zi/dxLY9B6OOIwlUIEQkcpcP786hcuf5D9ZHHUUSqECISOQKu7alf+c2/Pk9nc2USlQgRCRyZsb4Yd1579PtrN6yJ+o4ElCBEJGUMPbkbgA8t2BdxEmkkgqEiKSE7u1bUNSzA88tUD9EqlCBEJGUMfbkbizduIulG3ZFHUUIuUCY2cVmttTMVpjZnUmm9zSz181soZnNNrP8KtPbmlmJmf0yzJwikhouHdyVtJgxY4GuiUgFoRUIM0sDHgYuAQqBq8yssMpsDwBPuvsQYDJwf5XpPwTmhJVRRFJLTusszuzbiecWrMddd3iNWph7ECOAFe6+0t0PAlOBcVXmKQTeCJ7PSpxuZqcAnYFXQswoIilmzNBufLp1L++v2R51lGYvzALRHViT8LokaEu0AJgQPL8caGNmncwsBvwMuD3EfCKSgkYP6kJmWowZOpspclF3Ut8OnGtm84FzgbVAOfB14EV3r/GqGTO70cyKzay4tLQ0/LQiErp2LTI4r38uzy9cT7kGEopUmAViLVCQ8Do/aDvM3de5+wR3HwbcHbRtB84AbjGzVcT7Ka4xs59UXYG7P+7uRe5elJubG86nEJEGN/bkbpTuOsCcZfriF6UwC8RcoJ+Z9TazTOBKYEbiDGaWExxOArgLmALg7pPcvYe79yK+l/Gku3/uLCgRaZq+UNiZgo4t+MlLSygrr4g6TrMVWoFw9zLgFmAmsBiY5u6LzGyymY0NZjsPWGpmy4h3SN8XVh4RaTyy0tP410sGsnTjLqbOXXP0BSQU1lROJSsqKvLi4uKoY4hIPXF3rnz8HZZv2s2s28+jXYuMqCM1SWY2z92Lkk2LupNaRCQpM+N7lxWybe9BfvnG8qjjNEsqECKSsk7q3o4rTingt2+v4pPNustrQ6tVgTCzVpWdyWZ2opmNNTPt74lI6G4f3Z+s9DS+M32BOqwbWG33IOYA2WbWnfiVzV8BfhtWKBGRSrltsrjv8pOYu2obD7yyLOo4zUptC4S5+17iVz0/4u5fBgaFF0tE5IhxJ3fnqhE9eOzNj3ljycao4zQbtS4QZnYGMAl4IWhLCyeSiMjnfX9MIQO7tuXb0xawdvu+qOM0C7UtEN8kfiHbn4NrGfoQv7meiEiDyM5I45FJwykrd745dT4Vug1H6GpVINz9TXcf6+4/DTqrN7v7bSFnExH5jN45rbh37CDmrtrGU++sjjpOk1fbs5j+EAze0wr4EPjIzO4IN5qIyOd9aXh3zjkxl5++vISSbXujjtOk1fYQU6G77wTGAy8BvYmfySQi0qDMjB9ffhIA//rnDzWwUIhqWyAygusexgMz3P0QoH8VEYlEfoeWfPfiAcxZVsqf3tPwpGGpbYH4FbAKaAXMMbOewM6wQomIHM1XTu9JUc8O/OC5RazZqkNNYahtJ/WD7t7d3S/1uNXA+SFnExGpVixm/OyKoQDc8GQxew+WRZyo6altJ3U7M/t55ehtZvYz4nsTIiKR6dmpFQ/903CWbdzFHc8uVH9EPavtIaYpwC7giuCxE/hNWKFERGrr3BNz+c7FA3jhg/U8+ubHUcdpUtJrOV9fd/9SwusfmNn7IeQREamzm87pw6J1O/mPmUs5rXdHTunZMepITUJt9yD2mdlZlS/MbCSga91FJCWYGT/90mByWmfxk5eW6FBTPaltgfhn4GEzW2Vmq4BfAjeFlkpEpI5aZqZz26h+zF21jdlLS6OO0yTU9iymBe4+FBgCDHH3YcAFoSYTEamjiUUF9OjYkn+fuVT3aqoHdRpRzt13BldUA3w7hDwiIscsMz3Gv1x0IovX7+S5heuijtPoHc+Qo1ZvKURE6smYId0Y0KUNP391GYc0At1xOZ4CcdT9NzO72MyWmtkKM7szyfSeZva6mS00s9lmlh+0n2xmfzezRcG0iceRU0SakVjMuGN0f1Zv2cvv3l4VdZxGrcYCYWa7zGxnkscuoNtRlk0DHgYuAQqBq8yssMpsDwBPuvsQYDJwf9C+F7jG3QcBFwP/aWbt6/rhRKR5umBAHqMG5PHTl5cw/9NtUcdptGosEO7ext3bJnm0cfejXUMxAljh7ivd/SAwFRhXZZ5C4I3g+azK6e6+zN2XB8/XAZuA3Lp9NBFprszit+Ho3Dabm59+j617DkYdqVE6nkNMR9MdWJPwuiRoS7SA+DjXAJcDbcysU+IMZjYCyAR0iaSI1Fr7lpk8OukUNu8+yDemzqdcZzXVWZgFojZuB841s/nAucBaoLxyopl1BZ4Cvurun+ttMrMbK+8PVVqq855F5LMG57fj3rGDeGv5Zh6etSLqOI1OmAViLVCQ8Do/aDvM3de5+4Tguoq7g7btAGbWFngBuNvd30m2And/3N2L3L0oN1dHoETk864aUcCYod345RsrWLV5T9RxGpUwC8RcoJ+Z9TazTOBKYEbiDGaWE4xxDXAX8ZsCEsz/Z+Id2NNDzCgiTZyZ8b0vDiQjzfjRCx9FHadRCa1AuHsZcAswE1gMTHP3RWY22czGBrOdByw1s2VAZ+C+oP0K4BzgOjN7P3icHFZWEWna8tpmc9uofry2eBOzl26KOk6jYU3lplZFRUVeXFwcdQwRSVEHyyoY/Z9zMIOXv3EOmelRd8GmBjOb5+5FyaZpC4lIs5CZHuOeywpZWbpHF9DVkgqEiDQb5w/I44IBeTz4+nJ27DsUdZyUpwIhIs3Kt79wIrsOlDH1H59GHSXlqUCISLNyUvd2jDyhE7/52yoOlulmfjVRgRCRZufGc/qyYed+ZizQLcFrogIhIs3OOf1yGNClDb+es1LDk9ZABUJEmh0z44az+7B04y7eXKbb9FRHBUJEmqUxQ7vRpW02j89ZGXWUlKUCISLNUmZ6jP97Vi/e/ngLH67dEXWclKQCISLN1sRTe9AiI42n/r466igpSQVCRJqtdi0yGD+sO/+7YC3b92pQoapUIESkWbvmjJ7sP1TBs8UlUUdJOSoQItKsDezalhG9OvLUO6up0Khzn6ECISLN3lfO6MmnW/fqlNcqVCBEpNkbPagLuW2yePLvq6KOklJUIESk2ctMj3HViB7MXlbK6i0alrSSCoSICDDptB5kpMW4dso/+GjdzqjjpAQVCBERoHPbbP7wtdPYd6icyx/5G88Wr4k6UuRUIEREAkW9OvLCbWdzSs8O3DF9Ife/uDjqSJFSgRARSZDTOounrj+NSaf14FdzVvLHec33+ggVCBGRKtJixg/GDuL0Ph351z9/0Gzv1RRqgTCzi81sqZmtMLM7k0zvaWavm9lCM5ttZvkJ0641s+XB49owc4qIVJWeFuOX/zScjq0yuempeWzb0/xuxRFagTCzNOBh4BKgELjKzAqrzPYA8KS7DwEmA/cHy3YEvg+cBowAvm9mHcLKKiKSTE7rLB67+hRKdx/gtqnzKW9mV1qHuQcxAljh7ivd/SAwFRhXZZ5C4I3g+ayE6aOBV919q7tvA14FLg4xq4hIUkML2jN57CDeWr6Zx978OOo4DSrMAtEdSDxPrCRoS7QAmBA8vxxoY2adarmsiEiDmHhqAZcN6crPX13GvNVbo47TYKLupL4dONfM5gPnAmuB8toubGY3mlmxmRWXluoeKiISDjPjxxMG0619Nrc98z479h6KOlKDCLNArAUKEl7nB22Hufs6d5/g7sOAu4O27bVZNpj3cXcvcvei3Nzceo4vInJE2+wMHrpqOBt37ue7f1yIe9PvjwizQMwF+plZbzPLBK4EZiTOYGY5ZlaZ4S5gSvB8JnCRmXUIOqcvCtpERCJzckF77hjdn5cXbeDmP7zH3oNlUUcKVXpYb+zuZWZ2C/E/7GnAFHdfZGaTgWJ3nwGcB9xvZg7MAW4Olt1qZj8kXmQAJrt78znwJyIp68Zz+mAGP3lpCZ9s3suvrzmF/A4to44VCmsqu0lFRUVeXFwcdQwRaSZmL93Erc/MJyMtxpTrTuXkgvZRRzomZjbP3YuSTYu6k1pEpFE6r38ef7l5JK2z0vnKE++ysGR71JHqnQqEiMgx6pvbmqk3nk77lhlc/d/vNrlbcqhAiIgch27tW/CHr51Om+wMrn7iXd5cVtpkrrhWgRAROU4FHVvyzA2n0yoznWun/INT73uNO55dQPGqxn1ujQqEiEg96NGpJa986xwemTScs/vl8PKHG5j4+Du8sHB91NGOWWinuYqINDetstK5dHBXLh3cld0Hyvjqb/7BbVPnA/DFIV0jTld32oMQEQlB66x0fvvVEQzv0Z7bps5vlHsSKhAiIiFpVaVILFizPepIdaICISISolZZ6Txx3anktcni9mcXcKCs1vcjjZwKhIhIyNpmZ/DjCYNZvmk3D76+POo4taYCISLSAM7vn8cVRfk89ubKRnPVtQqEiEgDufuLheS2bjyHmlQgREQaSLsWGdz/pcEs27ibR2en/vClKhAiIg3o/P55jBnajUdmf8wnm/dEHadGKhAiIg3se18cSFZajHv+98OUHplOBUJEpIHltc3m9tH9eWv5Zp5P4QvoVCBERCJw9ek9Gdy9HZOf/4id+w9FHScpFQgRkQikxYz7Lj+JzbsP8NOXlkQdJykVCBGRiAzJb8/1I3vz9Luf8uay0qjjfI4KhIhIhG4f3Z9+ea35zvQF7NibWoeaVCBERCKUnZHGz684mS27D3LPjA+jjvMZoRYIM7vYzJaa2QozuzPJ9B5mNsvM5pvZQjO7NGjPMLPfmdkHZrbYzO4KM6eISJQG57fj1gv68b/vr+P5heuijnNYaAXCzNKAh4FLgELgKjMrrDLbvwHT3H0YcCXwSND+ZSDL3QcDpwA3mVmvsLKKiETt6+f3ZXD3dtz/4pKUuTYizD2IEcAKd1/p7geBqcC4KvM40DZ43g5Yl9DeyszSgRbAQWBniFlFRCKVkRbjqyN7sXb7PuanyLgRYRaI7sCahNclQVuie4GrzawEeBG4NWifDuwB1gOfAg+4e+Me/VtE5CguLOxMZlqM5xekxsVzUXdSXwX81t3zgUuBp8wsRnzvoxzoBvQG/sXM+lRd2MxuNLNiMysuLU29U8REROqibXYG5/bP5cUP1lNREf1hpjALxFqgIOF1ftCW6HpgGoC7/x3IBnKAfwJedvdD7r4J+BtQVHUF7v64uxe5e1Fubm4IH0FEpGFdNqQrG3buZ96n26KOEmqBmAv0M7PeZpZJvBN6RpV5PgVGAZjZQOIFojRovyBobwWcDqTmpYYiIvVo1MDOZKXHeCEF7tEUWoFw9zLgFmAmsJj42UqLzGyymY0NZvsX4AYzWwA8A1zn8e77h4HWZraIeKH5jbsvDCuriEiqaJ2Vzvn983jxg/WUR3yYKT3MN3f3F4l3Pie23ZPw/CNgZJLldhM/1VVEpNm5bGhXXl60gbmrtnJ6n06R5Yi6k1pERKq4YEAe2RnRH2ZSgRARSTEtM9MZNaAzL324PtKxq1UgRERS0FUjerB590EefmNFZBlUIEREUtBZ/XKYMKw7j8z+mEXrdkSSQQVCRCRF3TOmkA6tMrnj2YUcKq9o8PWrQIiIpKj2LTP50fiT+Gj9Th6d/XGDr18FQkQkhY0e1IUxQ7vx0BvLWbFpV4OuWwVCRCTF3TumkMy0GA81cIe1CoSISIrr1DqLSaf35LkF61i9ZU+DrVcFQkSkEfjaWb1JT4vx2JsrG2ydKhAiIo1AXttsrijK54/zStiwY3+DrFMFQkSkkbjpnL6Uu/PfbzXMXoQKhIhII1HQsSXjhnbj6Xc/Zeueg6GvTwVCRKQR+fr5fdlfVs6v5oR/XYQKhIhII3JCXhsmDMtnyl8/4ePS3aGuSwVCRKSRufOSAWRnpHHvjEXEx1gLhwqEiEgjk9smiztG9+et5Zt58YMNoa1HBUJEpBGadFpPBnVryw+f/4g9B8pCWYcKhIhII5QWMyaPO4kNO/fz4BvLQ1mHCoSISCN1Ss8OXFGUz8rSPVRU1H9fRHq9v6OIiDSYH44/icy0GGZW7++tAiEi0ohlpaeF9t6hHmIys4vNbKmZrTCzO5NM72Fms8xsvpktNLNLE6YNMbO/m9kiM/vAzLLDzCoiIp8V2h6EmaUBDwNfAEqAuWY2w90/Spjt34Bp7v6omRUCLwK9zCwd+D3wFXdfYGadgENhZRURkc8Lcw9iBLDC3Ve6+0FgKjCuyjwOtA2etwPWBc8vAha6+wIAd9/i7uUhZhURkSrCLBDdgTUJr0uCtkT3AlebWQnxvYdbg/YTATezmWb2npl9J9kKzOxGMys2s+LS0tL6TS8i0sxFfZrrVcBv3T0fuBR4ysxixA99nQVMCn5ebmajqi7s7o+7e5G7F+Xm5jZkbhGRJi/MArEWKEh4nR+0JboemAbg7n8HsoEc4nsbc9x9s7vvJb53MTzErCIiUkWYBWIu0M/MeptZJnAlMKPKPJ8CowDMbCDxAlEKzAQGm1nLoMP6XOAjRESkwViYdwIMTlv9TyANmOLu95nZZKDY3WcEZy79GmhNvMP6O+7+SrDs1cBdQfuL7p60HyJhXaXA6uBlO2BHwuTK14ntVdtygM11+HhV13G0adVlqu55Q+erKVOyXMnamvs2rClfslzJ2rQNtQ0bOl9Pd09+jN7dm9wDeDzZ68T2qm3Ei9Yxr+No06rLVItcDZKvpkzahsefT9tQ2zBV89X0iLqTOizPVfP6uaO0Hc86jjatukzVPW/ofDVlqi6PtmHNbdqG2obJftZV2PmqFeohpsbEzIrdvSjqHNVJ9XyQ+hlTPR+kfsZUzwepnzHV8yVqqnsQx+LxqAMcRarng9TPmOr5IPUzpno+SP2MqZ7vMO1BiIhIUtqDEBGRpFQgREQkKRUIERFJSgXiKMzsbDN7zMz+28zejjpPMmYWM7P7zOwhM7s26jxVmdl5ZvZWsB3PizpPdcysVXDzx8uizlKVmQ0Mtt90M/t/UedJxszGm9mvzex/zOyiqPNUZWZ9zOwJM5sedZZEwe/d74JtNynqPImadIEwsylmtsnMPqzSXuNARonc/S13/2fgeeB3qZiR+G3U84mPmVGSgvkc2E38Vir1mq8eMwJ8l+DeYKmWz90XB7+HVwAjUzTjX9z9BuCfgYkpmG+lu19fn7mqU8e8E4DpwbYb2xD5aq0uV/Q1tgdwDvGb/H2Y0JYGfAz0ATKBBUAhMJh4EUh85CUsNw1ok4oZgTuBm4Jlp6dgvliwXGfg6RTdhl8gfr+w64DLUi1fsMxY4CXgn1JxGyYs9zNgeArnq9f/I/WQ9y7g5GCeP4SdrS6PJj0mtbvPMbNeVZoPD2QEYGZTgXHufj+Q9NCCmfUAdrj7rlTMGIyncTB4Wa8DK9XXNgxsA7LqM199ZQwOfbUi/h92n5m96O4VqZIveJ8ZwAwzewH4Q31kq8+MZmbAT4CX3P29VMvXkOqSl/hedT7wPil2VKdJF4hqJBvI6LSjLHM98JvQEn1eXTP+CXjIzM4G5oQZLFCnfGY2ARgNtAd+GWqyI+qU0d3vBjCz64DN9VUcalDXbXge8UMRWcRvf98Q6vp7eCtwIdDOzE5w98fCDEfdt2En4D5gmJndFRSShlRd3geBX5rZFzn223GEojkWiDpz9+9HnaEmHh8zo0GOrR4Ld/8T8SKW8tz9t1FnSMbdZwOzI45RI3d/kPgfu5Tk7luI94+kFHffA3w16hzJpNTuTAOpzUBGUUv1jKmeD1I/Y6rng9TPmOr5qmpseZtlgajNQEZRS/WMqZ4PUj9jqueD1M+Y6vmqamx5m/xZTM8A6zly+uf1QfulwDLiZxTcrYyNN19jyJjq+RpDxlTP19jzVvfQzfpERCSp5niISUREakEFQkREklKBEBGRpFQgREQkKRUIERFJSgVCRESSUoGQJs3Mdjfw+uplzBCLj6Gxw8zeN7MlZvZALZYZb2aF9bF+EVCBEKkTM6vx/mXufmY9ru4tdz8ZGAZcZmZHGwdiPPG70YrUCxUIaXbMrK+ZvWxm8yw+0t2AoH2Mmb1rZvPN7DUz6xy032tmT5nZ34CngtdTzGy2ma00s9sS3nt38PO8YPr0YA/g6eB22JjZpUHbPDN70Myerymvu+8jfivo7sHyN5jZXDNbYGZ/NLOWZnYm8fEi/iPY6+hb3ecUqS0VCGmOHgdudfdTgNuBR4L2vwKnu/swYCrwnYRlCoEL3f2q4PUA4rcwHwF838wykqxnGPDNYNk+wEgzywZ+BVwSrD/3aGHNrAPQjyO3cv+Tu5/q7kOBxcRv4/A28fv63OHuJ7v7xzV8TpFa0e2+pVkxs9bAmcCzwRd6ODKIUT7wP2bWlfiIX58kLDoj+CZf6QV3PwAcMLNNxEfLqzqc6j/cvSRY7/tAL+JDr65098r3fga4sZq4Z5vZAuLF4T/dfUPQfpKZ/Yj4+BqtgZl1/JwitaICIc1NDNgeHNuv6iHg5+4+Ixig596EaXuqzHsg4Xk5yf8v1Waemrzl7peZWW/gHTOb5u7vA78Fxrv7gmCAo/OSLFvT5xSpFR1ikmbF3XcCn5jZlyE+TKaZDQ0mt+PI/fmvDSnCUqBPwnCUE4+2QLC38RPgu0FTG2B9cFhrUsKsu4JpR/ucIrWiAiFNXUszK0l4fJv4H9Xrg8M3i4iPCwzxPYZnzWwesDmMMMFhqq8DLwfr2QXsqMWijwHnBIXle8C7wN+AJQnzTAXuCDrZ+1L95xSpFd3uW6SBmVlrd98dnNX0MLDc3X8RdS6RqrQHIdLwbgg6rRcRP6z1q2jjiCSnPQgREUlKexAiIpKUCoSIiCSlAiEiIkmpQIiISFIqECIikpQKhIiIJPX/Aa4yenTVSwJKAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAEKCAYAAAAIO8L1AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAAsO0lEQVR4nO3deXyddZ3//dcnJ/uepmnaJl2h0Ia2tCVUEFkGkV2WqizDsPhjQEXHW+ZmRnjgqMMtPxx1RgcXHEYBERUKIgOKlJFVWZvShZbShdIlSZc0bZI2+/K5/zin9RBO0qTNyXWS834+Hnn0nO91XTnvHErfub7Xda7L3B0REZHeUoIOICIiiUkFISIiMakgREQkJhWEiIjEpIIQEZGYVBAiIhJTatABhsrYsWN96tSpQccQERlRli1bttvdS2ItGzUFMXXqVKqqqoKOISIyopjZlr6WaYpJRERiUkGIiEhMKggREYlp1ByDEBHpT2dnJ9XV1bS1tQUdJRCZmZmUl5eTlpY24G1UECKSFKqrq8nLy2Pq1KmYWdBxhpW7U19fT3V1NdOmTRvwdppiEpGk0NbWRnFxcdKVA4CZUVxcPOi9JxXEYXB31tQ2sr+9K+goIjIIyVgOBxzOz66CGKSGlg6+8NBbXHD3Xzj5rue46+m1bG9sDTqWiIwyubm5AGzevJnZs2cHkkHHIAbhtffqufmRFdQ3t/Plj8/gvbr9/PefN/Hzv7zPlOJs0lNDpIeMwux0jh2fx7GlecyakM8xpbmkhtTFIiPKqsXw3B3QWA0F5fDxr8Pcy4JONaxUEP1YXdPIo1XbeL++hc27m9m6p4XpY3P42bWnMLusAIBte1p46I0tVO9ppaO7h87uHnY2tfPae/V0dPcAkJmWwpyyAo4vL2RKcTYTCrKYWJjF0eNySU/tuzjcnd37O8jPSiUjNTQsP7OIEC6Hp74MnZHZgcZt4edw2CVx6623MmnSJL74xS8C8M1vfpPU1FReeOEF9u7dS2dnJ9/61re4+OKL+/we3d3d3Hrrrbz44ou0t7fzxS9+kc997nNcc801LFq0iEsuuQSAq666issuu6zf7zUQNlpuOVpZWelDeamNNzbV89kHlgIwvSSHqcU5zJqQz2dPmUp2+qF7tau7h831zaypbWLFtgZWbGtgTW0THV09B9fJz0zl7OPGc8GcCRw9Lpdd+9rY3tjG5t3NLN/awPJtDexp7gBgbG4GEwoy6epxGlo6aGjppKwoi6tPmsKnTignN+PIu97dae/qobm9i85up9udnh4n+q9IZnoKJbkZST2XKyPT2rVrmTVr1sBW/v7scCn0VjAJbl59WK+/fPlyvvKVr/DSSy8BUFFRwZIlSygoKCA/P5/du3dz0kknsWHDBsyM3Nxc9u/fz+bNm7nwwgtZvXo19957L7t27eJrX/sa7e3tnHLKKTz66KNs3bqV73//+zzxxBM0NjYyb948NmzYQGrqB/9diPUemNkyd6+MlVl7EDG89l49/+eBpUwszOQ3N5zEuPzMQX+P1FAKR4/L4+hxeVw8rwyA7h5n9/52ahtaqd7byovr6liyZgePLav+0PZHleRw5sxxVEzIZ19bF7UNrexoaiMtlMJxE/MpyEqjavMevvHkGr67ZB1nV5RSkpdBflYa+ZmppKQYKWaEzJhRmsucsoKD01zv727m9ytrWbGtgT0tHext7qChtZP9bV109Rz6F4astBBTirMpyctgT3MHdfvaqW/uIJRiZKWFyE4PMbU4hxOnFnHitDEcP6mQ/MwPnnvt7uxt6aSptZPmji5aOropzkln8pjsD03HtXR0saW+hS31LdTtb2fm+DzmlBWQmdb/XlVbZzfb9rSwo6mNoux0xhdkMiY7nZQUlZscQuOH/5/sd3wA5s+fz65du6itraWuro6ioiLGjx/PzTffzMsvv0xKSgo1NTXs3LmT8ePHx/wezz77LKtWreKxxx4Lx2lsZMOGDZx99tncdNNN1NXV8dvf/pZPfepTHyqHw5H0BdHe1c0L79YdfL63pYN/fWoNk4qy+fUNJ1GSlzFkrxVKMUrzMynNz2T+5CI+efxE2rtm8+rGenY2tVFakMmEgkwmFmZ96B/UvqzY1sAvXt3MnzfuprG18wN7KNFy0kOcOG0MdfvaWVPbBMDM8XmU5GVQXpRNYVYaeZmp5GSkkpuRSloohVAKpFi4aA7Y19bJ1j2tbN3TTN3+DkrzM5k9sYDi3HR6HFo7umju6ObdHU386IWN9Dwf3m58fiYzSnMZm5vB5vpm3tu1n6a2D58FlhYyphTnkJuRyp7mcHnti3G2WHoohdll+UwozCI7LURWeojO7h7q93dQ39zBjsY2ahtb6b2DnBYycjJSyUhNISM1XGbZ6SFyMlIpyEpj8phsJo/Jprwom5yMENnpqWSnh5hQkKnjSMmkoLyPPYjyI/q2n/nMZ3jsscfYsWMHl19+Ob/61a+oq6tj2bJlpKWlMXXq1H5PRXV3fvjDH3LOOed8aNk111zDQw89xMMPP8z9999/RDkPSPqC2N/WxecfWvaBsWNKc/n1DScxNnfoyqEvGakh/mbmuMPeft6kQuZdPu/g87bObpraOnEHd+jo6mFVTQOvb6rnjU17yMlI5WsXzOKCuROYUJA1BD9B3/a3d/HWlr2srm1k4679B7+mFGdz0byJTBubS1F2GtnpqWSlh6jb1857deF1Wju6mTwmmzE56ZTkZTB5TDZTirMpzs3gndomqjbv4a2te1m7vYnWjm5aOrpJCxnFORkU56ZTObWIqcXlTBubw/iCTBpawqWxc187Le1dtHX20NbVTVtneNvm9i627mnhmdU7Yu5FZaalUDEhnzllBZQWZJKaYoRSUggZ9Dj0uJOZFqJyahHHluZpCm6k+/jXP3gMAiAtKzx+BC6//HJuuOEGdu/ezUsvvcTixYsZN24caWlpvPDCC2zZ0ueFVQE455xzuOeeezjzzDNJS0tj/fr1lJWVkZOTw3XXXcfChQsZP348FRUVR5TzgKQviIKsNJ7+8qkHnzvO0eNyR+xB4cy00IemXiYXZ3Ph3InDniU3I5XTjinhtGNiXmr+sJUVZvGJitIh/Z4HdPc42xtbqdnbSkukePa1dbJu577wSQvLqmnp6O73e4zNTecj04sZl5dxcMqtrCiLigkFHFWSQ2oohZ4ep6mtk4aWTjq7e+jsdjq6e2hp72J/e3jKrSgnneljc5hYmEVI02LD68CB6CE+i+m4445j3759lJWVMWHCBK666io++clPMmfOHCorK5k5c2a/2//93/89mzdvZsGCBbg7JSUlPPHEEwCUlpYya9asgweqh4IOUosMQk9P+B/yrh6nO3IgP8XCH0Jqau3ktU31vLpxN0s376WptZOWzm66o/ZI0lNTKMhKY29zx4CO90B4Oq28KIvxBZmMz89kXH4mRdlpFGWnU5STzoTI1OSYnHTtufRjUAepR6CWlhbmzJnDW2+9RUFBQcx1dJBaJI5SUozMlNh7lwVZaUwak81llZM+MN7e1c2W+hbeqW1iTW0jTa1dFOemU5ybQWFWGumpKaSFjLRQCtnp4WNA2Rkh6vd3sKluP5t2N1Ozt5Xtja288f4edu1ro7P7w+WSkZrC2NzwFNuYSHFMHpPD1OJsppXkcFRJLmk6jjIq/elPf+L666/n5ptv7rMcDocKQiTOMlJDHFOaxzGleVwyv2zA2x1VAgunjfnQuLvT3NHN3uYO9jR3sL2xje2NrdQ2tB48SL97fztvVzdSHzlNGsJ7LzPH53F8eSE3/c1RcT8GJcPnrLPOOuTxi8OhghAZYcyM3MjZZpPGZHP8pL7X3dfWyZb6Fjbu2s8728N7MI8u28YTK2r414uO49L5ZZqWkj6pIERGsbzMNGaXFTC7rODg3suW+mb+38Ur+cfFK3l2zU6+duEsyouyA046PNw9aQvxcI43a0JSJMlMKc7hkc+dzG3nzeT5d3dx2nde4MYHq3hl4+7D+kdkpMjMzKS+vn5U/4x9OXA/iMzMwX3oN65nMZnZucB/AiHgZ+7+7V7LpwD3ASXAHuDv3L3azP4G+H7UqjOBK9z9ib5eS2cxiQxebUMrD72+hYeXbmNPcwenzhjLPX93wpBcuiXR6I5yse8o199ZTHErCDMLAeuBTwDVwFLgSnd/J2qdR4Hfu/svzOxM4LPufnWv7zMG2AiUu3tLX6+nghA5fG2d3fzmza186w9rmVNWwAOfPZHC7PSgY8kw6K8g4jnFtBDY6O6b3L0DeBjofWnBCiByMQZeiLEc4NPAH/srBxE5MplpIT57yjR+ctUC3qlt4vL/ep1dTcn5m7b8VTwLogyIvphJdWQs2kpgUeTxpUCemRX3WucK4DexXsDMbjSzKjOrqquri7WKiAzCOceN5/7Pnsi2vS1c+pNXWbvk5+Erm36zMPznqsVBR5RhFPRB6luA081sOXA6UAMcvI6BmU0A5gBLYm3s7ve6e6W7V5aUDO3lHESS1SlHj+XhG0/iPP8zU169NXLROv/rPRFUEkkjnkeiaoDoM7TLI2MHuXstkT0IM8sFPuXuDVGrXAb8zt0745hTRHqZW17I7IzFpLR3fHBBZ2v4+kRJdme1ZBXPPYilwAwzm2Zm6YSnip6MXsHMxprZgQy3ET6jKdqV9DG9JCLxldJUE3Pcj+CeCDKyxK0g3L0L+BLh6aG1wGJ3X2Nmd5jZRZHVzgDWmdl6oBS488D2ZjaV8B7IS/HKKCL96OPeB3UpY9lar3NGkoGu5ioisfW+LzPQFcrk9u4beMZO4+4r53P6EF/KXYZfUKe5ishINvcy+OTd4fswY1AwidSLf8hN/3AbEwoyue7+N/nJixuT8pPJyUJ7ECIyaC0dXXz1t2/z1MparvvoVL550XFBR5LDpPtBiMiQyk5P5e4r5lGUncYDr27m7IpSPnr02KBjyRDTFJOIHBYz47bzZjG1OJuvPr6K5vauoCPJEFNBiMhhy0oP8Z1PH0/13la+u2Rd0HFkiKkgROSILJw2hmtPnsoDr27mzff3BB1HhpAKQkSO2D+feyyTxmTxlYeXs37nvqDjyBBRQYjIEctOT+Weq06gs8f51E9e5aX1unjmaKCCEJEhMbusgP/54ilMGpPNZ+9/kwdf2xx0JDlCKggRGTITC7N49PMnc+bMUr7+P2t4fVN90JHkCKggRGRI5WSk8qO/nc/4/Ez+7Zl39UnrEUwFISJDLjMtxFfOmsHyrQ08+87OoOPIYVJBiEhcfPqEcqaX5PDdJevo6u4JOo4cBhWEiMRFaiiFfzr7WDbu2s/jy2PfW0ISmwpCROLm3NnjOX5SIT/43/W0dXYfegNJKCoIEYkbM+Or5x5LbWMb//zYKk01jTAqCBGJq48eNZavnjuTJ1fW8v88soJOlcSIoct9i0jcfeGMowilwP99+l26u527r5xPeqp+P010+i8kIsPixtOO4l8urOCZNTu4+ZEVdPfo8xGJTnsQIjJsrv/YNHp6nDufXsvY3HS+edFxmFnQsaQPcd2DMLNzzWydmW00s1tjLJ9iZs+Z2Soze9HMyqOWTTazZ81srZm9Y2ZT45lVRIbHDadN54ZTp/GL17bwkxffCzqO9CNuBWFmIeDHwHlABXClmVX0Wu17wIPuPhe4A7gratmDwHfdfRawENgVr6wiMrxuO28Wl8ybyHeXrGPx0m1Bx5E+xHMPYiGw0d03uXsH8DBwca91KoDnI49fOLA8UiSp7v6/AO6+391b4phVRIZRSorxnU8fz6kzxnLb797mZV0ePCHFsyDKgOhfDaojY9FWAosijy8F8sysGDgGaDCzx81suZl9N7JH8gFmdqOZVZlZVV2d/oKJjCTpqSn85KoFzBiXy02/eot3dzQFHUl6CfospluA081sOXA6UAN0Ez54fmpk+YnAdOC63hu7+73uXunulSUlJcMWWkSGRl5mGvdddyI5GSH+z/1L2dnUFnQkiRLPgqgBJkU9L4+MHeTute6+yN3nA7dHxhoI722siExPdQFPAAvimFVEAjKxMIufX3siDa2d/P0vqvRp6wQSz4JYCswws2lmlg5cATwZvYKZjTWzAxluA+6L2rbQzA7sFpwJvBPHrCISoNllBdxx8Wzermnkzc17go4jEXEriMhv/l8ClgBrgcXuvsbM7jCziyKrnQGsM7P1QClwZ2TbbsLTS8+Z2duAAf8dr6wiErzz54wnIzWFZ9fo/hGJwkbL3Z4qKyu9qqoq6BgicgRufLCKVdWNvHrrmaSk6AN0w8HMlrl7ZaxlQR+kFhE56NzZ49nR1MaqmsagowgqCBFJIB+fWUpqivHM6h1BRxFUECKSQAqy0zj5qGKeWb2d0TL9PZKpIEQkoZxz3Hg217ewfuf+oKMkPRWEiCSUsytKMYMlazTNFDQVhIgklHH5mZwwuUjHIRKACkJEEs65s8fzzvYmttbrGp1BUkGISMI557jxADy9envASZKbCkJEEs6kMdkcX17A71fVBh0lqakgRCQhffL4iayuaWLz7uagoyQtFYSIJKTz50wA0F5EgFQQIpKQJhZmUTmliN+v0nGIoKggRCRhXTh3Au/u2MeGnfuCjpKUVBAikrDOnzMBM3hKexGBUEGISMIal5/JR6aN4feranVtpgCoIEQkoV04dyKb6ppZu13TTMNNBSEiCe282eMJpRhP6WymYaeCEJGEVpybwSlHj+XJFbX09GiaaTipIEQk4V0ybyI1Da0s27o36ChJRQUhIgnvnOPGk5UW4nfLa4KOklTiWhBmdq6ZrTOzjWZ2a4zlU8zsOTNbZWYvmll51LJuM1sR+XoynjlFJLHlZKTyiYpSnn57Ox1dPUHHSRpxKwgzCwE/Bs4DKoArzayi12rfAx5097nAHcBdUcta3X1e5OuieOUUkZHhkvkTaWjp5KX1dUFHSRrx3INYCGx0903u3gE8DFzca50K4PnI4xdiLBcRAeDUGSWMyUnniRWaZhou8SyIMmBb1PPqyFi0lcCiyONLgTwzK448zzSzKjN73cwuifUCZnZjZJ2qujr9ViEymqWFUrhw7gT+9M5O9rV1Bh0nKQR9kPoW4HQzWw6cDtQA3ZFlU9y9Evhb4AdmdlTvjd39XnevdPfKkpKSYQstIsG4eF4Z7V09uh3pMIlnQdQAk6Kel0fGDnL3Wndf5O7zgdsjYw2RP2sif24CXgTmxzGriIwACyYXMnlMNve9sll7EcMgngWxFJhhZtPMLB24AvjA2UhmNtbMDmS4DbgvMl5kZhkH1gFOAd6JY1YRGQHMjH+5sIINO/dxzX1v0qSSiKu4FYS7dwFfApYAa4HF7r7GzO4wswNnJZ0BrDOz9UApcGdkfBZQZWYrCR+8/ra7qyBEhE9UlPLjqxawuqaRq3/2Bo2tKol4sdFyhcTKykqvqqoKOoaIDJM/vbOTL/xqGRUT8nn8plMIpVjQkUYkM1sWOd77IUEfpBYROSxnVZTy7UVzWVndyJ/W7gw6zqikghCREevieRMpK8zigVc2Bx1lVFJBiMiIlRpK4eqTp/Dapnre3dEUdJxRRwUhIiPaFSdOIjMthV+8ujnoKKOOCkJERrTC7HQunV/G75bXsLe5I+g4o4oKQkRGvGs/OpW2zh4eqdp26JVlwFQQIjLizRyfz8nTi/nla1vo6tblwIeKCkJERoVrPzqVmoZWnn93V9BRRg0VhIiMCmfNGkdJXgaLq6qDjjJqqCBEZFRIDaWwaEEZL6zbxa59bUHHGRUGVBBmlnPgonpmdoyZXWRmafGNJiIyOJ85YRLdPc4Tunf1kBjoHsTLhG/gUwY8C1wNPBCvUCIih+PocbmcMKWIxVXVjJbrzAVpoAVh7t5C+O5vP3H3zwDHxS+WiMjhuayynI279rN8W0PQUUa8AReEmZ0MXAX8ITIWik8kEZHDd8HciWSlhXhUn4k4YgMtiK8QvqHP7yL3dJhO+D4NIiIJJTcjlfPnTOCpldtp6egKOs6INqCCcPeX3P0id/+3yMHq3e7+5ThnExE5LJdVlrO/vYs/vq17Vx+JgZ7F9GszyzezHGA18I6Z/VN8o4mIHJ6F08ZQXpTFU6tqg44yog10iqnC3ZuAS4A/AtMIn8kkIpJwzIwL5kzgLxt209CiC/gdroEWRFrkcw+XAE+6eyegc8hEJGGdP2cCXT3Os+/obnOHa6AF8V/AZiAHeNnMpgC6O4eIJKy55QWUF2Xx9Nvbg44yYg30IPXd7l7m7ud72Bbgbw61nZmda2brzGyjmd0aY/kUM3vOzFaZ2YtmVt5reb6ZVZvZjwb8E4mIoGmmoTDQg9QFZvYfZlYV+fp3wnsT/W0TAn4MnAdUAFeaWUWv1b4HPOjuc4E7gLt6Lf//CH+KW0Rk0DTNdGQGOsV0H7APuCzy1QTcf4htFgIb3X2Tu3cADwMX91qnAng+8viF6OVmdgJQSvjSHiIig6ZppiMz0II4yt2/EfnHfpO7/ysw/RDblAHRH2WsjoxFW0n48h0AlwJ5ZlYc+azFvwO3DDCfiMiHaJrpyAy0IFrN7GMHnpjZKUDrELz+LcDpZrYcOB2oAbqBm4Cn3b3fC7ub2Y0Hpr3q6uqGII6IjDaaZjp8qQNc7/PAg2ZWEHm+F7j2ENvUAJOinpdHxg5y91oiexBmlgt8yt0bItd9OtXMbgJygXQz2+/ut/ba/l7gXoDKykqddisiH3JgmunZNTu4rHLSoTeQgwZUEO6+EjjezPIjz5vM7CvAqn42WwrMMLNphIvhCuBvo1cws7HAHnfvIXytp/si3/+qqHWuAyp7l4OIyECYGSdPL+b5d3fh7phZ0JFGjEHdUc7dmyKfqAb4x0Os2wV8CVgCrAUWRy70d4eZXRRZ7QxgnZmtJ3xA+s7B5BERGYi55QXUN3dQ26g7zQ3GQKeYYjlkDbv708DTvca+HvX4MeCxQ3yPB9DNiUTkCMwtLwRg1bYGygqzgg0zghzJPak15y8iI8LMCXmkhYxVNY1BRxlR+t2DMLN9xC4CA1TDIjIiZKSGOHZ8Hm9XqyAGo9+CcPe84QoiIhJPc8oK+cOqWh2oHoQjmWISERkx5pYX0NTWxdY9LUFHGTFUECKSFOaUhT/GtUrTTAOmghCRpHDs+DzSU1N4WweqB0wFISJJIS2UQsWEfFZuawg6yoihghCRpDG3vIDVNY309Ogs/YFQQYhI0phTVkBzRzebdjcHHWVEUEGISNI48Inqt2saAs0xUqggRCRpHD0ul6y0kM5kGiAVhIgkjVCKMbssX5+oHiAVhIgklTllhayubaSruyfoKAlPBSEiSWX+5ELaOnt4d8e+oKMkPBWEiCSVBVOKAFi2ZW/ASRKfCkJEksrEgkxK8zN4a6sK4lBUECKSVMyME6YUqSAGQAUhIklnweQitu1pZdc+3YK0PyoIEUk68yeHj0O8taUh2CAJTgUhIklndlk+6aEUlmuaqV9xLQgzO9fM1pnZRjO7NcbyKWb2nJmtMrMXzaw8avwtM1thZmvM7PPxzCkiySUjNcTssnydyXQIcSsIMwsBPwbOAyqAK82sotdq3wMedPe5wB3AXZHx7cDJ7j4P+Ahwq5lNjFdWEUk+CyYXsaqmkY4ufWCuL/Hcg1gIbHT3Te7eATwMXNxrnQrg+cjjFw4sd/cOd2+PjGfEOaeIJKEFU4ro6Orhne1NQUdJWPH8h7cM2Bb1vDoyFm0lsCjy+FIgz8yKAcxskpmtinyPf3P32jhmFZEkc8KUAweqNc3Ul6B/M78FON3MlgOnAzVAN4C7b4tMPR0NXGtmpb03NrMbzazKzKrq6uqGM7eIjHCl+ZmUFWaxTAeq+xTPgqgBJkU9L4+MHeTute6+yN3nA7dHxhp6rwOsBk7t/QLufq+7V7p7ZUlJyRDHF5HRbv7kQpZrD6JP8SyIpcAMM5tmZunAFcCT0SuY2VgzO5DhNuC+yHi5mWVFHhcBHwPWxTGriCShBZOLqG1so3pvS9BRElLcCsLdu4AvAUuAtcBid19jZneY2UWR1c4A1pnZeqAUuDMyPgt4w8xWAi8B33P3t+OVVUSS08dnjSM9lMJ3ntHvn7GY++i4eXdlZaVXVVUFHUNERpi7n9vAf/zven52TSVnVXzoUOeoZ2bL3L0y1rKgD1KLiATq86cfxczxedz+xNs0tnYGHSehqCBEJKmlp6bwnU/PpW5fO9/+49qg4yQUFYSIJL255YXccNp0fvPmNl7fVB90nIShghARAW4+6xjG5WXw05feCzpKwlBBiIgAmWkhrlw4mZfW17GlvjnoOAlBBSEiEnHlwsmkmPHrN7YGHSUhqCBERCLGF2RydkUpj1Rto62zO+g4gVNBiIhEufqkKTS0dPKHVduDjhI4FYSISJSTjypmekkOD72xJegogVNBiIhEMTOuPmkKy7c2sLqmMeg4gVJBiIj0smhBOVlpoaQ/5VUFISLSS0FWGjecNp3fr9rO75ZXBx0nMCoIEZEYvnzm0SycOobbf7eaTXX7g44TCBWEiEgMqaEU/vPKeWSkpvDFXy9PytNeVRAiIn2YUJDFv192PGu3N/F/n06+C/mpIERE+nHmzFKuPmkKv3pjK/X724OOM6xUECIih3Dlwsl09zhL1uwMOsqwUkGIiBzCrAl5TBubw9NvJ9enq1UQIiKHYGacP2c8r22qT6ppJhWEiMgAXDBnYtJNM6kgREQGIBmnmeJaEGZ2rpmtM7ONZnZrjOVTzOw5M1tlZi+aWXlkfJ6ZvWZmayLLLo9nThGRQ0nGaaa4FYSZhYAfA+cBFcCVZlbRa7XvAQ+6+1zgDuCuyHgLcI27HwecC/zAzArjlVVEZCCSbZopnnsQC4GN7r7J3TuAh4GLe61TATwfefzCgeXuvt7dN0Qe1wK7gJI4ZhUROaRkm2aKZ0GUAduinldHxqKtBBZFHl8K5JlZcfQKZrYQSAc+dFlFM7vRzKrMrKqurm7IgouIxBI9zbRrX1vQceIu6IPUtwCnm9ly4HSgBjh4wRMzmwD8Evisu/f03tjd73X3SnevLCnRDoaIxN+nFpTT4879r2wOOkrcxbMgaoBJUc/LI2MHuXutuy9y9/nA7ZGxBgAzywf+ANzu7q/HMaeIyIBNL8nlgjkTePDVzTS0dAQdJ67iWRBLgRlmNs3M0oErgCejVzCzsWZ2IMNtwH2R8XTgd4QPYD8Wx4wiIoP2pTOPprmjmwde3Rx0lLiKW0G4exfwJWAJsBZY7O5rzOwOM7sostoZwDozWw+UAndGxi8DTgOuM7MVka958coqIjIYM8fnc3ZFKfe/spl9bZ1Bx4kbc/egMwyJyspKr6qqCjqGiCSJVdUNXPSjV/jquTP5whlHBR3nsJnZMnevjLUs6IPUIiIj0tzyQk4/poSf/XkTrR2j82ZCKggRkcP0pTOPpr65g8eWbTv0yiOQCkJE5DCdOHUMx03M5+GlKggREenlihMnsaa2idU1jUFHGXIqCBGRI3DRvDIyUlN4ZBTuRaggRESOQEFWGufPmcATK2pG3cFqFYSIyBG6/MRJ7Gvr4o+rR9dF/FQQIiJH6CPTxjC1OHvUTTOpIEREjpCZcdmJk3jj/T1sqtsfdJwho4IQERkCn15QTijF+M/nNtDV/aGLT49IKggRkSEwLj+TL5x+FP+zopbr7l86Kq70qoIQERkit5xzLN/59FzefH8PF/3oFdbt2Bd0pCOighARGUKXVU7i4c+dRFtnN1f97A2a27uCjnTYVBAiIkNsweQifnr1Ceze3859f3k/6DiHTQUhIhIHCyYXcXZFKfe+vIm9zSPzeIQKQkQkTm4551iaO7q456X3go5yWFQQIiJxckxpHpfOL+eBVzezvbE16DiDpoIQEYmjr5w1Axz+808bgo4yaCoIEZE4mjQmm6tOmsyjy6pZu70p6DiDooIQEYmzL585g8KsNG57/G26ezzoOAMW14Iws3PNbJ2ZbTSzW2Msn2Jmz5nZKjN70czKo5Y9Y2YNZvb7eGYUEYm3opx0vv7JClZsa+Ch17cEHWfA4lYQZhYCfgycB1QAV5pZRa/Vvgc86O5zgTuAu6KWfRe4Ol75RESG00XHT+TUGWP5zjPvUtswMg5Yx3MPYiGw0d03uXsH8DBwca91KoDnI49fiF7u7s8BI/tz6iIiEWbGnZfModudbzy5Jug4AxLPgigDoi+OXh0Zi7YSWBR5fCmQZ2bFA30BM7vRzKrMrKquru6IwoqIxNvk4mxuPusY/vednfx2WXXQcQ4p6IPUtwCnm9ly4HSgBhjwPfvc/V53r3T3ypKSknhlFBEZMtd/bBonTy/mtsffpmrznqDj9CueBVEDTIp6Xh4ZO8jda919kbvPB26PjDXEMZOISKBSQync83cLKCvK4sZfLmNrfUvQkfoUz4JYCswws2lmlg5cATwZvYKZjTWzAxluA+6LYx4RkYRQmJ3Oz6+tpLvHuf4XS2lq6zyi7+cen1NnU+PyXQF37zKzLwFLgBBwn7uvMbM7gCp3fxI4A7jLzBx4Gfjige3N7M/ATCDXzKqB6919SbzyiogMp+kludxz1QKuue9Nzv6Pl7n+Y9O48iOTyc0I/7Pc0+Ns3dPCyuoGVm5rZMOufRw9LpeFU8dwwpQiahvbeGXjbv6yYTeF2Wnc83cnDHlGi1fzDLfKykqvqqoKOoaIyKC8vqmeH/xpPa9v2kN+ZirzJxdRvbeFbXta6YjcujQzLYVpY3N5f/d+2jo/eDvTWRPyObuilJs/ccxhvb6ZLXP3ypjLVBAiIsFbsa2Be19+j/d3tzBlTDZTxmYzrTiHueWFHFOaS2oohY6uHt6uaWT51r2U5GVwytFjGZubcUSvq4IQEZGY+iuIoE9zFRGRBKWCEBGRmFQQIiISkwpCRERiUkGIiEhMKggREYlJBSEiIjGpIEREJKZR80E5M6sDDtzLrwBojFp84Hn0eO+xscDuQbxk79c41LK+MvX1eLjz9ZcpVq5YY8n+HvaXL1auWGN6D/UeDne+Ke4e+34J7j7qvoB7Yz2PHu89RvgCgof9Goda1lemAeQalnz9ZdJ7eOT59B7qPUzUfP19jdYppqf6eP7UIcaO5DUOtayvTH09Hu58/WXqK4/ew/7H9B7qPYz152DFO1+fRs0U05Eysyrv43okiSDR80HiZ0z0fJD4GRM9HyR+xkTPF2207kEcjnuDDnAIiZ4PEj9joueDxM+Y6Pkg8TMmer6DtAchIiIxaQ9CRERiUkGIiEhMKggREYlJBXEIZnaqmf3UzH5mZq8GnScWM0sxszvN7Idmdm3QeXozszPM7M+R9/GMoPP0xcxyzKzKzC4MOktvZjYr8v49ZmZfCDpPLGZ2iZn9t5k9YmZnB52nNzObbmY/N7PHgs4SLfL37heR9+6qoPNEG9UFYWb3mdkuM1vda/xcM1tnZhvN7Nb+voe7/9ndPw/8HvhFImYELgbKgU6gOgHzObAfyBzqfEOYEeCrwOJEzOfuayN/Dy8DTknQjE+4+w3A54HLEzDfJne/fihz9WWQeRcBj0Xeu4uGI9+ADeYTfSPtCzgNWACsjhoLAe8B04F0YCVQAcwhXALRX+OitlsM5CViRuBW4HORbR9LwHwpke1KgV8l6Hv4CeAK4DrgwkTLF9nmIuCPwN8m4nsYtd2/AwsSON+Q/j8yBHlvA+ZF1vl1vLMN5iuVUczdXzazqb2GFwIb3X0TgJk9DFzs7ncBMacWzGwy0Oju+xIxo5lVAx2Rp92Jli/KXiBjKPMNVcbI1FcO4f9hW83saXfvSZR8ke/zJPCkmf0B+PVQZBvKjGZmwLeBP7r7W4mWbzgNJi/hvepyYAUJNqszqguiD2XAtqjn1cBHDrHN9cD9cUv0YYPN+DjwQzM7FXg5nsEiBpXPzBYB5wCFwI/imuyvBpXR3W8HMLPrgN1DVQ79GOx7eAbhqYgM4Ol4Bosy2L+H/wCcBRSY2dHu/tN4hmPw72ExcCcw38xuixTJcOor793Aj8zsAg7/chxxkYwFMWju/o2gM/TH3VsIl1hCcvfHCZdYwnP3B4LOEIu7vwi8GHCMfrn73YT/sUtI7l5P+PhIQnH3ZuCzQeeIJaF2Z4ZJDTAp6nl5ZCyRJHrGRM8HiZ8x0fNB4mdM9Hy9jbS8SVkQS4EZZjbNzNIJH5h8MuBMvSV6xkTPB4mfMdHzQeJnTPR8vY20vKP+LKbfANv56+mf10fGzwfWEz6j4HZlHLn5RkLGRM83EjImer6RnrevL12sT0REYkrGKSYRERkAFYSIiMSkghARkZhUECIiEpMKQkREYlJBiIhITCoIGdXMbP8wv96Q3DPEwvfQaDSzFWb2rpl9bwDbXGJmFUPx+iKgghAZFDPr9/pl7v7RIXy5P7v7PGA+cKGZHeo+EJcQvhqtyJBQQUjSMbOjzOwZM1tm4TvdzYyMf9LM3jCz5Wb2JzMrjYx/08x+aWavAL+MPL/PzF40s01m9uWo770/8ucZkeWPRfYAfhW5HDZmdn5kbJmZ3W1mv+8vr7u3Er4UdFlk+xvMbKmZrTSz35pZtpl9lPD9Ir4b2es4qq+fU2SgVBCSjO4F/sHdTwBuAX4SGf8LcJK7zwceBv45apsK4Cx3vzLyfCbhS5gvBL5hZmkxXmc+8JXIttOBU8wsE/gv4LzI65ccKqyZFQEz+Oul3B939xPd/XhgLeHLOLxK+Lo+/+Tu89z9vX5+TpEB0eW+JamYWS7wUeDRyC/08NebGJUDj5jZBMJ3/Ho/atMnI7/JH/AHd28H2s1sF+G75fW+neqb7l4ded0VwFTCt17d5O4HvvdvgBv7iHuqma0kXA4/cPcdkfHZZvYtwvfXyAWWDPLnFBkQFYQkmxSgITK339sPgf9w9ycjN+j5ZtSy5l7rtkc97ib2/0sDWac/f3b3C81sGvC6mS129xXAA8Al7r4ycoOjM2Js29/PKTIgmmKSpOLuTcD7ZvYZCN8m08yOjywu4K/X5782ThHWAdOjbkd5+aE2iOxtfBv4amQoD9gemda6KmrVfZFlh/o5RQZEBSGjXbaZVUd9/SPhf1Svj0zfrCF8X2AI7zE8ambLgN3xCBOZproJeCbyOvuAxgFs+lPgtEix/AvwBvAK8G7UOg8D/xQ5yH4Uff+cIgOiy32LDDMzy3X3/ZGzmn4MbHD37wedS6Q37UGIDL8bIget1xCe1vqvYOOIxKY9CBERiUl7ECIiEpMKQkREYlJBiIhITCoIERGJSQUhIiIxqSBERCSm/x90pnMLbv76DgAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -656,19 +609,190 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 15,
    "id": "c60ffae1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T14:01:26.646743Z",
-     "iopub.status.busy": "2022-08-16T14:01:26.646159Z",
-     "iopub.status.idle": "2022-08-16T14:01:26.840653Z",
-     "shell.execute_reply": "2022-08-16T14:01:26.839916Z",
-     "shell.execute_reply.started": "2022-08-16T14:01:26.646722Z"
+     "iopub.execute_input": "2022-08-16T14:42:00.484636Z",
+     "iopub.status.busy": "2022-08-16T14:42:00.484365Z",
+     "iopub.status.idle": "2022-08-16T14:53:20.088500Z",
+     "shell.execute_reply": "2022-08-16T14:53:20.087911Z",
+     "shell.execute_reply.started": "2022-08-16T14:42:00.484604Z"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<style>\n",
+       "    /* Turns off some styling */\n",
+       "    progress {\n",
+       "        /* gets rid of default border in Firefox and Opera. */\n",
+       "        border: none;\n",
+       "        /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
+       "        background-size: auto;\n",
+       "    }\n",
+       "    progress:not([value]), progress:not([value])::-webkit-progress-bar {\n",
+       "        background: repeating-linear-gradient(45deg, #7e7e7e, #7e7e7e 10px, #5c5c5c 10px, #5c5c5c 20px);\n",
+       "    }\n",
+       "    .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
+       "        background: #F44336;\n",
+       "    }\n",
+       "</style>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: left;\">\n",
+       "      <th>epoch</th>\n",
+       "      <th>train_loss</th>\n",
+       "      <th>valid_loss</th>\n",
+       "      <th>time</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>0</td>\n",
+       "      <td>0.230185</td>\n",
+       "      <td>0.153539</td>\n",
+       "      <td>00:33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1</td>\n",
+       "      <td>0.133782</td>\n",
+       "      <td>0.131332</td>\n",
+       "      <td>00:32</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>2</td>\n",
+       "      <td>0.117544</td>\n",
+       "      <td>0.173046</td>\n",
+       "      <td>00:34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>3</td>\n",
+       "      <td>0.107722</td>\n",
+       "      <td>0.086296</td>\n",
+       "      <td>00:34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>4</td>\n",
+       "      <td>0.099810</td>\n",
+       "      <td>0.091931</td>\n",
+       "      <td>00:33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>5</td>\n",
+       "      <td>0.085169</td>\n",
+       "      <td>0.077105</td>\n",
+       "      <td>00:33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>6</td>\n",
+       "      <td>0.078655</td>\n",
+       "      <td>0.081761</td>\n",
+       "      <td>00:33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>7</td>\n",
+       "      <td>0.082691</td>\n",
+       "      <td>0.098803</td>\n",
+       "      <td>00:33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>8</td>\n",
+       "      <td>0.047856</td>\n",
+       "      <td>0.061368</td>\n",
+       "      <td>00:33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>9</td>\n",
+       "      <td>0.051574</td>\n",
+       "      <td>0.055845</td>\n",
+       "      <td>00:34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>10</td>\n",
+       "      <td>0.047941</td>\n",
+       "      <td>0.052415</td>\n",
+       "      <td>00:33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>11</td>\n",
+       "      <td>0.044053</td>\n",
+       "      <td>0.041516</td>\n",
+       "      <td>00:34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>12</td>\n",
+       "      <td>0.039671</td>\n",
+       "      <td>0.040142</td>\n",
+       "      <td>00:33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>13</td>\n",
+       "      <td>0.032941</td>\n",
+       "      <td>0.034584</td>\n",
+       "      <td>00:33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>14</td>\n",
+       "      <td>0.030123</td>\n",
+       "      <td>0.037169</td>\n",
+       "      <td>00:34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>15</td>\n",
+       "      <td>0.026035</td>\n",
+       "      <td>0.031958</td>\n",
+       "      <td>00:34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>16</td>\n",
+       "      <td>0.020250</td>\n",
+       "      <td>0.030487</td>\n",
+       "      <td>00:34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>17</td>\n",
+       "      <td>0.013217</td>\n",
+       "      <td>0.031991</td>\n",
+       "      <td>00:34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>18</td>\n",
+       "      <td>0.017142</td>\n",
+       "      <td>0.030333</td>\n",
+       "      <td>00:34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>19</td>\n",
+       "      <td>0.015309</td>\n",
+       "      <td>0.027875</td>\n",
+       "      <td>00:34</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "epochs = 20\n",
     "model_name = f'{epochs}_epochs_{output_embedding_length}_features'\n",
@@ -676,7 +800,7 @@
     "try:\n",
     "    learn = learn.load(model_name)\n",
     "except:\n",
-    "    lr = 0.13\n",
+    "    lr = 0.1\n",
     "    epochs = 20\n",
     "    learn.fit_one_cycle(epochs, slice(lr))\n",
     "    learn.save(model_name)"
@@ -694,15 +818,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 16,
    "id": "fe76a6b6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T14:01:30.833579Z",
-     "iopub.status.busy": "2022-08-16T14:01:30.833018Z",
-     "iopub.status.idle": "2022-08-16T14:01:31.008581Z",
-     "shell.execute_reply": "2022-08-16T14:01:31.007519Z",
-     "shell.execute_reply.started": "2022-08-16T14:01:30.833559Z"
+     "iopub.execute_input": "2022-08-16T14:53:20.089983Z",
+     "iopub.status.busy": "2022-08-16T14:53:20.089724Z",
+     "iopub.status.idle": "2022-08-16T14:53:20.153135Z",
+     "shell.execute_reply": "2022-08-16T14:53:20.151996Z",
+     "shell.execute_reply.started": "2022-08-16T14:53:20.089931Z"
     },
     "tags": []
    },
@@ -748,12 +872,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[-0.10099696 -0.08450948  0.03510209 -0.15825109 -0.04520801  0.20577735\n",
-      "  0.10355564  0.01773667  0.05295658 -0.09321447  0.03732459  0.0393499\n",
-      "  0.02228327 -0.06537104  0.09933136  0.08348498 -0.02667931 -0.22959505\n",
-      " -0.04327893 -0.07219108 -0.09431483  0.0125113  -0.46360245 -0.11086255\n",
-      "  0.35560194  0.18639638  0.06533853  0.28910112  0.13699105  0.15609336\n",
-      " -0.30878097  0.42498502]\n"
+      "[-0.4385764   0.07380641  0.23816751  0.29184356 -0.14723992  0.34137195\n",
+      "  0.06991758  0.33740816  0.09130197 -0.22511393  0.21159591  0.10746336\n",
+      "  0.16765437  0.21437302  0.12018973 -0.16545856 -0.18934958 -0.07480964\n",
+      " -0.08150642 -0.17008734 -0.12432582 -0.08482609 -0.01266793 -0.02727649\n",
+      "  0.11497439  0.17786284 -0.03590712  0.02044249  0.03340663  0.02261158\n",
+      "  0.08458877 -0.12734443]\n"
      ]
     }
    ],
@@ -776,15 +900,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 17,
    "id": "4117ef00",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T14:01:35.782917Z",
-     "iopub.status.busy": "2022-08-16T14:01:35.782458Z",
-     "iopub.status.idle": "2022-08-16T14:01:35.829946Z",
-     "shell.execute_reply": "2022-08-16T14:01:35.829005Z",
-     "shell.execute_reply.started": "2022-08-16T14:01:35.782898Z"
+     "iopub.execute_input": "2022-08-16T14:53:20.155352Z",
+     "iopub.status.busy": "2022-08-16T14:53:20.154422Z",
+     "iopub.status.idle": "2022-08-16T14:53:20.296253Z",
+     "shell.execute_reply": "2022-08-16T14:53:20.295284Z",
+     "shell.execute_reply.started": "2022-08-16T14:53:20.155324Z"
     },
     "tags": []
    },
@@ -795,7 +919,7 @@
        "10000"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -807,15 +931,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 18,
    "id": "afdbf8b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T14:01:37.390863Z",
-     "iopub.status.busy": "2022-08-16T14:01:37.390647Z",
-     "iopub.status.idle": "2022-08-16T14:01:37.397059Z",
-     "shell.execute_reply": "2022-08-16T14:01:37.396243Z",
-     "shell.execute_reply.started": "2022-08-16T14:01:37.390834Z"
+     "iopub.execute_input": "2022-08-16T14:53:20.297508Z",
+     "iopub.status.busy": "2022-08-16T14:53:20.297357Z",
+     "iopub.status.idle": "2022-08-16T14:53:20.304989Z",
+     "shell.execute_reply": "2022-08-16T14:53:20.303860Z",
+     "shell.execute_reply.started": "2022-08-16T14:53:20.297490Z"
     },
     "tags": []
    },
@@ -826,7 +950,7 @@
        "Path('/home/jav/.fastai/data/mnist_png/testing/4/7818.png')"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -837,15 +961,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 19,
    "id": "d83ab8c7-b1fb-49c7-b4b0-f0a84c9d1afd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T14:01:39.217500Z",
-     "iopub.status.busy": "2022-08-16T14:01:39.217285Z",
-     "iopub.status.idle": "2022-08-16T14:04:31.302623Z",
-     "shell.execute_reply": "2022-08-16T14:04:31.301333Z",
-     "shell.execute_reply.started": "2022-08-16T14:01:39.217470Z"
+     "iopub.execute_input": "2022-08-16T14:53:20.306646Z",
+     "iopub.status.busy": "2022-08-16T14:53:20.306168Z",
+     "iopub.status.idle": "2022-08-16T14:56:21.595099Z",
+     "shell.execute_reply": "2022-08-16T14:56:21.593759Z",
+     "shell.execute_reply.started": "2022-08-16T14:53:20.306621Z"
     },
     "tags": [
      "hide-output"
@@ -885,7 +1009,7 @@
        "\n",
        "    <div>\n",
        "      <progress value='10000' class='' max='10000' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
-       "      100.00% [10000/10000 02:52&lt;00:00]\n",
+       "      100.00% [10000/10000 03:01&lt;00:00]\n",
        "    </div>\n",
        "    "
       ],
@@ -924,15 +1048,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 20,
    "id": "2390d32b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T14:04:53.622571Z",
-     "iopub.status.busy": "2022-08-16T14:04:53.621578Z",
-     "iopub.status.idle": "2022-08-16T14:04:53.626145Z",
-     "shell.execute_reply": "2022-08-16T14:04:53.625324Z",
-     "shell.execute_reply.started": "2022-08-16T14:04:53.622550Z"
+     "iopub.execute_input": "2022-08-16T14:56:21.597114Z",
+     "iopub.status.busy": "2022-08-16T14:56:21.596598Z",
+     "iopub.status.idle": "2022-08-16T14:56:21.601895Z",
+     "shell.execute_reply": "2022-08-16T14:56:21.600955Z",
+     "shell.execute_reply.started": "2022-08-16T14:56:21.597067Z"
     },
     "tags": []
    },
@@ -946,15 +1070,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 21,
    "id": "09966276",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T14:04:58.706649Z",
-     "iopub.status.busy": "2022-08-16T14:04:58.706471Z",
-     "iopub.status.idle": "2022-08-16T14:04:58.812765Z",
-     "shell.execute_reply": "2022-08-16T14:04:58.811999Z",
-     "shell.execute_reply.started": "2022-08-16T14:04:58.706632Z"
+     "iopub.execute_input": "2022-08-16T14:56:21.603602Z",
+     "iopub.status.busy": "2022-08-16T14:56:21.603011Z",
+     "iopub.status.idle": "2022-08-16T14:56:21.689074Z",
+     "shell.execute_reply": "2022-08-16T14:56:21.688191Z",
+     "shell.execute_reply.started": "2022-08-16T14:56:21.603583Z"
     },
     "scrolled": true,
     "tags": []
@@ -962,7 +1086,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAAeklEQVR4nNWQyxGDMAxEHzQWURnqTKayzcGQMUb2TI7sTdqPPvAmLACY7ZSjdkrpJK4Otb2meVtb2N1qvfjkA/csy65pHpGwLskwSZlbUoSkxPk7KZ0Kg20rhpmnseFuHzKAY0D2gS35WDJ/fEJ+ZsLpkbPv4DH0/YsvgaZpcV1JKgwAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAABEUlEQVR4nGNgGMzApHXZ9X8fy7HIyC3/+vvv379//34Ox5Sc8/fv1eV13xcY/X0viC7H/+h3HicDw8IMs78/zdElpf+uYGBgYODgXf/3DoapfPdfGjEwMDAk//2bhWln0LfX/gwMxt/+flTC4tzA7xf0WDf9/VWJRY6Bwf/mqxN/f1dglWNg8P/79+8UHHKh///9+xeDXa7s17+LOlNfGmOTq/jxdxc/g9jlO7yYcpXf/87hZGBgMP2LGfA+334VcjMwMDCIPXuEIiHJxsDQ9ncRlHfpEbpGhpN//SEMkacISSYovYlBiIGBgYFBrFfiF4ZOvWcPJrMxMMvt/fveAtO1uqf+Plp/5O/fd8GYclQGAJhmaL9I6F0zAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
       ]
@@ -974,72 +1098,16 @@
      "data": {
       "text/plain": [
        "['8',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/8/1530.png'),\n",
-       " 0.046761393547058105,\n",
-       " array([-0.15196997, -0.03608787,  0.00868906, -0.1474988 , -0.07871772,\n",
-       "         0.18009232,  0.06617993, -0.07894154,  0.12192538, -0.02143634,\n",
-       "         0.04440383,  0.10302673,  0.03750927, -0.07367066,  0.09718364,\n",
-       "         0.12069038,  0.0224285 , -0.25404668, -0.11400666, -0.16254014,\n",
-       "        -0.0650501 , -0.10554277, -0.3876711 , -0.04148291,  0.3751997 ,\n",
-       "         0.14719807, -0.00786453,  0.28334555,  0.04159332,  0.13660236,\n",
-       "        -0.338259  ,  0.44309753], dtype=float32)]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAABKElEQVR4nGNgGNxAY8u/9/lsjBOvWWJIaW75+e/v26ezKv/+3Ysmxdz35e+76c4SEpv//f0SgGbitL8fJ0ozMDA0/P33FU2u7fu/7SYMDAwMFb///qtGkWJa8O+2NwMDAwODwr9//zaj6qv/+1AWoqrt799bIlBRFgglzvAnmeHb5O/8q1wYljS8QdXJ175376uXT2Y8/vd3Px+2AODmln/5999LcSSXIJhfv/5lZPzOKIdNIwND3Me/xyRWfwzBJqf98e85DuZFf9djkXP88neXBEPq378rMeV0r/7bLsTg/e/vO2MMOY4T/2YxMFh/+X+UH1Pjwr8XRBgCv/49KoApF/3lozRz2ZdHs7HoY9jyd3bkib+7JLD5gqHn79+/xzOZscpRHQAA/XV6p7us4F4AAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "['8',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/8/9695.png'),\n",
-       " 0.05765575170516968,\n",
-       " array([-0.14378099, -0.01904452,  0.02563651, -0.16199934, -0.0731125 ,\n",
-       "         0.17124939,  0.04726793, -0.07125276,  0.1401669 , -0.03016548,\n",
-       "         0.08940042,  0.09959242,  0.03449062, -0.08187288,  0.08232458,\n",
-       "         0.1259517 ,  0.037958  , -0.27090096, -0.08992128, -0.15366232,\n",
-       "        -0.0683461 , -0.1331811 , -0.35772353, -0.02952323,  0.35062593,\n",
-       "         0.17712657, -0.0079319 ,  0.27478832,  0.03862523,  0.11074734,\n",
-       "        -0.3604329 ,  0.45798868], dtype=float32)]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAAx0lEQVR4nGNgGLyAkT2yad6/f//+XQllRJcTmf4XDqbxosoxzfmLBNK4USTl/6KA88LIkv1/0WQDGBiYUA3/8Q3G0jNEknzNwMDA8GLKF6weEUYz9m8mAwMLTPLPS3EkpS/vH5uJxGVdh6TraQGKqSxIrn3WrYZqJS9c6rm/Crp7imByx5Qx3Jr7CiZ5ASlooP4UhQvpqmBIGsIFjlzAkLyNkPyJIQkPtf4GDPcwcB6HOGclhjcYGBgYfP7+/fs6l5UJmxy1AQDgVqLo4CL5NQAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "['8',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/8/7845.png'),\n",
-       " 0.05808192491531372,\n",
-       " array([-1.07208796e-01,  1.58861019e-02,  1.01681929e-02, -1.64128333e-01,\n",
-       "        -7.68265128e-02,  1.69703022e-01,  8.00302997e-02, -3.77415568e-02,\n",
-       "         1.36849627e-01, -9.14011709e-03,  9.38586593e-02,  1.22826666e-01,\n",
-       "         2.78840382e-02, -1.06367722e-01,  7.64094442e-02,  1.00307576e-01,\n",
-       "         2.54410412e-02, -2.66223699e-01, -9.38874185e-02, -1.80105120e-01,\n",
-       "        -1.01681605e-01, -1.25512525e-01, -3.67389411e-01, -3.09003498e-02,\n",
-       "         3.22947919e-01,  1.96895123e-01,  3.48446702e-05,  2.83417195e-01,\n",
-       "         6.25862926e-02,  8.62728059e-02, -3.62059206e-01,  4.55357343e-01],\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/5876.png'),\n",
+       " 0.03822958469390869,\n",
+       " array([-3.68332297e-01,  1.58202797e-01,  2.95534283e-01,  2.31184542e-01,\n",
+       "        -1.78733289e-01,  3.77019674e-01,  1.26442909e-01,  3.05077612e-01,\n",
+       "         7.04605654e-02, -2.33200312e-01,  2.21860155e-01,  1.09218769e-01,\n",
+       "         1.93249613e-01,  2.20926225e-01,  1.08081222e-01, -2.30418533e-01,\n",
+       "        -2.20318958e-01, -8.47602636e-02, -5.90615310e-02, -1.71346053e-01,\n",
+       "        -7.63074979e-02,  3.74966156e-04,  6.62550181e-02, -1.17210075e-01,\n",
+       "         1.17863484e-01,  1.04648709e-01,  3.06050368e-02,  2.86547444e-03,\n",
+       "        -1.30512118e-02,  3.01726423e-02,  4.46750410e-02, -5.05277514e-02],\n",
        "       dtype=float32)]"
       ]
      },
@@ -1048,7 +1116,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA5ElEQVR4nGNgGLqAxX7GmycT1GBcRhhD1NHnjmCgHAMDA8PsdJhaKG26XQjTICYIxbdaiIGBgeFHutFKhGEw0Pzv379///595GBQ//evFE1SsKzdY/+/f/82sE/5d8ERi1N5Ov78+3fw5b8K7D4p+/fv3z9ckvz7/v37988UuySDyL9//3YxoXsFCn6jqkWVlGVgYNDkxW6q9L5///7908Cu086BgYGBIQC7pDkOdzIwMDDovP/3b8a/L05YdarzMzCIMxzah8O1DAz+vzZgN9bjw79//ybhstTj3793ingcRTwAAPS4S0rWnQxaAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAABJklEQVR4nM2QPUgDQRCF38UgCQQPPRAERQ5EQdIIYiEStBGjYGNlpeUZgp21RSo7/xqxSmFrZRGMhVhYmCYBFcHiEISQEIzGypxvziJcLua2tPA1szPfvpnZBf6ZtM5E790Y1gesspeH22R+ZdzsG4HmGmV0a/ebJEnJLSLgXNNQd64e0TiZgh7ZsrOdzkvuG63TYNams/qr7ULzxgCA2Podq2eJrqF13u4gOlcj36zARolnfp2+UsgZxZP1DEkKD3oUMFkiyZftIQWbfBIRef+YVTB8ks18KimVUTVsAMYSz8NBuEdm4kBombZX8m/FgaMqIP2IeKVQGxZbwTr0m/nOAnCff9gcc+EEZ0YvSJIua9OKdScKJCmVtIIBMdM85rXyE/5UP8ordu3DJ6iIAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
       ]
@@ -1060,15 +1128,15 @@
      "data": {
       "text/plain": [
        "['8',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/8/4978.png'),\n",
-       " 0.059948503971099854,\n",
-       " array([-0.13393578, -0.01838107, -0.00534778, -0.17210366, -0.07266845,\n",
-       "         0.18902731,  0.03273853, -0.08977108,  0.13195774, -0.02636713,\n",
-       "         0.09701853,  0.1159689 ,  0.02596068, -0.09155644,  0.10679887,\n",
-       "         0.15774828,  0.01430953, -0.24548481, -0.13471584, -0.16768138,\n",
-       "        -0.04165975, -0.1139208 , -0.39835957, -0.02385826,  0.35113412,\n",
-       "         0.1411736 ,  0.03943544,  0.27782732,  0.02119364,  0.11498547,\n",
-       "        -0.33189255,  0.43487713], dtype=float32)]"
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/2111.png'),\n",
+       " 0.04001057147979736,\n",
+       " array([-0.36306724,  0.13900602,  0.2915186 ,  0.22999087, -0.16271171,\n",
+       "         0.37451634,  0.12117532,  0.30122486,  0.05905059, -0.24575944,\n",
+       "         0.2301542 ,  0.12598327,  0.18955672,  0.2393089 ,  0.11471233,\n",
+       "        -0.25408018, -0.21603131, -0.07120273, -0.05722496, -0.16591428,\n",
+       "        -0.06492431, -0.00286971,  0.04813105, -0.1218137 ,  0.11783452,\n",
+       "         0.09741097,  0.03107424,  0.02289542, -0.02657417,  0.03526381,\n",
+       "         0.04927958, -0.04491814], dtype=float32)]"
       ]
      },
      "metadata": {},
@@ -1076,7 +1144,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA6UlEQVR4nM2RIXTCMBCG//RNMQt2SKgFTfVmq9G1vDc3zTQWdDXVs4PJPFDwkEOue3O1uTtE2kIacIjdqeRL7v//BPhnpS4XnScAm+sHE02GzEcCxLqBuism2++ZUNZy4NjQZQ8cuCImpmPBxCQkewDBmYrI+vXlS0SE5Xft3Yw6Wak7aztwYcik2ip+Thpuw6Jyy8vYi5mWPnfTlseGZU498p8nzMuEbZ8N80rR14vz+m2+m2Mf97VTYoqq7QcAwFtPBHWLC0MVcMAKCgrbw5879vnH6uXzgfsb1pAujmlyJYWt/k1y9zoBsSK4GWpO+WIAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAABI0lEQVR4nM3RrUtDYRgF8OMHyl68QQeGsQsaTYIrWxL3D1jWhAmCGMQg2ES4KFg0GQzzH7j7CLIhWByGCbrJoi5pGaxuKLOco4Yrst17o8GTXp4fPA+HF/inMTZg7Jxaa6vGb1aJheQxRVJnR9uxIUyRykSTrlujSL6mB3GuWlUGAEw87pC6Hl78cKvWgvfc6H35EHs3z/UEAKB08rICABj5xcmp8vT8VR5L9xMz5U6gzmxaJHuLZiy0bU7SZagAmyLZiYZRar+vQvbCq+TLcvOp60Rgnd6dB8z6lBwAGK9oy4+7Yi0CADbJn9nogLc/AKDfBhL+taILAIi9sR44WpEaAKxHvR8E0BTJfHa9qe5hSBer6H32TogBxmmQdCKh+If5BmtKe4BexolyAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
       ]
@@ -1088,15 +1156,15 @@
      "data": {
       "text/plain": [
        "['8',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/8/7923.png'),\n",
-       " 0.061333417892456055,\n",
-       " array([-0.13801472,  0.00621954,  0.01324526, -0.15497565, -0.07363982,\n",
-       "         0.18480222,  0.06190637, -0.07731929,  0.14280462, -0.01529375,\n",
-       "         0.06797428,  0.12477075,  0.03360037, -0.09421641,  0.08267348,\n",
-       "         0.1202066 ,  0.02800406, -0.23831494, -0.12120299, -0.17994858,\n",
-       "        -0.07378727, -0.12906069, -0.37269413, -0.03644777,  0.3587743 ,\n",
-       "         0.15787394, -0.00156036,  0.28049743,  0.04324026,  0.09545978,\n",
-       "        -0.3575211 ,  0.4439831 ], dtype=float32)]"
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/6629.png'),\n",
+       " 0.04018741846084595,\n",
+       " array([-0.37598267,  0.14729178,  0.29981396,  0.23184597, -0.17113245,\n",
+       "         0.3693326 ,  0.12197712,  0.29893762,  0.0649836 , -0.23279262,\n",
+       "         0.22444412,  0.11953775,  0.19433382,  0.23397318,  0.10269549,\n",
+       "        -0.23896007, -0.21337178, -0.08672515, -0.05094349, -0.16870372,\n",
+       "        -0.06659477,  0.00362819,  0.0638281 , -0.12545557,  0.12865227,\n",
+       "         0.0933653 ,  0.0260153 ,  0.00819198, -0.01368039,  0.03658072,\n",
+       "         0.04711308, -0.04478485], dtype=float32)]"
       ]
      },
      "metadata": {},
@@ -1104,7 +1172,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAABB0lEQVR4nMXQIUhDURQG4P8OEfVpGHsgPhCGwSAMw6KgVaPFZBmCXbCoxWDSKoMhqAOzdYaJCEbRYbZZxtJwsiH8/67B59N331udp1zO+bjncA7wn1E8tpJOvTSbu6ZI8j6bgjekGrUGdZC0+TapTWTLekriIsnmGICNnRSUtOsWM+Hb61jrD9ykQva2ftN8DKf2qI9ymCw/P8Q3Gj8Uu3UPAM47ZMHpXJKkkwtJVvtxWq+K5PeZPo9mYpZ7ZYS3K07PK0b4MunsCR9ANQiCR2BhIqyN/KAxyNy1AGMA42LLor/97vlFC1hnJHL1aGZl1EUsXYb4NhuN+sPTa6t5dGtn7cTHIcYXmSqKVRrT5rgAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA8UlEQVR4nGNgGNxAe8rXvxmYwiUlDAwMJY///PnzCFNy3q+jcos+XKuru/QFU1L58Z8/3YYMDGz7JsPFmGCMu+7PGL6eZ2CYbIfVMSoP/mYw8L89LoRVVvPBo9Cdf0JweCT/598/D9hxSDJc/vvHApdc0re/f2bgkEv9+2ba8b/Y7ZR9/6eAQfTtYmxyYlf/9LIwMNR/j8Ei6fqnV4aBgYH9yFoskgf+iDIwMDAw1P3BIvl/OoQO+huJKfk3iYGBgYGB4+hNLDonX5JhYOC13PqnC4sk3+IPK1fe+nO3nA8uxIgkHWOuc2XjxddYNFIXAAC6I1bDf23ArwAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
       ]
@@ -1116,15 +1184,15 @@
      "data": {
       "text/plain": [
        "['8',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/8/8522.png'),\n",
-       " 0.06222796440124512,\n",
-       " array([-0.12476783,  0.00766327,  0.01253117, -0.15939318, -0.0901918 ,\n",
-       "         0.14988562,  0.0321156 , -0.07108332,  0.12217312, -0.05132951,\n",
-       "         0.07190754,  0.11549593,  0.02556554, -0.12640232,  0.08192091,\n",
-       "         0.14909093,  0.04484734, -0.229729  , -0.08162493, -0.17374739,\n",
-       "        -0.07640947, -0.10110657, -0.34674266, -0.01630255,  0.3628034 ,\n",
-       "         0.1782804 ,  0.02545982,  0.29276216,  0.03688889,  0.08349589,\n",
-       "        -0.36321253,  0.47145176], dtype=float32)]"
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/401.png'),\n",
+       " 0.04267317056655884,\n",
+       " array([-0.3635762 ,  0.15103394,  0.30694067,  0.23331632, -0.16829519,\n",
+       "         0.36755362,  0.11850319,  0.29123622,  0.06036897, -0.2427889 ,\n",
+       "         0.22272967,  0.117998  ,  0.19722615,  0.23765899,  0.10490257,\n",
+       "        -0.24492508, -0.21673615, -0.06731602, -0.05699643, -0.1654917 ,\n",
+       "        -0.05789862, -0.00133317,  0.04790812, -0.13276196,  0.14030954,\n",
+       "         0.09052319,  0.03237328,  0.0209347 , -0.01486127,  0.03653141,\n",
+       "         0.05588738, -0.0459619 ], dtype=float32)]"
       ]
      },
      "metadata": {},
@@ -1132,7 +1200,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA7UlEQVR4nM3RsUtCURTH8a9CDcKbHgSB4RqCi24FPUhoSHAq/Av8A9RZwaGlubG1IRqiNkEkwyEwWpsDRSiDwMHld8jBBw33vq3Bs/y493POPcOFDatUnJ3u9Bbg7XHhNrUnkkxS3zNJbrc2e6Z2lK8M3NHSOhp29neXjrN5H7+UwsXfrRCA0/mLi+zchUD5YDlxVwZjDSPoqe0aBJdf9nT8anUfQvbCJPkNqErqnYd+3JNkGkZ+NKt2ZjYOEiazhO9qxOe00/Hdp5iIFLlO2LlPYer5FiAz0s3Jh1peJPqU6Wrbjxz+2EMuwf6tVpn0UrAs+pFvAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAABDklEQVR4nM3PvyvEcRzH8ddX6bq673DhWwZK2b+6gUEZXHSjAfkDlH+ADOQYTOomhAmzs1hc2NRthlNuMH4XmdR9hXq++xoU3fc+NoP39K5H7x8v6V/Wqdn8rzjzwn0gScMnW2GY1kO465c0BnA+3dOG/k5sNUndxQiM6/H22Q17r/dJyq/cGBynNpdfzYYkSXtm++m7C3x9FRhX+TT6q1CXFpvGVGcgv8rH9nqMnfmOuNkLA2gVHKaJVmJmTy7Khk0MGjmHZZaA6hGMOnASWFb2lp+1Xd9dSXo40FusXgd63mMxliqeV+7EJMkNSColyWDnzZGI6HKt8gyzjo8KNTAAV05lgs1daMw58Q/rE+k1fBf/kVZKAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
       ]
@@ -1144,17 +1212,15 @@
      "data": {
       "text/plain": [
        "['8',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/8/1899.png'),\n",
-       " 0.06499218940734863,\n",
-       " array([-1.27346948e-01, -1.83118563e-02, -1.64001400e-03, -1.12126172e-01,\n",
-       "        -9.83644724e-02,  1.20315835e-01,  6.54301345e-02, -5.12091704e-02,\n",
-       "         1.52682900e-01, -2.65320949e-02,  1.01760603e-01,  1.01684757e-01,\n",
-       "         4.37608658e-04, -9.08510759e-02,  1.15145333e-01,  1.16071053e-01,\n",
-       "         1.89567525e-02, -2.89904714e-01, -2.81014871e-02, -1.68478966e-01,\n",
-       "        -8.66025165e-02, -1.19814016e-01, -3.51793557e-01, -3.32695502e-03,\n",
-       "         3.51190627e-01,  1.90500647e-01, -1.87768824e-02,  2.90717572e-01,\n",
-       "         4.80326265e-02,  9.30584893e-02, -3.63771588e-01,  4.61655587e-01],\n",
-       "       dtype=float32)]"
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/631.png'),\n",
+       " 0.04328185319900513,\n",
+       " array([-0.35765868,  0.15655084,  0.2932479 ,  0.23065555, -0.1714703 ,\n",
+       "         0.37198526,  0.12562305,  0.30216062,  0.06489266, -0.23358652,\n",
+       "         0.23316738,  0.11417682,  0.194542  ,  0.234649  ,  0.11020373,\n",
+       "        -0.23875116, -0.2214867 , -0.07838724, -0.05085449, -0.16527662,\n",
+       "        -0.06611587,  0.00831954,  0.05939326, -0.12688471,  0.13511713,\n",
+       "         0.09956309,  0.03122707,  0.00056342, -0.02943123,  0.03529185,\n",
+       "         0.05423586, -0.04379964], dtype=float32)]"
       ]
      },
      "metadata": {},
@@ -1162,7 +1228,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA3ElEQVR4nM2SLQ/CQAyG2zGFZbNgmUXghgTsZtGbx47/gECR8BcIdpowjYJMkuAuAQVBXW+I21e2SgStufS5t9ePA/gzw+po9wMnBQDYpZ/mNf8mJGm/tHJsSZUe6pBZCr0MKtdmFDCwERHHHTNBxEcjq0uSJC3AF9yb/kuRoqVQ9B62u4ryWmXE9XzUte45BjNJkuS1y8KBUKSEUwXMGnR7WQaHlBWCns6EZStda8yxeT7XNQeLnVgMCzOtFJww1joxqsXKrVgGIuJzc67B8pt4UwfS5HRnG/mtfQG+9omQ6hxlYQAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAABJUlEQVR4nGNgGGSAEcGU/sEp/1VJVjGL5VbTMlRVbN1v73x49fff38e7T/79hGbE3L9/F2VVxlz+O4vBAkPy8197RgYGhgk/YplW/n2JJrn67yRWBgbJG7sZKv6+MkeT1Pv7dxIDg0S6pv/vv/XozmYq+/3nEDMDg+q9v1NZMX1V+uvvJDaNB39nKmPzc+nfv1M2/b3Pjk2Ogani799/k0UQAizIsoyMDJ+Xv8GqkSHy79/D/8/wYJVTvvfGg23x33UsWOTU7//pY2AI+f5XBFOO//7fVQwMDAyZfw9iSor/nSjLwMDA4Pz3OcL5MIYpw7LHDAwMTJYMvzF1Fv3dYKbLI1L5968ZpqTAwb9//569+e9lCzMW13JUfPn79+8BKyxSVAYAulNxOVnIV3IAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
       ]
@@ -1174,15 +1240,15 @@
      "data": {
       "text/plain": [
        "['8',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/8/580.png'),\n",
-       " 0.06748747825622559,\n",
-       " array([-0.13130559, -0.00427955,  0.00618431, -0.17756099, -0.07211003,\n",
-       "         0.19607309,  0.03610032, -0.07650073,  0.13990745, -0.00601777,\n",
-       "         0.09886124,  0.1305777 ,  0.03129087, -0.0902622 ,  0.09924899,\n",
-       "         0.13972628,  0.0141205 , -0.25533268, -0.12707938, -0.1729454 ,\n",
-       "        -0.05700621, -0.1422437 , -0.38782725, -0.02004008,  0.33749428,\n",
-       "         0.14314933,  0.02332693,  0.26700094,  0.02538364,  0.09330878,\n",
-       "        -0.33804575,  0.44703257], dtype=float32)]"
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/2213.png'),\n",
+       " 0.043420612812042236,\n",
+       " array([-0.36173356,  0.15118621,  0.29811877,  0.22328272, -0.17127284,\n",
+       "         0.37576228,  0.1278009 ,  0.2878798 ,  0.07162137, -0.23225948,\n",
+       "         0.23361638,  0.11763023,  0.19491744,  0.22889662,  0.10453572,\n",
+       "        -0.2426079 , -0.22669537, -0.06324654, -0.06669908, -0.18271776,\n",
+       "        -0.06520734,  0.01194281,  0.04815498, -0.12896037,  0.12580338,\n",
+       "         0.10066501,  0.04210657,  0.01241063, -0.01730939,  0.02693971,\n",
+       "         0.04445782, -0.05199178], dtype=float32)]"
       ]
      },
      "metadata": {},
@@ -1190,7 +1256,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA90lEQVR4nM3QMUvDUBTF8ZMOdTGUIt3EtQScBOlHcFEXwUFBnRtpXTPp3rEIThLpF/AbWMVJRBAUnAQ3IaVDNejwfzwHIYnNcxQ84/lx7+Nd6e/jR5E99N1WH4JhWHdiDBg4zYpKcavu2+eo6RqtXdGWwpRlx6S1knTcy5sCTkbalvTsRElLq5rddH9l54Pr/gX5mz+yBYZfcOPWGGtMx2X7n4BhUHFYJwVuDJe1snXf4W13rjkhLF/oEe72JIVp4bg5PjQkSUcka2VMToIgkBZeSFpTGL0CcBbHYxh8d16m8+uNrud7VpKeFqdQkmYOvFZ1JcN/ly/IdmwbWpa5jgAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAAkUlEQVR4nM3S0QmCMQyF0Q9xjc4hXSR7GOcoOEcHySDRPa4PP4hC8irep8LpDYUU/iOmsIbGlqRRiYeUTtH0kHLPcuCSDvECMwfAiFVhAFhG9ZqlBa7SmJljKUsDVzY9wPRtp0+8wP3RFF2p3dhU2Dee36dx5fZserg2puiGHheqmDaz3iOYMpXdD9ipZpU/zQvU5U2qO7eq9QAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
       ]
@@ -1202,15 +1268,15 @@
      "data": {
       "text/plain": [
        "['8',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/8/1955.png'),\n",
-       " 0.0702618956565857,\n",
-       " array([-0.13201681,  0.02472456,  0.00523583, -0.17277762, -0.08472393,\n",
-       "         0.16207097,  0.03596724, -0.08537581,  0.13170849, -0.02398622,\n",
-       "         0.08799887,  0.11950567,  0.0326271 , -0.11376908,  0.07973925,\n",
-       "         0.14595453,  0.03395455, -0.23491602, -0.11099958, -0.17845914,\n",
-       "        -0.05886613, -0.12497291, -0.36913148, -0.0124557 ,  0.3447679 ,\n",
-       "         0.15837647,  0.01603587,  0.28382334,  0.03426813,  0.08366528,\n",
-       "        -0.35784483,  0.45983088], dtype=float32)]"
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/5075.png'),\n",
+       " 0.04345858097076416,\n",
+       " array([-0.36603835,  0.13809067,  0.30036038,  0.22559561, -0.15871654,\n",
+       "         0.37045795,  0.11207646,  0.28772548,  0.06201591, -0.23874035,\n",
+       "         0.23705716,  0.13031502,  0.19684488,  0.23974243,  0.10817204,\n",
+       "        -0.2554767 , -0.21949022, -0.04996233, -0.06158025, -0.17326577,\n",
+       "        -0.0524784 , -0.00420228,  0.02706013, -0.13724124,  0.13671991,\n",
+       "         0.08337338,  0.02953451,  0.04146313, -0.01712115,  0.02942331,\n",
+       "         0.05245205, -0.04330927], dtype=float32)]"
       ]
      },
      "metadata": {},
@@ -1218,7 +1284,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA+klEQVR4nMXQoUtDURQG8A8RRJSFhYfXafIPMA3MBqPBNlh5D0EQDEZd0zIYBsGi+wtsA2VrCoKYDG6Wh2ls4WF/G+L3oeGNDd49WU/6uD/OuYcD/G+5Wir9KN1dMLBDkiJ5MnmYm1m083Xm3IoLseo3tvpbAIDnaeesSsNeFpKm8efTxxIAoAIAxRweKprm9eMchulobRKD27v83FN2s5VKDb7m0bXZ3wCi1lDc83e60dvVQNL4fNHHanahuOzTfPBJivf7y75FHZJ8uLbOfjES2X6sGIRLadw7aujdwoRxiCoZ2tgM6t98sQwJKbK7beJmTPGgYNpf1i+Cym8Z+mpaAQAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA+klEQVR4nM2RPUtCARSGX0QkKpSEMKwsmhOpobXAze4/CJqLQMQfEARFS0P0B1Lu0tjSIDi1NfQxNQUWEqiE0Bck+dzbeu/ltDV0xvPwnvMcjvTPa7ZQ2HU9/1iSFA+S/NLi5qQk359LvYYy4/tHL8BjC6iHMpJqQPesmHTgciLCFr5w11PS1vvHaSJqku2xI6nY59Dw3Bh+OvHVN+oj1hV33JTBjZknzj8A7ZzJpHNohxqBIWM56f6XnJrAd8lmawMOWlzZ8IK9WIXnGWvn9IquvVtNZSw4mvYG0WEB204jCgO/yZw8Oer2LJ9kE2BYtW2Xa9DYttnf1g9OjF6Q66JJOAAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
       ]
@@ -1230,15 +1296,71 @@
      "data": {
       "text/plain": [
        "['8',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/8/5771.png'),\n",
-       " 0.07090085744857788,\n",
-       " array([-0.12781088,  0.00892572,  0.00189792, -0.18430823, -0.08083843,\n",
-       "         0.18911533,  0.01223383, -0.08254232,  0.12467169, -0.04286132,\n",
-       "         0.08438423,  0.12680066,  0.02134114, -0.1101879 ,  0.10012072,\n",
-       "         0.1764467 ,  0.02061235, -0.22360286, -0.13817692, -0.17863664,\n",
-       "        -0.05047771, -0.11878041, -0.37152535, -0.01739322,  0.35964054,\n",
-       "         0.13495684,  0.05790193,  0.28195673,  0.01602801,  0.08603457,\n",
-       "        -0.33482018,  0.44657353], dtype=float32)]"
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/5041.png'),\n",
+       " 0.04408001899719238,\n",
+       " array([-0.37792206,  0.14327739,  0.29588518,  0.22205108, -0.15390421,\n",
+       "         0.375913  ,  0.12836885,  0.28317535,  0.06273706, -0.24125488,\n",
+       "         0.23851702,  0.1158187 ,  0.19479631,  0.23465155,  0.08906908,\n",
+       "        -0.24843045, -0.21785651, -0.05798931, -0.06816064, -0.1762644 ,\n",
+       "        -0.0602752 ,  0.00266467,  0.04674225, -0.12965332,  0.13261664,\n",
+       "         0.09208895,  0.03854197,  0.01601067, -0.02715193,  0.03724685,\n",
+       "         0.04685879, -0.04149384], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAABAUlEQVR4nGNgGJKAbeG/f///HYhUVeXGlLT6u+rlv7///v77++Rmu4koquTV1fr/ahW0nlzwDFl2/9+//SiSC1Rz/3oyMAT/lGdgYLP8twpNkvvmQjYGz3/6DAwMDBBjmWCSDx98rYqNZWD4+pWBgYHhNaajev759+zG6Z0F//7W4vQs9/9/9jgl2z/fO4olDBgYGBgYXL7U2n9ZjUP2/n4GhuS/7dik9KcdFWVgYJgI8SkaaFwFMfDKKkw5xgO5EIbVP0xJ0b96UMm/MCEmhOw3iBe5Z1/HYmfE51oGBgaG2Z9V4DYhydaWP5j1X9POEUuoMzAwRHz+d3m1FFYpEgEAQz9YkBO2F+IAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/3674.png'),\n",
+       " 0.044481873512268066,\n",
+       " array([-0.3735578 ,  0.13674317,  0.28267494,  0.22327714, -0.16084382,\n",
+       "         0.37290594,  0.12527774,  0.2872721 ,  0.05434507, -0.24710833,\n",
+       "         0.23781857,  0.12222282,  0.1894053 ,  0.24195391,  0.10637863,\n",
+       "        -0.25438133, -0.21751533, -0.06105465, -0.07418441, -0.17454109,\n",
+       "        -0.06548575,  0.00978926,  0.04441009, -0.12333474,  0.12435462,\n",
+       "         0.0965028 ,  0.05425693,  0.00577618, -0.04075005,  0.03111848,\n",
+       "         0.04606702, -0.04257673], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAABMElEQVR4nGNgGKpA3H/W379//z/plcGUs3/15++fx4+Pvvpz3RhNSu3Yqz9/DlnIyzOoXfzzEE2y8PSfa928DAwMDAx53b9qUeQir2b8/bsPwuZq+BeCpvX0nz/XpRgYGNiDNq3+iy4p3Lf6zzQGBgbZP0danwtjOJdr0zs1hlT/P45O3lg8avzp79+///4e4sUixyC17M+fP3+vaWPKcIW23fv758HZv6uxGNnw58Ofv4+1edO/GaHLGXx8tPLvx1QGBgbZvzcEoIJMULqA+/+tz02zGRgY3ob/50Hz5KYP3ze5sEE480ugoiwQ6stznhcpr6Bi28zQLV38Po4dZv8mNDsZtr6J7VOAMFVvQsUY4Vrlk9V4WebcYrjIIMzzEF2SgYGBt/6/z3MndAvJAQAVqXVqmJgVfAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/4117.png'),\n",
+       " 0.045124828815460205,\n",
+       " array([-0.35156298,  0.16355656,  0.30134732,  0.22667001, -0.17924194,\n",
+       "         0.37603086,  0.12719253,  0.30152017,  0.07219735, -0.23419859,\n",
+       "         0.22553216,  0.11478238,  0.19514334,  0.22200024,  0.11441004,\n",
+       "        -0.23573409, -0.22461611, -0.0799832 , -0.05228319, -0.17153245,\n",
+       "        -0.06698789,  0.01053997,  0.06450619, -0.12811044,  0.12589845,\n",
+       "         0.10002032,  0.03342265,  0.00417014, -0.02135291,  0.03006814,\n",
+       "         0.04590758, -0.04563618], dtype=float32)]"
       ]
      },
      "metadata": {},
@@ -1265,15 +1387,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 22,
    "id": "c31c0e03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T14:05:03.652454Z",
-     "iopub.status.busy": "2022-08-16T14:05:03.652278Z",
-     "iopub.status.idle": "2022-08-16T14:05:03.657790Z",
-     "shell.execute_reply": "2022-08-16T14:05:03.656941Z",
-     "shell.execute_reply.started": "2022-08-16T14:05:03.652438Z"
+     "iopub.execute_input": "2022-08-16T14:56:21.691329Z",
+     "iopub.status.busy": "2022-08-16T14:56:21.690215Z",
+     "iopub.status.idle": "2022-08-16T14:56:21.696248Z",
+     "shell.execute_reply": "2022-08-16T14:56:21.695555Z",
+     "shell.execute_reply.started": "2022-08-16T14:56:21.691284Z"
     },
     "scrolled": true,
     "tags": []
@@ -1291,15 +1413,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 23,
    "id": "c2342ec7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T14:05:05.154866Z",
-     "iopub.status.busy": "2022-08-16T14:05:05.154095Z",
-     "iopub.status.idle": "2022-08-16T14:05:05.375282Z",
-     "shell.execute_reply": "2022-08-16T14:05:05.373509Z",
-     "shell.execute_reply.started": "2022-08-16T14:05:05.154813Z"
+     "iopub.execute_input": "2022-08-16T14:56:21.698136Z",
+     "iopub.status.busy": "2022-08-16T14:56:21.697643Z",
+     "iopub.status.idle": "2022-08-16T14:56:21.825821Z",
+     "shell.execute_reply": "2022-08-16T14:56:21.824840Z",
+     "shell.execute_reply.started": "2022-08-16T14:56:21.698111Z"
     },
     "tags": []
    },
@@ -1353,7 +1475,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAAw0lEQVR4nGNgGHAgdOoobsn+f4Y45TTebWdF4jKhSGYLnP+NS5JDjOEzAw5JxkmhuF2j8e/fv2m4JHf/+/fvEg450V//TqFKItlZz7L1Bi5DNb/++/Du33U2ZBfCWYetGRgYGBgufljLIO70MApFo8qXfzca7/yDgqsMDAwMDCwwyX//Zta/UlA6NsePgYFh3Tk0O9mZGBgW/qtEFoLrZPiJ6UbUgOdjwBUIDAwMv88j+wRVpy3Txl84JQ//e43bVDoBANdbQi67gdv3AAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAAwklEQVR4nMXPvw7BUBgF8NNGxNCx8WfRGlnFIMwGD9DFG0gYPEGfQ2IQBom9TyA2iUF0ERuDxShRTixFe9tv5Wz3/u53cz7g/zE3u7xkuTnpSOiQnAhWvpB8Ft5HPYYDE4CmpQ62A5JkMc3sA0nSTZs0ZiQZbZv54qIr1AQqe4bxbNUsn5/4JQXHjKQZXurqFwDut2ShMI/A2yp4BkYdVC2gt0y8z/brGrAi2ZD2ucYxXmgKnI7SZItcSwZjyJqIv8kLkz9dYcz75hYAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
       ]
@@ -1365,17 +1487,15 @@
      "data": {
       "text/plain": [
        "['4',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/4/5677.png'),\n",
-       " 0.002303779125213623,\n",
-       " array([-3.13590840e-02, -2.15366315e-02,  1.10434815e-01, -2.51350909e-01,\n",
-       "         3.23935688e-01,  1.10073201e-01,  1.43108398e-01, -1.58630833e-01,\n",
-       "         4.42154333e-02, -2.16500740e-02,  1.73474327e-01, -2.91183650e-01,\n",
-       "         1.03035815e-01, -1.76725745e-01,  5.88470399e-02, -1.80038989e-01,\n",
-       "         2.79691927e-02,  3.16117406e-01, -3.16662580e-01,  3.13063711e-02,\n",
-       "         2.00232908e-01, -5.57611473e-02, -9.26752612e-02, -7.05756024e-02,\n",
-       "        -3.18065286e-01,  1.91690296e-01,  2.55467087e-01, -1.15748597e-02,\n",
-       "         2.07241531e-02, -5.14973290e-02, -2.25168813e-04, -3.16742092e-01],\n",
-       "       dtype=float32)]"
+       " Path('/home/jav/.fastai/data/mnist_png/testing/4/8092.png'),\n",
+       " 0.004058778285980225,\n",
+       " array([ 0.35101184,  0.18533671,  0.16524565, -0.11336396,  0.18572807,\n",
+       "         0.13833165,  0.09430952, -0.26853022, -0.02952386, -0.14158921,\n",
+       "         0.16469279, -0.06736279,  0.04023446, -0.01805294, -0.14961053,\n",
+       "         0.0477204 , -0.0230393 ,  0.34078282,  0.04045871,  0.09477866,\n",
+       "         0.24635829, -0.16606495, -0.08622643,  0.07870639,  0.28628054,\n",
+       "         0.08384995, -0.27257052,  0.00209487,  0.12181175,  0.30333257,\n",
+       "         0.2903119 ,  0.06974767], dtype=float32)]"
       ]
      },
      "metadata": {},
@@ -1383,7 +1503,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA60lEQVR4nGNgGLRARJeBgYGB4fo/Z7gQE5w1JYOBgYGB4f///1gk2Xxxm6r38WcUAwOD3OO/m+FiLDBGEQ+DIAMDg4MUgwimsdJwIR5BdFP1X/59raKpmXT679+/AWhynHP//v289O+/v3+xSAb+/fv371+I5C9vTK/AwdmtaJK3XjIxMTIynuj8ysiIqX7C3zeTXHnZGVL//j2OIckuJcbAwMDAcA1ZEhYIP58xMDAwMEQrY7oBBhRu/kXWiWp7pAoDA8M8HDrVvv79e14Uh051FgYGMVySan8YGL5+xeUi4w9//zrhdjB1AADuA0/BpOUT7AAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA10lEQVR4nGNgGLRA7ECbAozN78uKIif4+tdKuNydj6rIciJ7/06Gc7r/pqBodPv7VxTG1v63lhfFwpl/E+Byz//FoGhc/P8MN4yd8W8eqlMX/d0EdR9n89u/MFEWGMN714fpDAwM9g4WDGtQNTIYP/n799/fv3///vv797Yyms6zugYepa8XMjAsvshw7C4DDqD075woLjmGBX9dccqF/vtohFNy3r+lOOUYnn/BrTHj3wvcGi/8ncvAKwfnMqFJ/43e34xT57+/s2RxSNruaxBnw20rlQAAKNJLfTqR0FsAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
       ]
@@ -1395,15 +1515,15 @@
      "data": {
       "text/plain": [
        "['4',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/4/2886.png'),\n",
-       " 0.004014790058135986,\n",
-       " array([-0.03786912, -0.03118558,  0.08279644, -0.21122247,  0.32699743,\n",
-       "         0.12728068,  0.13448665, -0.18832497,  0.05738041, -0.03265832,\n",
-       "         0.14865893, -0.2861046 ,  0.09195897, -0.18459581,  0.10036085,\n",
-       "        -0.14381559,  0.0293766 ,  0.33007255, -0.319167  ,  0.02344558,\n",
-       "         0.23082243, -0.04694476, -0.12151314, -0.02910761, -0.28864992,\n",
-       "         0.16973186,  0.27506524, -0.01407119,  0.00416797, -0.06371135,\n",
-       "         0.0178963 , -0.33486405], dtype=float32)]"
+       " Path('/home/jav/.fastai/data/mnist_png/testing/4/6.png'),\n",
+       " 0.005051672458648682,\n",
+       " array([ 0.34555405,  0.22738989,  0.15732606, -0.1116602 ,  0.1947659 ,\n",
+       "         0.1581947 ,  0.13127914, -0.28170913, -0.01372535, -0.18691546,\n",
+       "         0.177644  , -0.08506849,  0.04331097, -0.03862855, -0.15377352,\n",
+       "         0.06774145, -0.0231163 ,  0.34597585,  0.01029764,  0.07634851,\n",
+       "         0.21663545, -0.17285186, -0.03970082,  0.07124569,  0.27594832,\n",
+       "         0.10873641, -0.22802049, -0.03993862,  0.10257587,  0.2943967 ,\n",
+       "         0.2667779 ,  0.08390071], dtype=float32)]"
       ]
      },
      "metadata": {},
@@ -1411,7 +1531,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA7klEQVR4nM3OrUuDcRTF8e82Vx7BNiYWmS/ggrAyEIyGNTEYtK4ImqyWJf+FJU0Dg2ltMFk1qCA2HStrK1MekMHYuWhQ8GHXX1vYjffDOffCHM+2XQOX1sz8gxfSPrxIud9F+s+yFShAgdaHx/NduOc0IpbHBRg8cpK4k8BNOKS8Brf+nVKs8Sp70kPWJ+uLNPorBzCYuGDxXXq660s6chZ1JEkm6Xl5GvNmZmZfZjYqOZQUtz9N6lRdbV662qBnqqWdkYqiFMWhdXPefp5qyNrJRbJk/RjeAkGq0nArlNyB3msIgZtQK2fSUhBnON9VgFyMLllSUAAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAAuklEQVR4nGNgGOKg538clMWEKtGdx8Dl/f8RVk2CT9/Ldf/7IIFV0vT9s4zf34OwyvEd+jfh6r867HJ7/l3o/3cDu6Ez//0r3v6vHKtc6u9/5bX/zrJhlTzw703Xg3/v7vTzYMql/P4HBVEwIRa4pDEzAwMDw9al9uZHMXWm3V698t9dcaw2MjAwMGz8V4tTzvT7A02cklP/VeKUk3//WAun5PR/BTjlZD4+E8at8W8gTjmGS2245UgGAJvcSsZ6Pa7FAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
       ]
@@ -1423,15 +1543,15 @@
      "data": {
       "text/plain": [
        "['4',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/4/7361.png'),\n",
-       " 0.004868447780609131,\n",
-       " array([-0.05694573, -0.04604704,  0.08696871, -0.21627809,  0.3156083 ,\n",
-       "         0.11708419,  0.14291759, -0.19755293,  0.06709458, -0.03699708,\n",
-       "         0.15461129, -0.30813265,  0.09053328, -0.1794673 ,  0.09742116,\n",
-       "        -0.14840591,  0.02772097,  0.3262057 , -0.3035298 ,  0.05381545,\n",
-       "         0.22480297, -0.05314825, -0.10575383, -0.04030157, -0.30172822,\n",
-       "         0.18327418,  0.25570568, -0.00873607,  0.0249078 , -0.04829767,\n",
-       "        -0.00615531, -0.33080208], dtype=float32)]"
+       " Path('/home/jav/.fastai/data/mnist_png/testing/4/9735.png'),\n",
+       " 0.005072355270385742,\n",
+       " array([ 0.3546063 ,  0.20625214,  0.13958235, -0.1208517 ,  0.20023637,\n",
+       "         0.15975833,  0.11960027, -0.2959247 , -0.0182486 , -0.16848847,\n",
+       "         0.16700178, -0.08251458,  0.02984622, -0.03509723, -0.17104702,\n",
+       "         0.07715525, -0.01949359,  0.33795583,  0.02228224,  0.05824993,\n",
+       "         0.23206739, -0.17951529, -0.03309315,  0.08179015,  0.26944944,\n",
+       "         0.10041799, -0.23446746, -0.03871253,  0.11144841,  0.29369944,\n",
+       "         0.26541716,  0.09351192], dtype=float32)]"
       ]
      },
      "metadata": {},
@@ -1439,7 +1559,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA+0lEQVR4nM3Rr0tDURjG8ceNK97gDBd1Y4KwpqhZNCtjGlxfELXZDGb/gk1MRk1WsQkXXBE0G7YVUXcn/mgq+IsvM1yQy7t7m8E3ns95Hjjvkf7xpI66O2lJhetmvgezwKrknMB+eDuCOUmXUm5JerBB5xZaI3LPoeHZ5NqY5L9oY1Y6fbPJDgQF6Rn2+q0dAGVp/hsWrbkBPE3IfYT2uLHpOoC/cAwf28YGt/idG1u6SxyGT8nMSdL7YWBDklQDqA17V3G1lc+vC68vtQm80p40WlxWuHhG1+OqpRngbCDeVAVKCebcQ92NnkR+petLQ0mtWuFuKp2Efzg/N/R9GUe8pJwAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAAtklEQVR4nGNgGOxgYghuOdn3ixEcJjRJC14pBIcFRUpaWhqZiyIpveOKOC5Jljla7/8yMmK3U8j1f+v///+xu3T1nz+W3//EYJUL+fbnz98/f/KlscipfPrz58/fP38+PcGUE7r090WxbvPfv5+XY0pm/f2jz8Cg/edPHhbXfr8Zf5mBgYHh/33srmVgYHD98xynHMMBPJJC//+uwikJcRWmg2CgGqfkMwaGb7gdVHVTFrcktQAAxtJAyRYEyvAAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
       ]
@@ -1451,15 +1571,15 @@
      "data": {
       "text/plain": [
        "['4',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/4/7376.png'),\n",
-       " 0.005374610424041748,\n",
-       " array([-0.03907151, -0.04383761,  0.07805806, -0.21245532,  0.31159526,\n",
-       "         0.12885717,  0.13754822, -0.18394949,  0.05765934, -0.04241817,\n",
-       "         0.14189789, -0.28625816,  0.08501954, -0.17751908,  0.10637633,\n",
-       "        -0.13228597,  0.02483746,  0.33107218, -0.33575127,  0.02612962,\n",
-       "         0.23956959, -0.03736461, -0.13207437, -0.03730523, -0.28433457,\n",
-       "         0.1630143 ,  0.28086212, -0.00990892,  0.00472082, -0.04490199,\n",
-       "         0.02159508, -0.33755064], dtype=float32)]"
+       " Path('/home/jav/.fastai/data/mnist_png/testing/4/2090.png'),\n",
+       " 0.005557060241699219,\n",
+       " array([ 0.31982094,  0.21720451,  0.1678011 , -0.0860101 ,  0.18208975,\n",
+       "         0.16532831,  0.11594524, -0.2803289 , -0.0105318 , -0.15397614,\n",
+       "         0.17849222, -0.08234603,  0.04110044, -0.02986524, -0.17142963,\n",
+       "         0.0846343 , -0.01117415,  0.3492195 ,  0.01880621,  0.0693465 ,\n",
+       "         0.22212014, -0.17916133, -0.05271771,  0.09398133,  0.28751895,\n",
+       "         0.09113014, -0.25812957, -0.04705611,  0.13254696,  0.284317  ,\n",
+       "         0.2771674 ,  0.07442302], dtype=float32)]"
       ]
      },
      "metadata": {},
@@ -1467,7 +1587,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA8UlEQVR4nM3PP0uCURTH8S9qSQlKS4K1OGaKLtLWO8glCOsdRCnoIG0Nbg2OvYCaHHR2srlGaWgxEBpcFOwPCPK7tvjn4XmeuzV04HI558M95x74vxE+2QI4M297XqypAfAg1b04VC8GfK0xsLJshPcJ5Ddh6sHqNkMgG2J0726a/tT4ELiTbj0TS9I1EHyVjpa10OKOlmGeyR0nDnyWvJQ0kIwkPYZdH9pfHICLmKvtUxFofyTLmEHz26c10JJe/AUwUsFmV0bPG+s04LSdU+jMLA8LMkpbbLcn049bsCLNb5wF58wU/HRtCJzbt/y7+AXgPVApXFyFXgAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAAvElEQVR4nGNgGBpA5/w1nHIFTw/74ZJLef03DZec2o2/O3lwyHFd/P/IBpdG37//TNGEErqgDMktf2egGsqS/faEGoRV+PWtGqo+q79/AyCs+L9/y+BaGBgYGBj4Ghg/+LxmkHNmYAhmZECz0evv379//0GI71vkUXWWMzBs/8Uo93D5z4lyk8rRnMqaFs7EwMDBwBD97VMgLi8yrP33Eqdc578jOOV0nnyVwym5/m8dTjmGKZNYcUsOBgAAmq5BZUu0/MsAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
       ]
@@ -1479,15 +1599,15 @@
      "data": {
       "text/plain": [
        "['4',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/4/7366.png'),\n",
-       " 0.005693972110748291,\n",
-       " array([-0.0610164 , -0.04146182,  0.09034172, -0.20866331,  0.31622782,\n",
-       "         0.11861764,  0.14218827, -0.20755155,  0.06992757, -0.03209638,\n",
-       "         0.1469732 , -0.30364928,  0.09821688, -0.18159218,  0.10560269,\n",
-       "        -0.14999603,  0.02323291,  0.3320828 , -0.301837  ,  0.04858053,\n",
-       "         0.22180717, -0.05564872, -0.11786508, -0.03112294, -0.3008989 ,\n",
-       "         0.17155057,  0.2510369 , -0.00963419,  0.02120073, -0.05657816,\n",
-       "        -0.00504775, -0.33360884], dtype=float32)]"
+       " Path('/home/jav/.fastai/data/mnist_png/testing/4/7520.png'),\n",
+       " 0.005947589874267578,\n",
+       " array([ 0.37265083,  0.19375034,  0.145137  , -0.13830844,  0.2098684 ,\n",
+       "         0.15132366,  0.10631462, -0.27915317, -0.02292181, -0.17636226,\n",
+       "         0.16750936, -0.08195923,  0.03583243, -0.05059244, -0.16483949,\n",
+       "         0.06027673, -0.01851156,  0.33573258,  0.0304315 ,  0.06812224,\n",
+       "         0.22151642, -0.18008788, -0.05873222,  0.06483659,  0.2631307 ,\n",
+       "         0.09355738, -0.25799656, -0.00271306,  0.11256584,  0.2984441 ,\n",
+       "         0.24904355,  0.10033774], dtype=float32)]"
       ]
      },
      "metadata": {},
@@ -1500,16 +1620,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "dc0fd289-f539-463d-aa71-aa721540ec0a",
+   "metadata": {},
+   "source": [
+    "# Finding Stars\n",
+    "\n",
+    "Even though stars are not in the mnist dataset, if we have good embeddings, the starts should probably be close together, maybe even be the closest embedding to each other.\n",
+    "\n",
+    "The embeddings do seem to be close to each other:"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 24,
    "id": "4d44ee49",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T14:05:10.666707Z",
-     "iopub.status.busy": "2022-08-16T14:05:10.666512Z",
-     "iopub.status.idle": "2022-08-16T14:05:10.935091Z",
-     "shell.execute_reply": "2022-08-16T14:05:10.933717Z",
-     "shell.execute_reply.started": "2022-08-16T14:05:10.666690Z"
+     "iopub.execute_input": "2022-08-16T14:56:21.827650Z",
+     "iopub.status.busy": "2022-08-16T14:56:21.827360Z",
+     "iopub.status.idle": "2022-08-16T14:56:21.979122Z",
+     "shell.execute_reply": "2022-08-16T14:56:21.978111Z",
+     "shell.execute_reply.started": "2022-08-16T14:56:21.827625Z"
     },
     "tags": []
    },
@@ -1612,12 +1744,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Cosine Distance between stars: 0.0862153172492981  best matches for each star:\n"
+      "Cosine Distance between stars: 0.03102654218673706  best matches for each star:\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAAeklEQVR4nNWQyxGDMAxEHzQWURnqTKayzcGQMUb2TI7sTdqPPvAmLACY7ZSjdkrpJK4Otb2meVtb2N1qvfjkA/csy65pHpGwLskwSZlbUoSkxPk7KZ0Kg20rhpmnseFuHzKAY0D2gS35WDJ/fEJ+ZsLpkbPv4DH0/YsvgaZpcV1JKgwAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAABEUlEQVR4nGNgGMzApHXZ9X8fy7HIyC3/+vvv379//34Ox5Sc8/fv1eV13xcY/X0viC7H/+h3HicDw8IMs78/zdElpf+uYGBgYODgXf/3DoapfPdfGjEwMDAk//2bhWln0LfX/gwMxt/+flTC4tzA7xf0WDf9/VWJRY6Bwf/mqxN/f1dglWNg8P/79+8UHHKh///9+xeDXa7s17+LOlNfGmOTq/jxdxc/g9jlO7yYcpXf/87hZGBgMP2LGfA+334VcjMwMDCIPXuEIiHJxsDQ9ncRlHfpEbpGhpN//SEMkacISSYovYlBiIGBgYFBrFfiF4ZOvWcPJrMxMMvt/fveAtO1uqf+Plp/5O/fd8GYclQGAJhmaL9I6F0zAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
       ]
@@ -1629,15 +1761,17 @@
      "data": {
       "text/plain": [
        "['8',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/8/1530.png'),\n",
-       " 0.046761393547058105,\n",
-       " array([-0.15196997, -0.03608787,  0.00868906, -0.1474988 , -0.07871772,\n",
-       "         0.18009232,  0.06617993, -0.07894154,  0.12192538, -0.02143634,\n",
-       "         0.04440383,  0.10302673,  0.03750927, -0.07367066,  0.09718364,\n",
-       "         0.12069038,  0.0224285 , -0.25404668, -0.11400666, -0.16254014,\n",
-       "        -0.0650501 , -0.10554277, -0.3876711 , -0.04148291,  0.3751997 ,\n",
-       "         0.14719807, -0.00786453,  0.28334555,  0.04159332,  0.13660236,\n",
-       "        -0.338259  ,  0.44309753], dtype=float32)]"
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/5876.png'),\n",
+       " 0.03822958469390869,\n",
+       " array([-3.68332297e-01,  1.58202797e-01,  2.95534283e-01,  2.31184542e-01,\n",
+       "        -1.78733289e-01,  3.77019674e-01,  1.26442909e-01,  3.05077612e-01,\n",
+       "         7.04605654e-02, -2.33200312e-01,  2.21860155e-01,  1.09218769e-01,\n",
+       "         1.93249613e-01,  2.20926225e-01,  1.08081222e-01, -2.30418533e-01,\n",
+       "        -2.20318958e-01, -8.47602636e-02, -5.90615310e-02, -1.71346053e-01,\n",
+       "        -7.63074979e-02,  3.74966156e-04,  6.62550181e-02, -1.17210075e-01,\n",
+       "         1.17863484e-01,  1.04648709e-01,  3.06050368e-02,  2.86547444e-03,\n",
+       "        -1.30512118e-02,  3.01726423e-02,  4.46750410e-02, -5.05277514e-02],\n",
+       "       dtype=float32)]"
       ]
      },
      "metadata": {},
@@ -1645,7 +1779,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAAeklEQVR4nNWQyxGDMAxEHzQWURnqTKayzcGQMUb2TI7sTdqPPvAmLACY7ZSjdkrpJK4Otb2meVtb2N1qvfjkA/csy65pHpGwLskwSZlbUoSkxPk7KZ0Kg20rhpmnseFuHzKAY0D2gS35WDJ/fEJ+ZsLpkbPv4DH0/YsvgaZpcV1JKgwAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAABEUlEQVR4nGNgGMzApHXZ9X8fy7HIyC3/+vvv379//34Ox5Sc8/fv1eV13xcY/X0viC7H/+h3HicDw8IMs78/zdElpf+uYGBgYODgXf/3DoapfPdfGjEwMDAk//2bhWln0LfX/gwMxt/+flTC4tzA7xf0WDf9/VWJRY6Bwf/mqxN/f1dglWNg8P/79+8UHHKh///9+xeDXa7s17+LOlNfGmOTq/jxdxc/g9jlO7yYcpXf/87hZGBgMP2LGfA+334VcjMwMDCIPXuEIiHJxsDQ9ncRlHfpEbpGhpN//SEMkacISSYovYlBiIGBgYFBrFfiF4ZOvWcPJrMxMMvt/fveAtO1uqf+Plp/5O/fd8GYclQGAJhmaL9I6F0zAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
       ]
@@ -1657,15 +1791,17 @@
      "data": {
       "text/plain": [
        "['8',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/8/1530.png'),\n",
-       " 0.17046701908111572,\n",
-       " array([-0.15196997, -0.03608787,  0.00868906, -0.1474988 , -0.07871772,\n",
-       "         0.18009232,  0.06617993, -0.07894154,  0.12192538, -0.02143634,\n",
-       "         0.04440383,  0.10302673,  0.03750927, -0.07367066,  0.09718364,\n",
-       "         0.12069038,  0.0224285 , -0.25404668, -0.11400666, -0.16254014,\n",
-       "        -0.0650501 , -0.10554277, -0.3876711 , -0.04148291,  0.3751997 ,\n",
-       "         0.14719807, -0.00786453,  0.28334555,  0.04159332,  0.13660236,\n",
-       "        -0.338259  ,  0.44309753], dtype=float32)]"
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/5876.png'),\n",
+       " 0.09338849782943726,\n",
+       " array([-3.68332297e-01,  1.58202797e-01,  2.95534283e-01,  2.31184542e-01,\n",
+       "        -1.78733289e-01,  3.77019674e-01,  1.26442909e-01,  3.05077612e-01,\n",
+       "         7.04605654e-02, -2.33200312e-01,  2.21860155e-01,  1.09218769e-01,\n",
+       "         1.93249613e-01,  2.20926225e-01,  1.08081222e-01, -2.30418533e-01,\n",
+       "        -2.20318958e-01, -8.47602636e-02, -5.90615310e-02, -1.71346053e-01,\n",
+       "        -7.63074979e-02,  3.74966156e-04,  6.62550181e-02, -1.17210075e-01,\n",
+       "         1.17863484e-01,  1.04648709e-01,  3.06050368e-02,  2.86547444e-03,\n",
+       "        -1.30512118e-02,  3.01726423e-02,  4.46750410e-02, -5.05277514e-02],\n",
+       "       dtype=float32)]"
       ]
      },
      "metadata": {},
@@ -1685,20 +1821,22 @@
    "id": "1c229c64-129c-4ade-979f-d54d67f7f0e5",
    "metadata": {},
    "source": [
-    "By adding a star to the list of fingerprints we should be able to find it, and if all went well, also find the other star:"
+    "# ...with star fingerprints...\n",
+    "\n",
+    "By adding one of the stars to the list of fingerprints we should be able to find it, and if all went well, also find the other star!"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 25,
    "id": "3f76e6c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T14:05:17.166001Z",
-     "iopub.status.busy": "2022-08-16T14:05:17.165820Z",
-     "iopub.status.idle": "2022-08-16T14:05:17.225973Z",
-     "shell.execute_reply": "2022-08-16T14:05:17.225286Z",
-     "shell.execute_reply.started": "2022-08-16T14:05:17.165986Z"
+     "iopub.execute_input": "2022-08-16T14:56:21.981182Z",
+     "iopub.status.busy": "2022-08-16T14:56:21.980518Z",
+     "iopub.status.idle": "2022-08-16T14:56:22.069301Z",
+     "shell.execute_reply": "2022-08-16T14:56:22.068703Z",
+     "shell.execute_reply.started": "2022-08-16T14:56:21.981156Z"
     },
     "tags": []
    },
@@ -1719,13 +1857,13 @@
        "['*',\n",
        " 'stars/Star1.png',\n",
        " 0,\n",
-       " array([-0.10099696, -0.08450948,  0.03510209, -0.15825109, -0.04520801,\n",
-       "         0.20577735,  0.10355564,  0.01773667,  0.05295658, -0.09321447,\n",
-       "         0.03732459,  0.0393499 ,  0.02228327, -0.06537104,  0.09933136,\n",
-       "         0.08348498, -0.02667931, -0.22959505, -0.04327893, -0.07219108,\n",
-       "        -0.09431483,  0.0125113 , -0.46360245, -0.11086255,  0.35560194,\n",
-       "         0.18639638,  0.06533853,  0.28910112,  0.13699105,  0.15609336,\n",
-       "        -0.30878097,  0.42498502], dtype=float32)]"
+       " array([-0.4385764 ,  0.07380641,  0.23816751,  0.29184356, -0.14723992,\n",
+       "         0.34137195,  0.06991758,  0.33740816,  0.09130197, -0.22511393,\n",
+       "         0.21159591,  0.10746336,  0.16765437,  0.21437302,  0.12018973,\n",
+       "        -0.16545856, -0.18934958, -0.07480964, -0.08150642, -0.17008734,\n",
+       "        -0.12432582, -0.08482609, -0.01266793, -0.02727649,  0.11497439,\n",
+       "         0.17786284, -0.03590712,  0.02044249,  0.03340663,  0.02261158,\n",
+       "         0.08458877, -0.12734443], dtype=float32)]"
       ]
      },
      "metadata": {},
@@ -1746,14 +1884,14 @@
       "text/plain": [
        "['*',\n",
        " 'stars/Star1.png',\n",
-       " 0.0862153172492981,\n",
-       " array([-0.10099696, -0.08450948,  0.03510209, -0.15825109, -0.04520801,\n",
-       "         0.20577735,  0.10355564,  0.01773667,  0.05295658, -0.09321447,\n",
-       "         0.03732459,  0.0393499 ,  0.02228327, -0.06537104,  0.09933136,\n",
-       "         0.08348498, -0.02667931, -0.22959505, -0.04327893, -0.07219108,\n",
-       "        -0.09431483,  0.0125113 , -0.46360245, -0.11086255,  0.35560194,\n",
-       "         0.18639638,  0.06533853,  0.28910112,  0.13699105,  0.15609336,\n",
-       "        -0.30878097,  0.42498502], dtype=float32)]"
+       " 0.03102654218673706,\n",
+       " array([-0.4385764 ,  0.07380641,  0.23816751,  0.29184356, -0.14723992,\n",
+       "         0.34137195,  0.06991758,  0.33740816,  0.09130197, -0.22511393,\n",
+       "         0.21159591,  0.10746336,  0.16765437,  0.21437302,  0.12018973,\n",
+       "        -0.16545856, -0.18934958, -0.07480964, -0.08150642, -0.17008734,\n",
+       "        -0.12432582, -0.08482609, -0.01266793, -0.02727649,  0.11497439,\n",
+       "         0.17786284, -0.03590712,  0.02044249,  0.03340663,  0.02261158,\n",
+       "         0.08458877, -0.12734443], dtype=float32)]"
       ]
      },
      "metadata": {},
@@ -1768,15 +1906,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 26,
    "id": "ebc200ba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T14:05:24.975445Z",
-     "iopub.status.busy": "2022-08-16T14:05:24.975221Z",
-     "iopub.status.idle": "2022-08-16T14:05:25.096222Z",
-     "shell.execute_reply": "2022-08-16T14:05:25.095230Z",
-     "shell.execute_reply.started": "2022-08-16T14:05:24.975415Z"
+     "iopub.execute_input": "2022-08-16T14:56:22.076715Z",
+     "iopub.status.busy": "2022-08-16T14:56:22.075562Z",
+     "iopub.status.idle": "2022-08-16T14:56:22.217037Z",
+     "shell.execute_reply": "2022-08-16T14:56:22.215667Z",
+     "shell.execute_reply.started": "2022-08-16T14:56:22.076685Z"
     },
     "tags": []
    },
@@ -1796,14 +1934,14 @@
       "text/plain": [
        "['*',\n",
        " 'stars/Star1.png',\n",
-       " 0.0862153172492981,\n",
-       " array([-0.10099696, -0.08450948,  0.03510209, -0.15825109, -0.04520801,\n",
-       "         0.20577735,  0.10355564,  0.01773667,  0.05295658, -0.09321447,\n",
-       "         0.03732459,  0.0393499 ,  0.02228327, -0.06537104,  0.09933136,\n",
-       "         0.08348498, -0.02667931, -0.22959505, -0.04327893, -0.07219108,\n",
-       "        -0.09431483,  0.0125113 , -0.46360245, -0.11086255,  0.35560194,\n",
-       "         0.18639638,  0.06533853,  0.28910112,  0.13699105,  0.15609336,\n",
-       "        -0.30878097,  0.42498502], dtype=float32)]"
+       " 0.03102654218673706,\n",
+       " array([-0.4385764 ,  0.07380641,  0.23816751,  0.29184356, -0.14723992,\n",
+       "         0.34137195,  0.06991758,  0.33740816,  0.09130197, -0.22511393,\n",
+       "         0.21159591,  0.10746336,  0.16765437,  0.21437302,  0.12018973,\n",
+       "        -0.16545856, -0.18934958, -0.07480964, -0.08150642, -0.17008734,\n",
+       "        -0.12432582, -0.08482609, -0.01266793, -0.02727649,  0.11497439,\n",
+       "         0.17786284, -0.03590712,  0.02044249,  0.03340663,  0.02261158,\n",
+       "         0.08458877, -0.12734443], dtype=float32)]"
       ]
      },
      "metadata": {},
@@ -1811,7 +1949,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAAeklEQVR4nNWQyxGDMAxEHzQWURnqTKayzcGQMUb2TI7sTdqPPvAmLACY7ZSjdkrpJK4Otb2meVtb2N1qvfjkA/csy65pHpGwLskwSZlbUoSkxPk7KZ0Kg20rhpmnseFuHzKAY0D2gS35WDJ/fEJ+ZsLpkbPv4DH0/YsvgaZpcV1JKgwAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAABEUlEQVR4nGNgGMzApHXZ9X8fy7HIyC3/+vvv379//34Ox5Sc8/fv1eV13xcY/X0viC7H/+h3HicDw8IMs78/zdElpf+uYGBgYODgXf/3DoapfPdfGjEwMDAk//2bhWln0LfX/gwMxt/+flTC4tzA7xf0WDf9/VWJRY6Bwf/mqxN/f1dglWNg8P/79+8UHHKh///9+xeDXa7s17+LOlNfGmOTq/jxdxc/g9jlO7yYcpXf/87hZGBgMP2LGfA+334VcjMwMDCIPXuEIiHJxsDQ9ncRlHfpEbpGhpN//SEMkacISSYovYlBiIGBgYFBrFfiF4ZOvWcPJrMxMMvt/fveAtO1uqf+Plp/5O/fd8GYclQGAJhmaL9I6F0zAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
       ]
@@ -1823,212 +1961,16 @@
      "data": {
       "text/plain": [
        "['8',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/8/1530.png'),\n",
-       " 0.17046701908111572,\n",
-       " array([-0.15196997, -0.03608787,  0.00868906, -0.1474988 , -0.07871772,\n",
-       "         0.18009232,  0.06617993, -0.07894154,  0.12192538, -0.02143634,\n",
-       "         0.04440383,  0.10302673,  0.03750927, -0.07367066,  0.09718364,\n",
-       "         0.12069038,  0.0224285 , -0.25404668, -0.11400666, -0.16254014,\n",
-       "        -0.0650501 , -0.10554277, -0.3876711 , -0.04148291,  0.3751997 ,\n",
-       "         0.14719807, -0.00786453,  0.28334555,  0.04159332,  0.13660236,\n",
-       "        -0.338259  ,  0.44309753], dtype=float32)]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA5ElEQVR4nGNgGLqAxX7GmycT1GBcRhhD1NHnjmCgHAMDA8PsdJhaKG26XQjTICYIxbdaiIGBgeFHutFKhGEw0Pzv379///595GBQ//evFE1SsKzdY/+/f/82sE/5d8ERi1N5Ov78+3fw5b8K7D4p+/fv3z9ckvz7/v37988UuySDyL9//3YxoXsFCn6jqkWVlGVgYNDkxW6q9L5///7908Cu086BgYGBIQC7pDkOdzIwMDDovP/3b8a/L05YdarzMzCIMxzah8O1DAz+vzZgN9bjw79//ybhstTj3793ingcRTwAAPS4S0rWnQxaAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "['8',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/8/4978.png'),\n",
-       " 0.19324219226837158,\n",
-       " array([-0.13393578, -0.01838107, -0.00534778, -0.17210366, -0.07266845,\n",
-       "         0.18902731,  0.03273853, -0.08977108,  0.13195774, -0.02636713,\n",
-       "         0.09701853,  0.1159689 ,  0.02596068, -0.09155644,  0.10679887,\n",
-       "         0.15774828,  0.01430953, -0.24548481, -0.13471584, -0.16768138,\n",
-       "        -0.04165975, -0.1139208 , -0.39835957, -0.02385826,  0.35113412,\n",
-       "         0.1411736 ,  0.03943544,  0.27782732,  0.02119364,  0.11498547,\n",
-       "        -0.33189255,  0.43487713], dtype=float32)]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA80lEQVR4nM2PL0tDcRSG359FHF4MSzoQi2ax3W8gTvwQGi1rGo0WP8EwiFE0iU0UnWk2qzDumMiEwYpanpcZ/Hd391szeMo5vA/ve86R/nvN7fl6elRev8mydvYMXiuihd03wPCI97+08NkmF0+WBi/1B0mdRph/GvKl4PtZSdI2rgyHpvag8j0dFDamP2dcwEwBJnXcrUra7FM0SqUj060mSQdqo1/qDLi8gsOVCNSx7YEbMSRNbYC5zSkTv+N7SZKSctx6B4bzJAp3oNbLX5uLVQih9RpCPHYV2stNelGYgpt9iMLyVsswBkoycDoO/lV9ABHSeGo+SxS/AAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "['8',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/8/1149.png'),\n",
-       " 0.2018195390701294,\n",
-       " array([-0.12702534, -0.00469792, -0.009922  , -0.18974611, -0.07716948,\n",
-       "         0.21863632, -0.00714376, -0.09015532,  0.11959117, -0.00474182,\n",
-       "         0.11099031,  0.14397548,  0.01711641, -0.0858542 ,  0.10849203,\n",
-       "         0.18830577, -0.01769255, -0.22273687, -0.19109313, -0.18539554,\n",
-       "        -0.02787323, -0.11901999, -0.42014134, -0.03187113,  0.35428157,\n",
-       "         0.08303296,  0.07685167,  0.2601822 , -0.00407309,  0.10560863,\n",
-       "        -0.29776138,  0.40547028], dtype=float32)]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA+0lEQVR4nGNgGNRAd+bThQwMDAwMDvck0eXSvl6aEsjAwMAgtXczmhRr74drshCm0087VDnjo3+nQ81yeXqbF1Vy97/ZUDn2Vf8tUKTEnv3LY4EwOY//jWJClpNb+Pcs1CT+ZZ8WoZq55u9fFyjz8N/VqHJS7//9+/fv8sIMBfYz/6bAhRkhVBXnhxgONQbGR9fcF+R9ZcAEnHr+K//+vY1FBgIy/v79q4RDTurfvyf/yhF8ZA/x7mHwX/JfAaska4v6+QNPGCSxSnJ4M5R/VmB4j91YRkYG3kDG41idw3r5b2ji3zc4HLv/78MXnyJwSPI/+femEIccNQEATwZV3Vt4OpcAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "['8',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/8/5183.png'),\n",
-       " 0.20350545644760132,\n",
-       " array([-0.10779518,  0.01560267, -0.01500396, -0.18105853, -0.06782977,\n",
-       "         0.19930756,  0.01427122, -0.09341715,  0.12315948, -0.02313614,\n",
-       "         0.10789926,  0.13603845,  0.01581355, -0.10072555,  0.10688944,\n",
-       "         0.18113281,  0.01356881, -0.2025257 , -0.18652841, -0.2082253 ,\n",
-       "        -0.02865512, -0.10153925, -0.3971089 , -0.02807097,  0.36581576,\n",
-       "         0.11472838,  0.06546995,  0.27885213,  0.00611124,  0.10469785,\n",
-       "        -0.3225268 ,  0.41033518], dtype=float32)]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA6UlEQVR4nM2RIXTCMBCG//RNMQt2SKgFTfVmq9G1vDc3zTQWdDXVs4PJPFDwkEOue3O1uTtE2kIacIjdqeRL7v//BPhnpS4XnScAm+sHE02GzEcCxLqBuism2++ZUNZy4NjQZQ8cuCImpmPBxCQkewDBmYrI+vXlS0SE5Xft3Yw6Wak7aztwYcik2ip+Thpuw6Jyy8vYi5mWPnfTlseGZU498p8nzMuEbZ8N80rR14vz+m2+m2Mf97VTYoqq7QcAwFtPBHWLC0MVcMAKCgrbw5879vnH6uXzgfsb1pAujmlyJYWt/k1y9zoBsSK4GWpO+WIAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "['8',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/8/7923.png'),\n",
-       " 0.20535790920257568,\n",
-       " array([-0.13801472,  0.00621954,  0.01324526, -0.15497565, -0.07363982,\n",
-       "         0.18480222,  0.06190637, -0.07731929,  0.14280462, -0.01529375,\n",
-       "         0.06797428,  0.12477075,  0.03360037, -0.09421641,  0.08267348,\n",
-       "         0.1202066 ,  0.02800406, -0.23831494, -0.12120299, -0.17994858,\n",
-       "        -0.07378727, -0.12906069, -0.37269413, -0.03644777,  0.3587743 ,\n",
-       "         0.15787394, -0.00156036,  0.28049743,  0.04324026,  0.09545978,\n",
-       "        -0.3575211 ,  0.4439831 ], dtype=float32)]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAAh0lEQVR4nM2RQRLDIAwDdzr9V/w052WGl6kHUsgY59ZDdcqwsZAF/LEsJMlL5hqyCobkEIoKSgL85vvKvzTaw53p5DZ5QMryXp+TmNGyt0mBe0gqEoe+8s2WPoxPfE872rMdTNdi6Mrj2ladg5GLXSUYHaPXsNCCJ4dTt35tUr4lAB5Pm/xWH3n+VQ+JElsGAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "['8',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/8/9572.png'),\n",
-       " 0.2056165337562561,\n",
-       " array([-0.13871859,  0.00794921, -0.00714709, -0.16992597, -0.07731196,\n",
-       "         0.18034327,  0.02632423, -0.07574032,  0.13707913, -0.00746076,\n",
-       "         0.09539922,  0.1278962 ,  0.02255916, -0.10655132,  0.11078995,\n",
-       "         0.13779849,  0.01083361, -0.22742479, -0.14258838, -0.19795327,\n",
-       "        -0.05902013, -0.12295273, -0.39121884, -0.01822287,  0.35681796,\n",
-       "         0.12615526,  0.03557264,  0.27636376,  0.0111395 ,  0.09952669,\n",
-       "        -0.34341872,  0.43269384], dtype=float32)]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAABCElEQVR4nMXRTytEYRTH8V9muiVJ1DWLSZZGSVLK7Cy8Ac3OBgsUspPlbPxJNhrFDONdTE2SnY2XYGOnWdyowc1N39PYMDf3PmvO8vfp9JxzHumfq3Rg1in3O20rAoxqN8jGtn2Y1f3D5JTn6Jt/h5tBlaIdBy5Aa0LStKeho2IC/Wu4y0mSZl7a67nfWmxDWdLAeKUFG4nelTc+FvP5BkCwlHx2GTCA19OxpI1Uv7EymqS1SzMz6xzv+6lNCk8Q1MEc1ys8QnMuc4XtpXETan1SBQuGu2FP7PVQkhSaCyV5Oens2YW+5Jek8zj5+bLQMrVb9UqNKD2QTj4BCGcdJq1eAOw67Q/rC2njd+YEmNW1AAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "['8',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/8/9575.png'),\n",
-       " 0.2076045274734497,\n",
-       " array([-0.1331005 ,  0.00942803, -0.00043982, -0.18562244, -0.07275735,\n",
-       "         0.19512178,  0.02175655, -0.08774138,  0.13060835, -0.01647614,\n",
-       "         0.09030168,  0.13614202,  0.01462775, -0.11180203,  0.10697227,\n",
-       "         0.15972283,  0.00986198, -0.21282187, -0.16065034, -0.19177778,\n",
-       "        -0.04452091, -0.11539748, -0.39441586, -0.02117794,  0.35692507,\n",
-       "         0.11903383,  0.05488091,  0.27992192,  0.01625808,  0.08508871,\n",
-       "        -0.32969016,  0.42906052], dtype=float32)]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA9klEQVR4nM3Pr0tDYRTG8WciDMxrQzBNERaEFYNFhrDgNakgY0UwLAmCwR/J4p9gEa4o/kBBjGKxiqCYLgarDFa8vnIZY9+LQTfmvcdm8Ekv58M57znSf079KI73ly2ZWG90ADq7aTuM+M5jrzbYfXhZ6eVG+VlragisSNP9nT/QLWr8FT+NtXsgXM0NF/LzZ8FOQiuXDrieu3gGPiaTzdX37sLRSXr02he581LiFEnKSJJuN+6Ma3wHgNcrDPRhe0gukpZMLEtXT9KoidLDZlZ6M37UVMjBArRmLBxrctoAa1VJAUB7y8YqwLZtKh7D3sgv+If5BHsFeneuZrOfAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "['8',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/8/277.png'),\n",
-       " 0.20783281326293945,\n",
-       " array([-1.24270067e-01,  2.43610330e-03, -1.17951035e-02, -1.92144334e-01,\n",
-       "        -7.65644014e-02,  2.06153139e-01,  8.63673176e-06, -8.66443664e-02,\n",
-       "         1.18992284e-01, -3.14740348e-03,  1.11963585e-01,  1.48036689e-01,\n",
-       "         1.99435558e-02, -1.01394281e-01,  1.07662492e-01,  1.79325625e-01,\n",
-       "        -3.35485861e-03, -2.20356420e-01, -1.79223344e-01, -1.95037887e-01,\n",
-       "        -3.24723795e-02, -1.18083686e-01, -4.10369486e-01, -2.41548866e-02,\n",
-       "         3.47002447e-01,  9.94626656e-02,  7.00019300e-02,  2.65486211e-01,\n",
-       "         8.39820132e-04,  1.00934029e-01, -3.08309078e-01,  4.18250412e-01],\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/5876.png'),\n",
+       " 0.09338849782943726,\n",
+       " array([-3.68332297e-01,  1.58202797e-01,  2.95534283e-01,  2.31184542e-01,\n",
+       "        -1.78733289e-01,  3.77019674e-01,  1.26442909e-01,  3.05077612e-01,\n",
+       "         7.04605654e-02, -2.33200312e-01,  2.21860155e-01,  1.09218769e-01,\n",
+       "         1.93249613e-01,  2.20926225e-01,  1.08081222e-01, -2.30418533e-01,\n",
+       "        -2.20318958e-01, -8.47602636e-02, -5.90615310e-02, -1.71346053e-01,\n",
+       "        -7.63074979e-02,  3.74966156e-04,  6.62550181e-02, -1.17210075e-01,\n",
+       "         1.17863484e-01,  1.04648709e-01,  3.06050368e-02,  2.86547444e-03,\n",
+       "        -1.30512118e-02,  3.01726423e-02,  4.46750410e-02, -5.05277514e-02],\n",
        "       dtype=float32)]"
       ]
      },
@@ -2037,7 +1979,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA+klEQVR4nGNgGLaAp+Tp95diDAzSEgwMDCyoctIVxmtkXjIZ+7IHqWNojDBmYRDy5t76728TmozZ5GghFgYG5lmvv29rRpHpeHAxwFWBgYGBfdHPf38sUbXlf/v3764qA4P55X/nA2XQrVMwP/bzrVfFi3//bLD6w//fv3//LpVyYpMTW/3v378CrFIMojf///v3zxqbFOfil//uHKn5eQpTiiP/0r8fzVIMDFdei6PLaV/59/OWKQMDg/D9P/rokk/+XYgSZ+UQ0pmUksqDEGZkYGBgYDA6aD3r1U32yq9yrhKXNqNJSjBksNf9ZmBgSGRb/gmrVwYHAABmK1aAjnS+AAAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAABI0lEQVR4nM3RrUtDYRgF8OMHyl68QQeGsQsaTYIrWxL3D1jWhAmCGMQg2ES4KFg0GQzzH7j7CLIhWByGCbrJoi5pGaxuKLOco4Yrst17o8GTXp4fPA+HF/inMTZg7Jxaa6vGb1aJheQxRVJnR9uxIUyRykSTrlujSL6mB3GuWlUGAEw87pC6Hl78cKvWgvfc6H35EHs3z/UEAKB08rICABj5xcmp8vT8VR5L9xMz5U6gzmxaJHuLZiy0bU7SZagAmyLZiYZRar+vQvbCq+TLcvOp60Rgnd6dB8z6lBwAGK9oy4+7Yi0CADbJn9nogLc/AKDfBhL+taILAIi9sR44WpEaAKxHvR8E0BTJfHa9qe5hSBer6H32TogBxmmQdCKh+If5BmtKe4BexolyAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
       ]
@@ -2049,15 +1991,211 @@
      "data": {
       "text/plain": [
        "['8',\n",
-       " Path('/home/jav/.fastai/data/mnist_png/testing/8/9629.png'),\n",
-       " 0.2087579369544983,\n",
-       " array([-0.11165629,  0.02385902, -0.01111764, -0.17699666, -0.06776313,\n",
-       "         0.2086679 ,  0.0387623 , -0.10095822,  0.12849547, -0.02318227,\n",
-       "         0.10139351,  0.12179026,  0.02673438, -0.09662878,  0.10835069,\n",
-       "         0.1599886 ,  0.01882683, -0.21521384, -0.17701268, -0.20212372,\n",
-       "        -0.03210105, -0.11860982, -0.40316784, -0.0160803 ,  0.35840863,\n",
-       "         0.1322023 ,  0.03488598,  0.2792674 ,  0.02634823,  0.09203189,\n",
-       "        -0.3286124 ,  0.408755  ], dtype=float32)]"
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/6629.png'),\n",
+       " 0.09657961130142212,\n",
+       " array([-0.37598267,  0.14729178,  0.29981396,  0.23184597, -0.17113245,\n",
+       "         0.3693326 ,  0.12197712,  0.29893762,  0.0649836 , -0.23279262,\n",
+       "         0.22444412,  0.11953775,  0.19433382,  0.23397318,  0.10269549,\n",
+       "        -0.23896007, -0.21337178, -0.08672515, -0.05094349, -0.16870372,\n",
+       "        -0.06659477,  0.00362819,  0.0638281 , -0.12545557,  0.12865227,\n",
+       "         0.0933653 ,  0.0260153 ,  0.00819198, -0.01368039,  0.03658072,\n",
+       "         0.04711308, -0.04478485], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAABC0lEQVR4nGNgGEqAEc7iLOcW4XJ4sH3G+58M4c8Oo6jiXffn758/f/78/RPFIPb3Gi8DAwMDC0zS0o+B4ctxBgY3hgmaIQwsbCg63f786VFlYGCwuP3nz5+v/qiWs1/+s0mLgYGBYeGfP39E0Z229/f/FwYMDOF//562x3R4yIs/j40mX/mz2wqbtwwe/3n87W+bMHZP5/758+eVIHY5h9N//vx5hiTAhMT2NmKcsI2ZE7vOK1+qBbVOLsEqp/D3HAMDQ9gHI2ySc/8WMDAwSPxxxWanJ8MbNOVIkt+Z7BgYkCMRWXL6v6BGTgbR/9gdtO/PnyM77t3CHkL8G7HEFhywds79tAmHHGkAAJwGYRWdKzLIAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/2935.png'),\n",
+       " 0.09884512424468994,\n",
+       " array([-0.37280595,  0.15897597,  0.28989008,  0.22285101, -0.1670044 ,\n",
+       "         0.37233832,  0.13940181,  0.28261966,  0.06178808, -0.2429069 ,\n",
+       "         0.23300242,  0.10157636,  0.19003914,  0.2398941 ,  0.09573724,\n",
+       "        -0.23489654, -0.21493019, -0.07550802, -0.07048855, -0.16840123,\n",
+       "        -0.06363808,  0.02348284,  0.07065178, -0.11406957,  0.13142216,\n",
+       "         0.11321332,  0.05171952, -0.03479308, -0.03963634,  0.04629163,\n",
+       "         0.052859  , -0.04963508], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAABDklEQVR4nM3PvyvEcRzH8ddX6bq673DhWwZK2b+6gUEZXHSjAfkDlH+ADOQYTOomhAmzs1hc2NRthlNuMH4XmdR9hXq++xoU3fc+NoP39K5H7x8v6V/Wqdn8rzjzwn0gScMnW2GY1kO465c0BnA+3dOG/k5sNUndxQiM6/H22Q17r/dJyq/cGBynNpdfzYYkSXtm++m7C3x9FRhX+TT6q1CXFpvGVGcgv8rH9nqMnfmOuNkLA2gVHKaJVmJmTy7Khk0MGjmHZZaA6hGMOnASWFb2lp+1Xd9dSXo40FusXgd63mMxliqeV+7EJMkNSColyWDnzZGI6HKt8gyzjo8KNTAAV05lgs1daMw58Q/rE+k1fBf/kVZKAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/631.png'),\n",
+       " 0.09895122051239014,\n",
+       " array([-0.35765868,  0.15655084,  0.2932479 ,  0.23065555, -0.1714703 ,\n",
+       "         0.37198526,  0.12562305,  0.30216062,  0.06489266, -0.23358652,\n",
+       "         0.23316738,  0.11417682,  0.194542  ,  0.234649  ,  0.11020373,\n",
+       "        -0.23875116, -0.2214867 , -0.07838724, -0.05085449, -0.16527662,\n",
+       "        -0.06611587,  0.00831954,  0.05939326, -0.12688471,  0.13511713,\n",
+       "         0.09956309,  0.03122707,  0.00056342, -0.02943123,  0.03529185,\n",
+       "         0.05423586, -0.04379964], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAABJklEQVR4nM2QPUgDQRCF38UgCQQPPRAERQ5EQdIIYiEStBGjYGNlpeUZgp21RSo7/xqxSmFrZRGMhVhYmCYBFcHiEISQEIzGypxvziJcLua2tPA1szPfvpnZBf6ZtM5E790Y1gesspeH22R+ZdzsG4HmGmV0a/ebJEnJLSLgXNNQd64e0TiZgh7ZsrOdzkvuG63TYNams/qr7ULzxgCA2Podq2eJrqF13u4gOlcj36zARolnfp2+UsgZxZP1DEkKD3oUMFkiyZftIQWbfBIRef+YVTB8ks18KimVUTVsAMYSz8NBuEdm4kBombZX8m/FgaMqIP2IeKVQGxZbwTr0m/nOAnCff9gcc+EEZ0YvSJIua9OKdScKJCmVtIIBMdM85rXyE/5UP8ordu3DJ6iIAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/2111.png'),\n",
+       " 0.09899801015853882,\n",
+       " array([-0.36306724,  0.13900602,  0.2915186 ,  0.22999087, -0.16271171,\n",
+       "         0.37451634,  0.12117532,  0.30122486,  0.05905059, -0.24575944,\n",
+       "         0.2301542 ,  0.12598327,  0.18955672,  0.2393089 ,  0.11471233,\n",
+       "        -0.25408018, -0.21603131, -0.07120273, -0.05722496, -0.16591428,\n",
+       "        -0.06492431, -0.00286971,  0.04813105, -0.1218137 ,  0.11783452,\n",
+       "         0.09741097,  0.03107424,  0.02289542, -0.02657417,  0.03526381,\n",
+       "         0.04927958, -0.04491814], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA+0lEQVR4nNXPMUtCYRjF8YMGgXlxKCyhqammsLXGcGqr5iT8DEFNbkFDDQ21tFRLUVFC6BAkhBd0DKQoqBaXoiAMLob+b0tD3fu4tXTG98d5OK/0H+Kky243ixeb5EKvvSuuu1caKdI5jwQoMdvgOxvB2kIF4O4V2OkJWP4NvMJUvAb14WDRhbMJxZbhJhUas85xRE4JnsbD+yfxsrF7eAzdlBS9pHUNzBkmaQl875f9+Kwj+c9HNkbTUiuZt6+uQSVZZbXfwm0+pzWwyUmfgZl2c0zS6fuiVT2gkZEGX24tHH2gvb9V4MOcNLTbAZ8Le7DmD7maSXTBP8sXqeFxFm2O7JwAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/3873.png'),\n",
+       " 0.09926354885101318,\n",
+       " array([-0.36901474,  0.15787706,  0.29737303,  0.22478062, -0.15418836,\n",
+       "         0.3734246 ,  0.13528934,  0.28086886,  0.05955824, -0.24400482,\n",
+       "         0.23644102,  0.10771276,  0.19347136,  0.24361722,  0.09144159,\n",
+       "        -0.2443816 , -0.21140052, -0.06678322, -0.06436917, -0.16337655,\n",
+       "        -0.05840407,  0.00990716,  0.06189672, -0.12514324,  0.14273718,\n",
+       "         0.10190678,  0.03659718, -0.01593812, -0.03545793,  0.04970628,\n",
+       "         0.05617644, -0.04308477], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA8UlEQVR4nGNgGNxAe8rXvxmYwiUlDAwMJY///PnzCFNy3q+jcos+XKuru/QFU1L58Z8/3YYMDGz7JsPFmGCMu+7PGL6eZ2CYbIfVMSoP/mYw8L89LoRVVvPBo9Cdf0JweCT/598/D9hxSDJc/vvHApdc0re/f2bgkEv9+2ba8b/Y7ZR9/6eAQfTtYmxyYlf/9LIwMNR/j8Ei6fqnV4aBgYH9yFoskgf+iDIwMDAw1P3BIvl/OoQO+huJKfk3iYGBgYGB4+hNLDonX5JhYOC13PqnC4sk3+IPK1fe+nO3nA8uxIgkHWOuc2XjxddYNFIXAAC6I1bDf23ArwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/401.png'),\n",
+       " 0.09932023286819458,\n",
+       " array([-0.3635762 ,  0.15103394,  0.30694067,  0.23331632, -0.16829519,\n",
+       "         0.36755362,  0.11850319,  0.29123622,  0.06036897, -0.2427889 ,\n",
+       "         0.22272967,  0.117998  ,  0.19722615,  0.23765899,  0.10490257,\n",
+       "        -0.24492508, -0.21673615, -0.06731602, -0.05699643, -0.1654917 ,\n",
+       "        -0.05789862, -0.00133317,  0.04790812, -0.13276196,  0.14030954,\n",
+       "         0.09052319,  0.03237328,  0.0209347 , -0.01486127,  0.03653141,\n",
+       "         0.05588738, -0.0459619 ], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAABMElEQVR4nGNgGKpA3H/W379//z/plcGUs3/15++fx4+Pvvpz3RhNSu3Yqz9/DlnIyzOoXfzzEE2y8PSfa928DAwMDAx53b9qUeQir2b8/bsPwuZq+BeCpvX0nz/XpRgYGNiDNq3+iy4p3Lf6zzQGBgbZP0danwtjOJdr0zs1hlT/P45O3lg8avzp79+///4e4sUixyC17M+fP3+vaWPKcIW23fv758HZv6uxGNnw58Ofv4+1edO/GaHLGXx8tPLvx1QGBgbZvzcEoIJMULqA+/+tz02zGRgY3ob/50Hz5KYP3ze5sEE480ugoiwQ6stznhcpr6Bi28zQLV38Po4dZv8mNDsZtr6J7VOAMFVvQsUY4Vrlk9V4WebcYrjIIMzzEF2SgYGBt/6/z3MndAvJAQAVqXVqmJgVfAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/4117.png'),\n",
+       " 0.10217827558517456,\n",
+       " array([-0.35156298,  0.16355656,  0.30134732,  0.22667001, -0.17924194,\n",
+       "         0.37603086,  0.12719253,  0.30152017,  0.07219735, -0.23419859,\n",
+       "         0.22553216,  0.11478238,  0.19514334,  0.22200024,  0.11441004,\n",
+       "        -0.23573409, -0.22461611, -0.0799832 , -0.05228319, -0.17153245,\n",
+       "        -0.06698789,  0.01053997,  0.06450619, -0.12811044,  0.12589845,\n",
+       "         0.10002032,  0.03342265,  0.00417014, -0.02135291,  0.03006814,\n",
+       "         0.04590758, -0.04563618], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAABJUlEQVR4nGNgGGSAEcGU/sEp/1VJVjGL5VbTMlRVbN1v73x49fff38e7T/79hGbE3L9/F2VVxlz+O4vBAkPy8197RgYGhgk/YplW/n2JJrn67yRWBgbJG7sZKv6+MkeT1Pv7dxIDg0S6pv/vv/XozmYq+/3nEDMDg+q9v1NZMX1V+uvvJDaNB39nKmPzc+nfv1M2/b3Pjk2Ogani799/k0UQAizIsoyMDJ+Xv8GqkSHy79/D/8/wYJVTvvfGg23x33UsWOTU7//pY2AI+f5XBFOO//7fVQwMDAyZfw9iSor/nSjLwMDA4Pz3OcL5MIYpw7LHDAwMTJYMvzF1Fv3dYKbLI1L5968ZpqTAwb9//569+e9lCzMW13JUfPn79+8BKyxSVAYAulNxOVnIV3IAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/2213.png'),\n",
+       " 0.10343778133392334,\n",
+       " array([-0.36173356,  0.15118621,  0.29811877,  0.22328272, -0.17127284,\n",
+       "         0.37576228,  0.1278009 ,  0.2878798 ,  0.07162137, -0.23225948,\n",
+       "         0.23361638,  0.11763023,  0.19491744,  0.22889662,  0.10453572,\n",
+       "        -0.2426079 , -0.22669537, -0.06324654, -0.06669908, -0.18271776,\n",
+       "        -0.06520734,  0.01194281,  0.04815498, -0.12896037,  0.12580338,\n",
+       "         0.10066501,  0.04210657,  0.01241063, -0.01730939,  0.02693971,\n",
+       "         0.04445782, -0.05199178], dtype=float32)]"
       ]
      },
      "metadata": {},
@@ -2065,27 +2203,27 @@
     }
    ],
    "source": [
-    "list(m for m in best_match_mnist(fingerprint_db, fps2, 10, display_data=True));"
+    "list(best_match_mnist(fingerprint_db, fps2, 10, display_data=True));"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 27,
    "id": "efdb8a93-f978-4cd1-98a5-b92a29146a6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T14:05:50.347680Z",
-     "iopub.status.busy": "2022-08-16T14:05:50.347106Z",
-     "iopub.status.idle": "2022-08-16T14:05:50.951379Z",
-     "shell.execute_reply": "2022-08-16T14:05:50.950093Z",
-     "shell.execute_reply.started": "2022-08-16T14:05:50.347660Z"
+     "iopub.execute_input": "2022-08-16T14:56:22.218362Z",
+     "iopub.status.busy": "2022-08-16T14:56:22.218022Z",
+     "iopub.status.idle": "2022-08-16T14:56:22.828122Z",
+     "shell.execute_reply": "2022-08-16T14:56:22.826980Z",
+     "shell.execute_reply.started": "2022-08-16T14:56:22.218346Z"
     },
     "tags": []
    },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD7CAYAAACscuKmAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAABkcElEQVR4nO39V5Bd2X3YC//2yTnnzgGNOBjMYAInkzMcDkWKpCxWyZJsF2/ZVaqyr6uuq/xgXX8Pvm9X3/fgKlVd+0F1qbJM25ITJVKmJAZwcgQwMxjEBjqHc06fnPM5+3sA1prTQDfQDXTu86vq6u590t7r7P9a//WPiqqq9OjR4+Cj2e0T6NGjx87QE/YePQ4JPWHv0eOQ0BP2Hj0OCT1h79HjkNAT9h49DgmPJOyKonxTUZRJRVGmFEX5w606qR49emw9ysP62RVF0QI3gdeBJeA88Huqql7butPr0aPHVqF7hNc+A0ypqjoDoCjKXwDfA9YVdkVRehE8q0mpqupf64HeWK1GVVVlvcd6Y7Wa9cbqUdT4PmCx6/+lO8d6bJz53T6BHoeHR1nZN4SiKH8A/MF2f85BoDdWG6c3VpvnUfbszwH/l6qqb9z5//8EUFX1/77Pa3rq1mouqqr61FoP9MZqNT01fuNshxp/HjiiKMqIoigG4HeBnz7C+/Xo0WMbeWg1XlXVlqIo/xz4OaAF/lRV1atbdmY9evTYUh5ajX+oD+upW3fTU+M3SE+N3zjbocb36NFjH9ET9h49Dgnb7nrbCyiKgtvtxuv1YjQacblc6PV6arUajUaDfD7PwsICjUZjt0+1R49t48ALu6IoKIpCf38/Z86cwe12c+LECWw2G+l0mmw2y61bt0ilUj1h73GgOdDCrigKBoMBnU6H0+nE7/djs9lQVZVGo4HJZMLn85FIJNDpdCiKQq8mX4+DyoEWdr1ez+DgIE6nk7Nnz/LVr36VdDrNuXPnyGazfO1rX+OZZ56h0Whgs9kolUo0m03a7fZun3qPHlvOgRZ2rVaLw+HA6/USDAbp6+uj2WyyvLzM0tISzz//PH6/H5fLhdFoRKfT0Wq1dvu0HxlFUVb97mYrNZeeFrQ23eN+93fQPWY7PX77TtjF4N1voLRaLXq9HrvdztjYGAMDA9RqNX79618Tj8eJxWLk83nS6TQrKytUKhU8Hg+tVotEIkGxWNypy9kStFotHo8Hk8mE3W7H6XTKa7darfJ5tVqNTCZDs9kkm81SqVQe+jM7nY58j3K5TC6Xo9PpbMXl7DvEdlEsGn6/H4/Hg9VqJRgMotPp6HQ6qKpKPp8nmUxSrVZZXFykWCxSq9WoVqvbfp77StgVRUGjue0tFIO3FlqtFrPZjMvl4tixYxw9epRLly7xzjvvkMvlWFxcpNFokEwmiUajVCoVAoEAOp2OUqm074Rdr9cTCoVwu9309/czPDxMJBLh29/+NqFQSD4vk8lw69YtSqUS09PTJBKJh/7MVqvF1NQUiUSClZUVCoXCoRR2cU+aTCb6+vpwOBycOnWKiYkJQqEQZ86cwWKxyO3hwsICly9fJpVK8e6777K0tEQ2m6VWq237Sr+nhV2n06HRaHC5XLjd7nuEXQi8+C3+NplM2Gw2PB4PLpcLi8WCyWTCaDRisVjwer20Wi0sFguKomA0GvH5fOj1egqFgrTgix+NRrPqbwCNRoOqqpTLZSqVCq1Wa0e+sLXQaDRYrVacTieBQICBgQGCwSA2mw2TySSfZ7VapQZQrVZXPbZZWq0WiqLg9XoJBAK43e77boE6nQ7Ly8uPNMHsBBqNBo1Gg06nw2g0yoVDr9fT6XRoNpurnmcymbBYLNhsNoaHh7Hb7YyMjBCJRPB6vdjtdkwmE61Wi06ng8fjIRwOYzQaCYfDtFotWq0WmUxm269tzwq7VqvF6XRiMpl46aWXeO2119BqtVKY2u02nU6HVqtFvV6n3W5Tr9elEAuVKhgMYrFY6OvrY3x8nEajwcjICACjo6OYzWbC4TAWi4V6vc7IyAjJZBKdToder5dftvjfYDCg0WgwGAx0Oh0uX77M5OQkuVyOubm5XXHf6fV6uaI/9dRTPP/885jNZpxO56rnWa1WRkdHabfbjI6OPpJ9QlVVOd7NZpN6vX7fia5er/Pv/t2/47/8l/+yp/f6RqMRo9GI0+lkaGgIm83G2NgYfr+fSqVCNpsFwGQySQPwyMgIZrOZQCCA0WjEbDbLx81ms1wYVFWV91uhUMBgMLC4uMj777/P0tLSttuL9qywK4qCTqfDYDDg8/k4cuQIWq2WRqNBp9NZJey1Wo12u02tVqPVamGz2fB6vXLvLoTTarXK1V1RFKxWKxqNBqPRiNfrpdlsUi6X5cxuMBjQarVYrVZ0Oh0mkwmTyYRWq8VkMtHpdFhZWWF5eZl6vS5X/Z1Go9FgNpux2+1y5dDp7v1qdTrdmse3E/EdVSoVvF7vjn72ZhCam9FoxGazSS3JbrczODhIJBKhWCxit9tRVRWLxYJer2d8fJyjR49iMpnweDwYDIb7fo7BYMBms2E0GgkEAtTrdWw2245c454V9k6nQ6VSod1u02q10Ov15HI5zp07RzKZlIY6jUaDVqtFUZRVs20gEABgaWmJcrlMKpVatfpoNBqazSbValWqbBqNhk6nI40lqqpK1V2j0RAKhejr65OrvFDrisUilUrlUO5ZH0QqleKtt94iGo1y5cqV3T6dNdHr9Xg8HiwWC88//zxnzpzBZrMRDAblFs9ms9FoNOS9IbaYbrcbt9uNTqdDq9Xu8pXcnz0r7KqqyhW73W6j1+splUq8/fbb3Lp1C61Wi1arxWAwYLfb0ev1+P1+7HY7VqsVrVZLp9MhHo+TTCap1+s0m00URZFfitAKzGazXMU7nY5UT4UW0Wq15Gw+MDCAVquVFtZWq0W5XN61/fpeJ5vN8qtf/YqbN28yMzOzJ8dIr9fj9Xpxu928/PLL/NZv/ZbUBIW95iCwp4VdVVXa7TbVapV8Pk+tVpORcKVSSa6mQv3SarVSJcpkMjQaDRYWFohGo3JvCciJotlsyvc0Go20222SySSLi4vo9XqMRiMGg4G+vj6sVit2u51CoUC73aZUKlGr1VhYWJB/79bK3m63KRaLZDIZotEoU1NTWK1WuYfcaVRVJR6Ps7y8zMzMDNFolHQ6vSPupc0gtDa73c6xY8cIhULSeCZW7vttzcQ9KhamWCxGrVaTORdmsxmfz4fBYMDhcGA2m3fw6u7lgcKuKMqfAr8JJFRVPXXnmAf4r8AwMAf8jqqq2a0+OWHBzGQyzM7OUqlUGB0dxe12c+XKFVKpFACFQgGz2czJkyfp6+tDURSmpqbI5/O89dZbzM7Oyi/lzvmj0Wjo7+8nFAoxMDAg/dGXL1/mo48+IhwOMz4+TiAQ4MUXX2RsbIzr169z+fJlEokE77//PqlUimq1KgV9tyLvms0mS0tL8iZLp9OEw2Fee+01uZ3ZSVRV5fz58/yP//E/SCQSfP755+RyuT0XsCTsMn19fXz/+9/n6NGjhMNhrFar3MM/CPG9JxIJ/uZv/oZoNEo8HieVSjEwMMBLL72E1+vl5MmT9Pf3y9fthrawkZX9PwD/D/Afu479IXBOVdU/utMc4g+Bf7X1p/elOi+CNux2u7SQd6+knU5HGlc6nQ75fJ5sNks+nyefz9/zvoqiSLeIx+Oh3W5La7/Yq+v1evR6vdyPNZtN8vk8mUyGRCIhJ5vdRtgZisUi6XRaTlzJZFKuTsKuIX6LnIGNIFyawkYhJre736PT6dBoNGi1WsTjcRYXF8lms5RKJer1+rZc+6Og1+uxWq04HA4CgYB0V25WdRdbv0QiQTQaJRqNkkgk0Gg00tV49/WLMRWG5p3ggd+2qqrvKIoyfNfh7wFfvfP3nwFvsY3Cvri4yHvvvSdXWZvNRiqVYnJyElVVpSo2NjbGk08+yZUrV3jzzTfJZrPSVbIWlUqFTCZDJBLBbrdjs9l4+eWXZTy933+7pPt7773Hr371K+bm5piamqJSqeypwJtWq8Xy8rIMErp27RoWi4X33nsPi8VCIBDA4/Fgs9kIhULYbDZOnz7N4ODght5fVVVSqRSZTIapqSn+9m//lmq1yuOPP77qPcrlMp9++ikrKyssLCwwPT1No9HYk4IOMDQ0xGOPPcbo6CiRSASXy/VAa/rdiEmwWCxy9epVJicnpcFW2HFE7MPY2Jh8XbvdJp/Pk0qlKJfLW31pa/Kwe/agqqqxO3/HgeAWnc+aZDIZbt68CUB/fz/9/f0yDBFu78GFK2NwcJDJyUlmZ2fvGxIq/MQi+cVkMuFwOJiYmMDv98tgiXw+z/nz55mZmSGZTBKPx/eckandbpPL5dZ8TKPRMDIyQn9/P16vlyNHjuDxeBgcHGRgYAB4sEqpqirFYpGVlRWuXbvGj3/8YwqFAoVCgccee0w+L5vN8r/+1/9iZmZmy65tuxABQceOHWNgYAC3243FYpGPr/cdrxXr3ul0qNVqLC8vMzs7S6vVot1uSwNvKpVa9f2I14hF40ExClvFIxvoVFVV71cDbCvqe9frdak+R6NRGbk0MTEh/7ZarXQ6HZaWlkgmk5TLZer1+roqkkajwWKx4Ha7cblcOBwO7Ha7/BJSqRT5fJ5isShDGiuVyrZ+KdtRC71bUMWYOBwOrFYrsViMvr4+jh49il6vv995YbfbCQaDuN1utFqtDP3sHo9msyl90yKqTAhHu91mamqK+fmt6YvxqGOlqirpdJobN25QKBTo6+sjEAhI4229XpfaWzgcxul0yliGbqOdiOVwu92cPXsWp9PJ9PQ0i4uLUtsMBoM4HA7g9r1crVbJZrNkMhnS6fQj5ShshocV9hVFUcKqqsYURQkD68ZAqqr6J8CfwMMXBhQhqSaTiRs3blAqlbDb7Tz33HMy2klkrF2+fJnZ2Vny+fy6win2sE6nk0gkQjgcJhgMYrfbabfbZLNZpqam+OSTT6hUKhQKBTlLbydbMVZrvKdUwcWe3WAwMDU1RSgU4tVXX2VoaOiBwu7z+fB4PExNTaHX62k0Gly6dImrV78sKOxwOHj11VcZHBykr6+PgYEBKRiNRoMf/ehH90wQj3BdjzxWCwsLZLNZ/H4/zWZTanRGo5FsNsvMzAyKovDKK69w9OhRAoEAFovlHmHXarWEw2G++93vsrKywo9//GNisRg+n49nnnmGSCRCIBBAVVWq1SrxeJxEIsHS0hJLS0vkcrk9vbL/FPgB8Ed3fv9ky85oDYTRrF6vk81mZUy32+3GbDbLuPl4PC4Ncu12e80B1Ol02O12GZnn9/txOp0oirLKzVcoFGRGUqPR2Nc57mJfCbdXXxGLrdFoWFlZIRaLUSqVZHiwCPnsTpXtjmsQAtFqtahWqzLuQKvV4vV6iUQihEIhAoHAKmH3+Xy43W4ajcaeCEJqNptSlU4kEnI7ZzAYyOfzrKysoCgKy8vLUnMUYdgihFogAnNUVSUUCskxENcsXKCNRoNCoSC1xmKxSKPR2BvCrijKn3PbGOdTFGUJ+DfcFvL/pijKP+F2v7Lf2c6TFBQKBT788EOcTifPPfccZ86cwW63Ew6HqdVqfPLJJ7zzzjtyANfC5XLx8ssvEwgEGB0dZWBgALvdTq1Wo1AocO3aNc6fP086naZYLEr330Gi3W4Tj8fJZDJ0Oh2pKfX39+NwODhx4gSPP/74mhFhVquVkZERdDody8vL5HI5HA4HkUiESCTC1772NR5//HFMJtMqv3Kz2eSFF16g1WqxtLTExx9/vGOGqfUQYbytVov3339fTnYiurJSqaAoCrFYDKfTybFjx3jxxRfxer08+eSTBINBOSGazWYmJiao1WpoNBpOnjyJ1+vl6NGjMikLbkcUfvbZZ8RiMa5evcrMzMyOBWRtxBr/e+s89NoWn8sDqdfrRKNR8vk8zzzzDF6vF6fTSSgUkqmp09PTwL0Glu4vRRinhOEKkJFw6XSaeDwuDXcHTdABma1XLpdZWFiQuf+lUkkW+uh0OmsKu9iflkol0um0DFP2eDzSQNptdRbfQ7PZJBKJMDIyQqvV2vEY/bUQGo8Q+vXI5/PodDra7TbhcJhKpcKxY8fodDrSTSfGpd1uMzExgc1mw2KxEAqFpDYEt2sKiLRgUQNxp9j9Ed8EwngmVHrh1xUqkXDxdMe/22y2VdlJDocDn8+Hoih8/vnnvPvuu/j9fh577DEp2Eajcc+6i7aacrlMNBrFaDRSLpexWq309fWtu9K4XC6eeOIJBgcHOXr0KKVSiVAoxNjYGF6vd1X+PNwW8kwmQ7lc5sqVK3z44YcyfHm/ILaE0WiUjz76CJ/Ph9lsZmlpiYGBAYaHh1dtecS2UITc7pW4+X0l7CJMVQR2iEy3bDZLoVC4x4UhjHB2u52vfOUrfOMb35BW2HK5zCeffMK7777LY489JiuLwO3Vv1qtHpiY6PtRKpUol8sy6lCr1fLEE0+sq9F4vV6ee+45qtWqHOtgMMj4+LgMQOqmXq+zvLxMJpPh4sWLvPnmmzsaSLIViMi/hYUFlpaWpI1oZGSEF198cZUhUpQtd7vd8v+9wr4S9u60VxEJJirFNptNmRQjEPnsLpcLk8lEqVSi0WgQjUYpFotks1nq9bo0wLXbbWmM2q101d2gO5RYVVUKhQKxWAybzSZr7Av0er2sMyBwOBwynly8R7lclmN869YtkskkyWRSJhXtR0SuRq1WI5VKYTKZSKVSFItFjEajTH9eT8BVVZVZkuVyecfDh/eVsOt0OlwuF1arVbpAhEW4XC7j9/s5ceIEcHtgbTYbTz/9NKFQiHw+z4ULF8hms1y6dIlcLkcul5NCLqzUIlddr9fvqVl5p1BVlampKX72s58RiUR4+eWX8fl88nFRAKN7ZRaGrW6mpqa4cOEC0WiUX/ziF8TjcdLp9L4V9G5qtRqXL19mZmYGh8PB6OgoTqeT4eHhVYE5a5HL5bh16xaJRGLHDZT7SthFAI3ZbJbpqELY6/U6ZrNZFkgQwu7z+fD5fBQKBVKpFKlUSlqR7y5nJWLiD9vKfjcikEgUC+lmIwUwVFWlVCoRjUZZXFxkenqaeDy+nae8o4hQ12q1SiqVkobK9Vbq7uy4er0u3bq9lf0+WCwWjh07JqvQTE9PUy6XZQjryMgIZ8+elQkb9XqdpaUlpqamWFxcZG5uTmoB3b5nWK3KHmZUVWV+fp633nqL48eP8+qrrz7U+4gyXfF4fF8Z4zaC2Dq2220uX74MwNjYGOFwWEbKddPpdGTV4rm5OZaXl+UWcifZV8JuMpkYHR0lFArRarVYXFyUyRkGg4GvfOUrvPTSS1LQE4kEly5d4sqVKzK/ej3DUE/Yv0RkbrXb7YcO5SwWiywvL5NOp2UdgYOEKBR58+ZNlpeXOXPmDL/927+95nPb7bZ06S4vL7OyskKxWNxxI+W+EHZhlLNardhsNmw2m6xA02w2ZWEAnU4nBV343UWo7YOilLrr0feE/jbdKb0WiwWj0bimHaNer1OpVKhWq8zNzZHP57l06RKpVIpCobDn8ti3ku703wfdN7vZIAL2ibCLhJVgMEg4HCYQCHDt2jUuXrwofeRutxuDwUCxWKRQKJBMJkkkEjLvvFwuP1DYhXX/bhX/sFKv15mfn5fluO72ocOX1vv5+XmWl5f54Q9/yBdffEG5XKZUKq0qv3wQERb6/RBOvS+E3Wg0ytpydxdLENlrZrNZxs6Xy2VptNPpdJjNZhqNxgMbN26k28xhwGw2Y7FYcDqdaDSaNf3i4iYXxrhEIkE8HmdhYWHLMtv2C939BNZDVCzu7kHQa/90F4qiMDQ0xHPPPYfJZCKfz1MqlfD7/Xzta1/DZrMRDodRFIV3332XRCKBz+djcHAQjUbDSy+9xLPPPsvHH3/Mu+++u2YIbHcF2c2oZQcRRVF47bXX+P73v4/X6+X48eMyJbabdrvNysoK+XyeTz75hL/8y78klUqxuLi4S2e+O5hMJlwul6ygtBYajUbW8BdNOkSC1U5qkHte2AF507VaLWKxGPV6XbY6EoX4q9Uqk5OTfPbZZxw9elT2PJuYmMBut7OyssIHH3ywbvRWdymiwyrocFvYT5w4we/+7u/et2OM6Fu2srLCjRs3ePPNN/dU9Z6dQq/Xy45D663uiqJgNptRVRWr1SrLee10ktWeFXbRv8xmsxGJRGTNOZEiaTKZUBSFbDbL1atXKRaLRKNRqtUqiUSCy5cv43K50Gq1MpX161//Ovl8nunpaUqlklT1u1d24bvfD3uwrUR0vBWtsx6EqPN3GPu8ibh3rVbL4OAgp06dYmxsbN2AGvF8uL1FEh1jdrp70J4VdpPJxGOPPUZ/f7+MUFJVVZZ8FmGu0WiUv/qrv5LdSVutFtPT08zPz8vi/cPDwwwPD/Piiy+yvLzMf//v/52lpSUSiYTs5CKKS3Z3ljlMq7tOpyMSieDxeGSi0P0QarxoEHmYhF301jOZTJw+fZrvfve7+Hw+XC7Xms9XFAWLxSLtIA6HQ+b076TA7zlhFwUSRAunQCCwqryR+F2pVMjn8+RyOVlDXiB8oOVymUwmg81mkyWntFotLpeLarUqCxd05zGLip+HbWXX6XQEAgFZeHGjZZRFd9LDhOhTYLFYcDgcMtV6vcjCboOcuLcrlcqOZ8LtOWF3u90MDQ0RCAR44YUXZDNG0dGlUChQrVa5ePEiV65coVAorBtjXKlU+OSTT7hy5QpjY2PMzc1hMpk4c+YMTzzxBB9//DEajQa/34/FYsFgMMjPOGwdXlwuF9///vd59tlnCYVCeyLffK+i1+vp6+vD7/czMTHBxMQEZrN5Qw05PB4Pp06dIh6Pk81md9TOsZFKNQPcrhkfBFTgT1RV/ePtahRhMpnwer34/X4ikQj9/f2kUikSiYRU36vVKrFYjFu3bslecGsh6pcDMsHF7/czPj6O3W5nbm5OWprFHkxUBT3IgSB3IwpQTExM8NRTT+326ex5ROlyj8cj01k3WoLaZDLh8/loNBqbLlv9qGxk+m4B/1JV1U8VRbEDFxVF+SXwv7ENjSKEUBqNRlkaKJPJyOSVq1evksvlWFhYkG60jazA2WyW6elpstmsTN0MhUJ873vfw+v1yn2U6P92WPbsfr+fkZERBgcH191z9liNTqfD4/EQCoWw2+37JjtyI2WpYkDszt9FRVGuA31sU6MIEQQjVOpSqUQymWR+fp5YLMbbb79NMpncdJRbOp0mk8nIKiI+n4/f+I3f4OWXX5b7+2w2+8ASRQeNcDjMSy+9RCQSkQUXetwfnU6Hz+ejv79/w/aNvcCmNmZ3OsM8AXzMBhtFbLS+t/Bzm81mPB4PTqdTlpwSSQSpVEquuptFxLyL6p4ajUY2ZBQGud2uoLIddeM38Jmycux+uWlhd8ZK1Ii3WCx4PB78fr/sCycQhTuq1ao0xolgLXH/iTyCnTZsbljYFUWxAf8T+BeqqhbuusB1G0VspL63sG4aDAb6+/t56qmnMBqNpNNpotEo58+f54MPPqBWqz2yQaNWqzE1NYXZbGZ8fJxQKCQtq6If/G6xHXXjDyq7MVYWiwWfz0dfXx9PPPGEbArRLQudToeZmRmmpqYIBoOcOXMGi8UiYzdyuRzz8/MkEokd72q7IWFXFEXPbUH/z6qq/vjO4Q03itjQidzJbDObzTidTrRaraxdlk6npYHuUWm325TLZZrNJrlcjkwmI0seV6vVQ2WYg9WhwvtpZd8NRENRq9WK2+3G4/HckwkoVvZ0Or2q+agI1hIZmeVyee+t7MrtK/khcF1V1X/b9dCWNYrQarX4/X68Xi9ms5loNEqj0eDjjz+WudVbrV6L7jGiTLBoerAf+pRtJTabjaGhIUKh0K73D9/riJLZojipqDl3N6KbsGi00W63SSaT5HI5ZmdnmZmZuW8fwu1iIyv7C8A/Ai4rivL5nWP/mi1sFKHRaHC73fT19WEymUgmkxQKBVnnaztyzDudDjdv3uTWrVurjh8GC3w3FotFtr/aiJ/4MGMwGHC5XLhcLmlEvhsRGivy/0WgViaTIRaLsbS0xOLi4q7kEWzEGv8esJ5+tyWNIjqdDoVCgUQiIY0XonzUdheTOGzCfTdGoxGPx3NPFdkHITrJiJTiwxIu262yr7ftsdlsBAKBVW3F9kIewZ4Ik2q1WrL4gWi62Ol0qFarh+Ym2i2cTqds8LCZqLl2u00sFuPmzZvE4/He93QHjUYjGzkKT0elUmFubo5Lly6xsLCwa3ahPSHscLvh3U5nAfX4srf9RlV4EWFYqVRkbfjDFFrcXSm20+nck7Mh1HiDwSArH4s8DtEZZ7fGas8Ie4/9QTKZ5PPPPyeRSPDZZ59x69YtGatw0BHtxkSuhqiEtJ5GlM1muXbtGslkkg8//JALFy7sak2+nrD3ANZvhHn348VikRs3bhCLxaS/+LAg3GetVotms0mz2ZRdiroRYyXUd5HHMTU1tRunLekJ+yEnk8lw9epVPB4PDodjVRVfIfDtdpupqSnm5+dZWFjgs88+I5VK7WgH0r1ApVIhHo/Tbre5cOEC+Xye0dFRJiYmpAtO1ObrdDqy+0s0GqVQKOzy2feE/dATjUb59a9/jdvtZmxsTLpAu8NAW60W7733Hj/96U9JJpPcuHGDarV6oKvGroWof7i8vIyqqgSDQb7zne8wNja2yt/ebDZpNBrEYjE+/PBDlpaWWFlZ2cUzv01P2A85YrUSsdzFYlFW/BHC3mg0WF5eJpFISFfbYTSmqqoqo+Cy2SyKorC8vMzs7Kx0W4oWT2LM8vn8rjRxXAtlJy2DvXjve7ioquqaCeQ7NVaiH55Op8NisaDX62U/PUGn0yEajbKysiLTjnfa1aaq6rqxvDt9X2k0Gmw2G3q9nmAwSCgUWlVsUmRkiog5UXhlp4yY641VT9h3l10X9v3CXhL2vc56Y3V4W5X26HHI6Al7jx6HhJ6w9+hxSNhpa3wKKN/5vV/xsXXnP3Sfx3pj9SX3GyfojVU3647VjhroABRFubCeUWo/sJPn3xurvflZ28FOnH9Pje/R45DQE/YePQ4JuyHsf7ILn7mV7OT598Zqb37WdrDt5/9Ie3ZFUb4J/DGgBf5fVVX/aKtOrEePHlvLQwu7oiha4CbwOrAEnAd+T1XVa1t3ej169NgqHsX19gwwparqDICiKH/B7S4x6wp7L6zxHlKqqvrXeqA3VqvphctunO0Il+0DFrv+X7pzbBWKovyBoigXFEW58AifdVCZ7/6nN1YbpzdWm2fbg2p6XU42Tm+sNk5vrDbPo6zsy8BA1//9d4716NFjD/Iown4eOKIoyoiiKAbgd7ndJaZHjx57kIdW41VVbSmK8s+Bn3Pb9fanqqpe3bIz69Gjx5bSK16xu/SKV2yQnjV+4/SKV/ToccjpCXuPHoeEnrD36HFI6Al7jx6HhF7d+DtotVoURcFkMqHX6zEYDLKccrPZpNPpUC6XKZVK295GercRnXS1Wi1msxmtVovBYECn08l+Z+12m1KpRL1e3/D7ir5oBoMBu90O3G68UK1WZaPE/YIoHa3RaFaVkV6PVqu169fXE3ZAr9djtVoxmUycPHmSSCTC6OgoZ8+eBZDte95//33OnTtHo9Gg2WweWIG32+24XC7cbjdnzpzB7XYzMDBAKBSiWCyysLBAPp/n3LlzXL9+fUPvqSgKfr8fv9/PyMgIX//619FqtfzlX/4lFy9epF6vU6lU9sWYajQazGazrLXf3T1nLdrtNslkkmKxuINneS8HUti7B/5+X4JAp9NhMpmwWq1EIhHGx8c5ffo0r776KgBTU1NkMhkWFxcxGAyywd9+uDE3i6IoGI1GHA4HPp+PI0eOEAwGOXr0KMPDw6TTaZxOJ8lkkgsXNh6WrigKVqsVj8fD4OAgzzzzDHq9no8++giDwbCvusAqioJer8doNGK1WnE6nfe9z1qtFvl8ftVzHnTvbOa5G+XACLtGo8Hn88kOJ4ODg1IV7+7DBfcOpF6vx2KxYDQa5c0dDoelau/z+bBYLPT19dHX10exWCQWi21Khd3rGAwG+vv7sdvtHD9+nMceewybzUY4HMZsNlOtVpmamiKdTsvJr1QqPfB9NRoNRqMRg8HA+Pg4Z86cIRQKUa1WKRQKFAoFyuXyvtCU3G43kUgEq9XK6OgoLpcLj8eDz+dDURR5/nffX61Wi5mZGZLJJIVCgVQqRbVaZWlpadUYGo1GgsEgZrNZalLRaJSPP/6Ycrn8yOd/YIRdq9USDoeJRCKcPHmSV155BZvNhsfjwWQyyeet1YpYo9Gg0+nQarXY7XbMZjOKosi9WDAYpNPpMDw8zPDwMKlUinQ6faCE3Wg0MjExQX9/P6+88gpvvPEGnU6HTCZDrVZjYWGBaDRKOp3mxo0bFAoF8vn8A99Xq9VitVqxWCwcP36cV155BYBSqUShUCCXy+26ertRvF4vZ86cwefz8cILL9DX1ycXhvsJe7PZZHJykng8zuLiIleuXCGdTlMoFFYJu9lsZnR0FK/Xy0svvcTZs2f5+OOPuXbt2uEWdmFA6t5vDw8PMzQ0xMDAAF6vF6vVisPhwGg0rnqt+DK6vxytViuNLe12W/4tnitWKIfDQa1Wu0db2I8oioLFYsHpdOJyuRgcHKS/vx+3242iKNTrdRYXFykUCiwuLhKPx8nlcqRSqQ0b58S2wGKxSFtAuVwmkUiQyWSoVqs7cKWbR/Rd12q1eL1ebDYbo6OjstOt3+/H5XJhtVoxGAxoNJpVmkm38Gs0GpxOp+ztXi6XcTgcLCwsAF8aLt1uN0eOHMHr9RKJRHC73QQCAUZGRjCZTKTTacrl8kMbiPetsFutVqxWK36/n+PHj+PxeHj11Vc5ceKEvIG1Wi06ne6+e3hVVVcJf7FYpF6vYzab79mLeTwejhw5gtFo5IsvvtiZC90mxGQ2MjLCyy+/jN/vl6uVVqsll8sxPz/Pf/pP/4n5+XkymQy5XE52MW232xsSVL1ej8/nw+12MzQ0xJEjR7h69SoffPAB0WiUaDS6A1e7eQwGAw6HA4fDwbe+9S1Onz5NJBJhYmJC2nf0ej16vV5qgELAxT0j/tfpdPT39xMKhThy5AhPPfUU2WwWn8/H3NwcTqcTt9uNx+PhiSeewO12S21IURR+8IMfsLKyws9+9jO++OIL2u32Q7XL3nfCriiKdJHZ7Xa5j/L7/QwPDzMyMrLKHdLpdFbNhHfPiN2PdTodarUa5XL5npkabs/ARqMRo9G4IXfLXkSMn8FgQKvVSkt7IBAgEokQDAYpFovk83kymQzz8/NMTU3do3Ju9HOE5uVwOLDZbPIGTqVSJBIJarXaNl7tw6PRaDCZTFgsFvr7+zl27BiBQIDBwUF0utti0y3YgrX+VxRlVVdcuN09d2BggE6nI/f9breb0dFRnE6nvC/dbjcjIyPSEKjVah/atrEvhF3sn/V6PTabDZPJxHPPPcfjjz+Ox+NhfHwcm81GJBJBq9XSarWo1WrUajVmZmZkj+xisXjPSt5Np9OR/cdPnz7N66+/vupLWl5e5pNPPiGZTG7JHmqnMZlMuFwuLBYLZ86cYWBgQLoY9Xo96XSalZUVbt26xfXr10kkEszPz1MoFDZtn3C5XHi9XsLhMN/85jeJRCIMDAyQz+dJp9PE43FWVlb2rBpvNpvp6+vD7/czNDTE4OAgVqtVTvLdi8da20LBesdMJhOnT59meHhYtsg2mUwYjcZV96XNZmN8fByPx0N/fz9+v59SqSRjPzbDvhB2EeRhMBhwuVzY7XaefvppvvWtb2Gz2QgGg+j1+lUrdLVaJZ/Pc+3aNZaXl0mlUqysrNx3VhQ9tSuVCoqi8NWvflUKu6qqJBIJLl26RKlU2rM36f0wGAxyBXn55Zc5e/as1IgqlQrvvfceS0tLfPjhh7z99ttUq1VyudxDqYwOh0NOJq+88gpDQ0O0Wi1KpRL5fJ5UKkUqldqzK7vJZCIUChEMBolEIkQikXUXibX+796zr3XMaDRy9OjRe15/9+ssFgtDQ0M4nU5CoRButxtVVclms5u+pn0h7AaDAavVitvt5oknnsDn8zE8PIzNZsNsNkuVu1ar0Ww2icViTE1NkcvluHbtGolEgnw+Ty6Xu6+wC7Wz2yK/FnvdRbQeVquVkZER/H4/4XAYj8eDoijE43EKhQKzs7PMz8/LFbder2969RBqq8PhoL+/n3A4jN1ux2g0Eo1GWVpaYmZmhkqlsqdjFUwmE+FwmHA4vCpoZi2Bv/uYMMR1G3m7jb13v26tY3e/v16vZ3BwkNOnTzM9PU0sFtt0bMIDhV1RlD8FfhNIqKp66s4xD/BfgWFgDvgdVVU3P9VsEIfDQSQS4ciRI/yzf/bPGB0dXWXA0Gq1tNttMpkM+Xye9957j7/4i78gl8uRTCapVqu02+0HDo7RaOTs2bMMDg7i9Xr37b58PYLBIG+88QZ9fX2cOnWKvr4+FhcXuXDhAolEgp///OfMzMyQzWbJZrN0Op1NC7vwkgwNDfHCCy8QCoUIhUJYrVYuXbrEX//1X0tLfL1e37PC7na7eeqpp+jv7ycQCAD3BmvdvWdXFIVOp0OlUqFcLsv4DY1Gg8FguO/rxLG71f1uG9Urr7zC8ePH+bu/+zsuXbpEo9HY1DVtZGX/D8D/A/zHrmN/CJxTVfWPFEX5wzv//6tNffImECq8xWKRhqRuxGAVi0Wpri8tLZHP5ykWiw8cFDHzilhwj8cjZ3PhJ221WjImXBj99jrdN4rRaMTr9RIIBPD7/ej1eqlWJxIJVlZWSKfTZDIZuepuFq1Wi81mw2g04na78Xq92O12Wq0WlUqFTCZDPB4nm83u+SAanU6H1WrFZrNJg9xaiAlRRFW2220ZLCQMuXq9XrrxHgYxThaLRdpcNhIZes81beCD3lEUZfiuw98Dvnrn7z8D3mIbhb2b9ayd9Xqdt956i/fff5+FhQVSqRT1en1DN63ZbCYQCOB2u/na177GCy+8gNfrxWAwUKvVuHr1KslkkuvXr5PNZqXraS8j4reNRiPf+MY35Cp75swZ9Hq9DPKYnJzkgw8+oFgsSp/6ZgVdTJRut5tvf/vbjI6OcuLECR5//HFKpRLnzp0jnU7z/vvvMz8/v+HvZa9xtzFO7J3T6TSlUom5uTlKpZKMSejr6+P555/H5XLR39+Px+O5r2Hv7j0+IF2d9Xqd5eVlYrEYiUTioZJqHnbPHlRVNXbn7zgQfMj32TJarRbXr1/nnXfeWWV53wgGgwG3200wGOT48eMyAQagUqmwuLjI3Nwc0Wj0oVe9nUaojlarlSeeeIK/9/f+HiaTSQYFxeNxLly4wOTkJOfPn6dWqz20xiK2UjabjSeffJKnnnqKcDhMX18f8/PzXL9+nenpaaampkilUvs6a/Du865UKnJbcvnyZTKZDFNTU8zPz3Ps2DFpmPT5fA98r7WOtdtt6vU61WqVbDZLIpGgUCjsqLB3n5x6vxpgiqL8AfAHj/o5XZ+37mPCiAdQLBY3vPra7XaOHTtGOBzG5XKteqxerzMzM8OVK1eIxWLbmqa4FWMlAj3sdjsTExO43W76+vqkV6FQKMjMtenpaVZWVqShbLMCKKIOg8Ego6OjhEIh+vr6cDqd1Ot15ubmmJ2dlYa/fD6/ZYK+1ffVJj4X+PI+TCQSfPHFF2SzWaampiiVSthsNs6cOcPo6CgDAwN4PB4sFssD32utY9VqVWpcV69eZXp6moWFhYfSLB9W2FcURQmrqhpTFCUMJNZ74nYX8+/2Y4oAG7j9JWx0QHw+Hy+//LK0HndTqVS4cOGC1Bi2U9i3YqxESG8kEuHVV1+lr6+PEydOYLfbKZfLRKNRUqkUly9f5uOPP6Zer9NoNDYtgMJCrNfrmZiY4Lvf/S6BQIATJ04QCASYm5tjamqK6elpLl68yPz8/JZa33ejScRaRrWZmRl+/vOfUygUWF5ept1u88Ybb/DCCy8QDoc5deoUVqtV7tfXs8CvZ7QrFApcvnyZRCLBr3/9axknv5MRdD8FfgD80Z3fP3nI99kQ7XabRqNBvV6nVCpRLBYxGo3o9Xo5KBqNBpfLRTgcpl6vY7VaqdVqNBqNdQVUZGM5HA5cLhdOpxO9Xg9Ao9GgVqvJyLFyubxp6+duYLFY8Pv9BAIB+SOCQZrNJplMhlQqRbFYpFarPbQAajQa3G43DodD+qO7Y+qz2SzLy8vE43Eqlcq+GLtuhMHtQcErIonKaDTicrlQVRWv14vP58PlcmE0Gu8J2V4r8q77M0WBkGazSTKZlPv0bDYrcxK2JTZeUZQ/57YxzqcoyhLwb7gt5P9NUZR/wu1+Zb+z6U/eBKVSiVgshtFo5OLFi6TTaY4cOcLQ0JB8jslk4qWXXuLo0aNcvHgRRVHIZrPMzs5SKBTueU+NRiOz2E6dOsXExAR+vx+73Y6qqsRiMS5fvszS0hLxeFzuafcyiqJw9OhRvv71rxMMBnn++edlEgdAPB7n7/7u74hGo8zMzFCr1R56pTWZTLz++us89dRTDA0Ncfr0aemzX1xc5Ne//jV/8zd/Q6FQIJ1Ob+Vl7gj1ep1EIoFer6e/vx9Y26gmjHBwO9rNYDBw7NgxRkdH5YLU/dr7GehqtRrRaJRyucz8/DzRaJS5uTnefPNNstmsTCt+WNvKRqzxv7fOQ69t+tMekkajISOvYrEYBoOBUCh0T9aaCCfM5XIEg0E0Gs26iRaKouByuejr65ORSd0re7lcZmlpieXlZUql0r4wysHtNEwxcfX19a2yQVQqFebn51laWlplwFwrDwDWt48IFX54eJgnnngCv99PKBSiXq8zOztLMplkbm6Oq1evPpS6uRdot9vSXy60n7uj2+C2vaevr0/ekxaLhXA4LH3z9+Nu67soclEoFKRNZW5ujsnJyS1JA94XEXRCrclkMpw/f57Z2VmputvtdsLhsNw/KorC8PAwr776Kslkkk6nw8LCgkzuEANsMBgYGxvj+eefJxKJSH+qCKRpNptSfd/rbjaRRioyzAYGBnC5XDKQQxAKhfiN3/gN8vm8LJMkEn9arRaFQkFOrOKxVCpFo9GQamU4HObpp58mEAjw5JNPEolEaDQaXL9+nVwux7lz55ibm+P69et7ftzuRz6f58qVK6RSKalFCpUdvhRUn8/HsWPHZC0EkfizXrz8WnnvmUyGdDpNLpfj8uXLZLNZrl27xtTUFNlsdsu2QPtC2EX0WyqV4p133sFkMsnChX19fXi9XlkkUlRECQaD0iViMplYWlpaFf5pMpk4evQor776KmazGYfDsSroodlsSsv1Xl/VNRoNFosFs9ksLeOi8k43/f39fP/73weQ45DL5VhZWaFSqbC0tEShUCAWi7G0tCTDjcU4dDodRkZG+If/8B/S39/P0NAQPp+Pmzdv8vnnn7O8vMxPfvITJicnZfDRfiWXy/Hpp5/i9/t58cUXabVaq4JrhKCKIKVu7pdSvdaxTCbDjRs3SKVSnD9/nlQqJS3vDxPFuB77QtgFnU6HZrOJoiisrKwwPT1Nu91mdHSUdrstK8OKmnI2m43BwUFarRZms1nWj4PbxrlAICADT8SMWy6XpYFJlEza68KuqqrMcS4WiySTSZlFpdVq5Q0j/O4iTlukuooCH/V6HYvFIouCFAqFVRFhxWJRhhI7HA5p8FtZWWFhYYF4PC4zsvY7Qo0X28dsNovFYlml/cGXQV2wsaw38T2JegDNZpOFhQVmZmbkWIpkrK2+7/aVsHeHrn700UdcuXKF06dPy33S2NgYwWBQhjoajUZ++7d/W/oq5+fn6XQ6co9/5swZnE6nTFhoNpvcunWL5eVlrl27xuTkpBz4vUyn05GZeNevX+eXv/yl1HI0Go10rwUCAU6ePLnqpjWZTHJ/KcpvNZtNms0mtVpNJsWkUimy2Sx9fX0cPXoUo9Eoo/AuXrzIX//1X5PP50kk1vXC7iuEga5er3Pjxg18Ph/9/f2cOHECg8Fwj6Htfhlu3cdE2HC5XGZycpJ0Os3Fixf54IMPqNVqMstwO7IB95Www5dhiplMhkwmg8fjYWVlBb1eTyQSkdlGokpNJBJBVVUMBgN6vX6VsHs8nlXW0larRS6XIx6Py+KApVJpX+w9hdqcz+dZXl6W16soinRBij13o9GQsdqqqmKz2WReALBq8rPb7dTrddxuN5lMZpV1v1QqEY/HiUajLC8vS63oICAmPeHuLRQKsr79Zi3h3RNDo9GgWCzK7VIikWBhYYH5+XlpG9mu6MJ9J+x3E41G+clPfoLP5yOXy3Hq1Cm8Xi/9/f2rAhlcLpe0Ogs11m63oygK1WqVdDpNPp/n7bff5pNPPpF+YuFv3w+oqsri4iLvvvuujG5TFEUmaFitVj799FM5EWi1WhwOh0yMEaWWRA63yWSS/mKDwYDX60Wn01EulymXy7z//vu8//77xOPxfVMhdqOIQh8ul0uOgchgW8vIdr9jqqqSy+VkhV5xf12/fp1UKkU8Hpf5Fts5fvte2EVkkc1mk4a6kZERWQpaYLfbZReSu6uN1Ot1kskkiUSC8+fP86tf/Wrf3rSxWIxYLLbmY903Ybew+3w+jEajLJl97NgxHnvsMXw+H8FgcNXYVSoV0uk06XSaTz/9dF+P1f3oLvThdrvvqXGwEcObOCYi4bLZLJOTk7z99tuyJPfDFKF4WPa9sMOXKvji4iJ2u51SqSRX7oGBAXmjwtoFJ8Xv7p+DSPe1ilWkVqtJN5uqqjIVNp1Oo9frabfbq8ZMGD/NZrM0AopIs4OA0HqCwSCnT5+WrkxRBHIzxjhxrNlsMjs7y9TUFJOTk9LtudNRhQdC2OH26vz+++/z2WefSSNSJBLhH/yDf8Dx48fl89ZKI1wrxfCg02q1UBRFehxETr/QekwmE/V6/Z4tjF6vx+PxALd9zD6fj3K5TC6X29euNkAuEC6XizNnzvCP//E/JhQKyeYjYmu0UWNcdzLLL37xC372s59RLBZJp9Oyms1OcmCEvdPpUCwWqVQqGAwGPB4PRqNxzdlzLaEWLhTxcxgEX2gxQkiFwLfbbWnAE6tUtyAL15woqbzXXZMbQQiy3W7H5/MRCARkzH93zMLD3BuqqlIqlWSdfGHo22kOjLADq6rIdEfUPQhRCUeUDrZardISe1gQgTkGg4EzZ87w/e9/XzZ3BOQqL0ot6XQ6hoeHOXPmDLOzs6TT6X2X7CIQ+3Or1crrr7/Oc889RzgcluW07s5Y26yBTqvVEgwGGRsbI5FI7FrsxoESdrH6iAHuXpnuh6Lc7v4hovBEOd/tdIPsNUSAjcViYWBggLNnz2IymeT1C9+vqqqyf57X62VwcJBCobCv6/XpdDrZFef06dN8/etfl0FZ613XZgx0Go0Gh8NBMBikVqs9VEmpreBACbvA6XRy5MgR2YTvQej1ehwOB6qqcvLkSWq1GktLS1y/fl1GOx1Uoe+uMvPUU0/Jwp5arZZCocDk5CSlUmlV6SlhqBICYTKZdu0GfhTE/tzj8ch4f9FqqTs0djPGuLWO6XQ6RkZGqFarWCwW2Xdgp410B1LYg8Egzz33nKwr9yBE6KzT6eTrX/86R48e5YMPPmB5eVm2g9oPgTUPg1arxWg04vf7+d73vsdTTz1FKBRCq9WSSqX4q7/6KxYWFmR24PDwMP39/dIv312cc78RCASYmJhgeHiYv//3/75MIBLXs5nIuPsdMxgMnD17liNHjuD3+4nFYmQyGWZmZnrC/qgIo9Naeb+isZ6IpRdx8aIKqAgy8Xg8crXfSBnq/YqoBOvxePB6vasMmyLYKJlMYrPZsNvtMq9fbH1EG6n9hBBkq9VKMBiUi4LT6VzV2mutslHi+GY0PUVRZEVY4cozm82riqLuxB5+I8UrBrhdRjoIqMCfqKr6x8oO147fDNlslqtXr5LJZIhEItJVJB575513yOVyPP744xw7dmzVTdvdYmd2dpZEIsGnn37KysrKLl7R1iMiwYaHh2Wa78TEBMFgUObyiz5vs7OzGI1GrFarLJ6gKIpsfikiy/YDYpLS6XQcO3aM3/zN35Rtqrr36GuViLrfsfsZ6DQajWxo8uyzzzI4OEg8HudHP/oRV69e3VC3oq1gIyt7C/iXqqp+qiiKHbioKMovgf+NHawdvxlEHrbBYLgn2KNWqzE/P08ikaC/v19m0QHS9WK322V9etGq+aDRbTgaHR2VHWIsFovMZxfZXt3lkERIrIjCMxgM962rvhcRrkOv18vY2JhsOtmdJ7ER7t663M9oJ7xDomlGNBrl3LlzsjLNTrCRSjUxIHbn76KiKNeBPnaxdvxGWWvwRYZYPp+nUqnQbDbXrNSyH/egm0EY3JxOJ8PDwzLdV8TXf/TRRywsLMgsLJEKK1ZxERnWPQHsB4xGI8eOHcPr9XLkyBE5wYmtyP3KRq117GGNdmv9vd1sakpWbjeLeAL4mD1YO76b9WKY2+02xWJRpq42m81195wHWeBFVqDb7WZ8fByv1yvLHc/NzfGrX/2KVCol/eeiqaZQdYVrUuRk7xfMZjOPPfYY4+PjnDhxQiYBrbUPX0sQ13rOwxjtusOyd0rgNyzsiqLYgP8J/AtVVQt3zVTr1o5XdqG+tygMUKvV7jGsibhn0Yt9amoKl8slrdJi7y6qvrRarR1T43dqrLonwu4w2e5oOZEpJ1xzFosFj8eD3W6Xk2OtVqNUKj1S4cpHuIaHGithaxAuw+5CHnD/Gu7rHRPH1xsDoQWJMW02m+RyOVndd6fCjDck7Iqi6Lkt6P9ZVdUf3zm8odrx6i7U9y6XyywvL6PRaO6J7fZ4PHzzm9+UDSB/8YtfMD4+zne+8x28Xi/BYFB2IP3GN77B/Pw87777Lrdu3dr2896NsbrzWWtqQqKrjEajYWhoiDNnzsh012azSSKRYHp6+qHbET0KDztWOp0Oj8dDKBTCbrffI+x33nvdY4LNGO06nQ6pVErWR0in09IoVyqVdsz9thFrvAL8ELiuquq/7XpoR2vHb4ZWqyVjkNdb2W02G+12W2bKlctleUxEiQWDQSqVyoEz0D0oAag7R0Cv10trsgioEWp8tVqVRR32UxKMMNCJ67hbaB8GIdTdv8XxVqtFsViUpc4SiQTpdFpuI3fKrbuRlf0F4B8BlxVF+fzOsX/NDteO3wyiP9Za/cVFtJgIdNDpdLIvmd1ux2AwSNXVaDSu8rseJMQNJkpQCSObCDUWxRvEtkakeWq1Wllt5ebNm5w/f55sNrtv4hDq9To3b96k2Wyi0+kYHByUeRHd3/N62ZF3q/GiAlC1WmVpaYlyuSwbO4rntFotlpaWZJvqSqVCtVplbm5uVQWc7WYj1vj3gPWmvR2rHb8ZujtqrCXsosjkyZMn8fv9shW0qNsGX6qwQvgPGmJcREBH995R5Kzr9Xr8fj9Go5FQKITD4VhVT31+fp7Lly/v5mVsmkajwdzcHOVymf7+fiqVCqqqrvk9P8hAJ1Zt0XTx5s2bpNNpLly4wJUrV9YU9ge9/3ayvxykG0T0A8/n88zMzMi+1mJlEl+syWSSUVPCX7yeFf+gIdRNYTDqdp95PB4mJiZkRVqj0YjT6aTT6VAoFGSwUT6f3+Wr2DztdptcLgfA/Pw8165dw+FwMDg4iMVikf5wETnZ6XSoVCqyaGe1WpU19kV31Wq1SrFYZGpqimKxKMtwi/HsdDoP3bJpKzmQwl6tVkkmk9Trdf72b/+WL774gieeeIJnn31Wqqd6vV6WG+q2Rh90IReIVVw0hbBYLLKgxcTEBE6nE2BV+apGo8HCwgI//elPicVizM3N7eIVPBzNZlN2xel0OmQyGcLhMK+++iqBQACPx4PT6ZQLRqPRYH5+XhrVFhcXKRaLMvKtWq1SqVSkQIvf3e5IMXHsNgdS2IUaL4QeIBwOk0wmsdvtMlpKpMGuhYiH308BIw9Do9Egn89jMpnktsdsNuP1eqXtQkyApVJJNpWIx+NUq9VdPvvNI+IDAFlJWFEUGQ4tNJ5msymr5SYSCZLJJMlkkmg0Sj6fZ2FhQQr7fhmHAyns3bPylStXMJlM3Lp1i3PnznHkyBH+6T/9p4yMjKz7elW9XQ10cXGRhYUFSqXSDp79znLz5k1+9KMf0dfXxw9+8ANOnjyJTqfD5XKtqiE/OTnJ7Owst27d4vz586TT6R0tlrgdiLrworW06IDrdrtl+69ms0kqlZLxBOKYMLbtpyo9B1LYxcreaDRkg4fp6WkAzp49y+///u/L5663aote5rFYbN+Ukn4YVlZWyOfzDA4O8s1vfpOxsTFsNhsWi0XuWZvNJrFYjC+++ILZ2dl1O+PuN4rFomyYeOvWLRRFuUfYRZbkQahadCCF/X6k02l+9rOfrbKWrve85eXlA7GC3Q8hzLlcjnfeeYdoNIrJZMJkMq3af964cYOZmRmSyeS+LT/1IFT1drXdQqFAq9WSdQz2wn57K1B2cj+6k1Fh66HValfVFVsPYakWN/w2feEXVVV9aq0HdnqshEtSeCTujuMWwR/tdlu2MN5JVFVd13K6lWO1VujsfrPZrDdWh25lF40Ke6ym3W4faNvERulOUDloHLzQsB49eqxJT9h79Dgk9IS9R49DQk/Ye/Q4JPSEvUePQ8JOW+NTQPnO7/2Kj607/6H7PNYbqy+53zhBb6y6WXesdtTPDqAoyoX1fMv7gZ08/95Y7c3P2g524vx7anyPHoeEnrD36HFI2A1h/5Nd+MytZCfPvzdWe/OztoNtP/9H2rMrivJN4I8BLfD/qqr6R1t1Yj169NhaHlrYFUXRAjeB14El4Dzwe6qqXtu60+vRo8dW8Siut2eAKVVVZwAURfkLbreEWlfY90LW2x4jpaqqf60HemO1mp3KejsIrDdWj7Jn7wMWu/5funNsFYqi/IGiKBcURbnwCJ91UJnv/qc3VhunN1abZ9uDanary8l+pDdWG6c3VpvnUVb2ZWCg6//+O8d69OixB3kUYT8PHFEUZURRFAPwu9xuCdWjR489yEOr8aqqthRF+efAz7ntevtTVVWvbtmZ9ejRY0s5dDXo9hh7pgbdXqdnjd8422GN79Gjxz6iJ+w9ehwSDl112R5ro9Pp8Hg8mEwmzGaz/Onr68NkMq16rqIotFototEo2WxWtoQSpaYPanXW/U5P2HsAYDAYGB0dxe/3EwgECAaDhEIhXnvtNQKBwKrnKopCtVrl3LlzXL16lcnJSd5//32q1ep21tjv8YgcSGHXarXodDq0Wq1sw6vT6Va1ZF6LTqdDtVql0WjIdrwHfZXS6/WYTCbsdjuhUIhwOIzP5yMYDBIIBPD5fLjdbvl80UShVqsRDAblyu7z+SiVSqTT6QMv7IqiyIYa3fea0WhEo/lyZ9xut6nVarLrjvi9W+3EDqSwOxwOIpEILpeLZ599lnA4LFer7i/jbur1OufPn2d2dpbp6WkuXLhwYFsdCUKhEKdOnSIQCPCtb32L0dFR2f7JaDRit9tXPV9Mfjqdjscff5yxsTHGx8fx+XwkEgl++ctfsrCwsBuXsmOYzWZOnz6N3+/H5/Ph9/txOp0cPXp01XilUimuXbtGqVQiHo+Tz+dZXl7mxo0bq1o67xQHTtgVRcFkMuHxePD7/Zw8eZKxsTH6+/sZGRm5r7CLzq9arZZSqfTAFlH7HUVRsNls9Pf3E4lEOH78OBMTEyiKsmqc1tJuNBoNgUAAv99Pq9UilUphsViwWq07eQk7htAIFUXBYDAQDAbp7++nr6+PgYEBvF4vzzzzzCotaHl5GZ1ORy6Xw2w2yxbPWq12V1poHRhh1+l0jIyM4Pf7GRsb4+zZs7hcLo4fP47X68Xlcm3oPY4cOYLdbqfT6XD9+nXy+bxsz3tQ0Gq1DAwM4PF4eOyxx3jppZfwer14PJ5Vvc6azSb5fJ5ms0mlUqFer2MwGGR/e5vNhtFolJPDQZocDQYDdrsdvV6Px+PBarXi8/kYGBjAZrNx7NgxvF4vDocDl8uF1Wq9x5Bps9mYmJigWq3S19dHqVRiYGAAg8FALpfj1q1b5HK5HbumAyPser2eEydOcOrUKR5//HG+8Y1vYDab0Wg0cpW63369+z2OHz9Oo9HgwoULJBIJaXg6KOj1esbHx5mYmODJJ5/k9ddfx2q1YjAYVq3ozWaTlZUVyuUyqVSKXC6HzWYjEolgsVjkPlVRFLRaLRqN5oFjvF8wGo0EAgGsVisTExOEQiGOHz/OSy+9hNVqxeFwYDAYVmlBd2uNDoeDkydPyv5xqqpy9epVLBYLsViMTCbTE/aHQVEUrFYrbrcbu92OwWDAYDAAt9XQcrlMsVik0WiQy+VW7ZmsVivBYBCDwYDRaESn02G324lEImg0GhYXF9f72H2F6NRqtVoJh8MMDQ3h9/sxGo3o9Xp5s4re9rlcjtnZWXK5HJlMhnw+j9PpRFVV7HY7LpcLl8slDVH1ep1Op7PLV/nwKIqC2+2Wq/XIyAg2m43h4WF8Ph+hUAi73Y7ZbMZgMKDX61e9dq3302q1q9R1i8WCx+OhWq2uev1OcGCEXavVEg6H5Sx8t0o5NTXFhQsXiMfjvP3226TTafnYqVOn+P3f/31CoZBUbwcGBnjjjTdYWlpidnaWeDy+05e05dhsNkZGRvB6vbz22ms8//zz2Gw2LBbLqlU5k8kQjUaZm5vjz//8z1lYWKBcLlOtVgkEApw6dQq/34/dbicYDFIul1lZWSGZTO5rDUir1fLss8/y3HPPEQwGeeyxx7BarVitVoxGIyaTCZvNtkpb3Cwul4tjx45hsViw2WxbfAX358AIu3CHOJ1OzGbzqplWVVWKxSJLS0ssLi5y+fJlVlZW5ON6vZ5MJoPFYpErvslkwu/3U61WpYaw39HpdFitVpxOJ36/n0gkglarXTUxqqpKrVYjm82STCaZm5tjdnZWrty1Wg23202r1SKfz1Or1ahWq5TLZcrl8j1uN7G6iffu/tlrKIqC1+tldHSUUCjExMQEFotFutYE3X3b17sWYfu4u9+7Xq/Hbrdjs9l23MZxYIRdq9USCAQYGRnBarXeM/POz8/z1ltvkclkKBaLqx6rVCosLi7S6XSIRCIEg0FKpRILCwssLS3tml90q9FoNHJ7I2IPum/Eer1Oq9Xi+vXrnDt3jng8TiKRoFar0Wq1ACiVSty6dYtYLIbFYuHy5cvMz8/zxRdfUCgU5B5Up9Oh1+txOBwcO3YMq9XKysqKtEjvRX+88DAcO3YMh8OByWRaMzaj0+lQKpVoNptkMhnS6fQqgRduS5vNRjgc3jOLxYERdo1Gg8fjob+//57HVFUlGo3y8ccfrym4tVqNeDyORqOhWq0CUC6XiUajxOPxAyXser1eCvvdq1W9XqderzMzM8O77767pieiUqkwNzeHTqejXC5z8eJFstkssViMVqslJwWdTiddoE8++SQ+n49r164xMzNDNpsln8/vOWHvXtmF/WatvXin06FcLstFYnp6WtoqFEXB4XBgs9mka7In7NvEetbg+6mOzWZT+kLFjV2v12V02G4EQGwHzWaTQqGA0Wgkk8mQyWQwGo1YLBbgtoCqqkowGOT48eMkk0kKhQKdTodWq7XK+NbpdKhUKmg0GiqVCu12e9XjOp0Os9mMw+EgHA4TDocB8Hg8xONxKTDFYlFGmYmJYrfpvofWup+azSbxeJx0Os309DQ3btxYJew+nw+Xy4Wqqhw/fnzHzvtBPFDYFUX5U+A3gYSqqqfuHPMA/xUYBuaA31FVNbt9p7m9lMtlZmZmqFQqUsUvFApMT0+zsrJCpVLZ5TPcGsSqnM/nmZycxOfzEQgEGB4eRqfTYbFY6HQ6nDlzBpvNxszMDKlUSgpmt4bT6XRIp9Nks1k6nc49CTAWiwW/38/AwABPP/00o6OjcuWfmpriZz/7GYlEghs3bkjtqVwu78m9/N1Uq1U+/fRTbt68yZUrV/j000+llqLRaBgeHqavr48nn3ySr3zlKzgcjl0+49tsxKT4H4Bv3nXsD4FzqqoeAc7d+X/XaTQaMvhjMzdNq9WiXC5TKBTkHiybzVIoFCiXy3tmxXlUhIusUqlIFb1UKq1albRaLXa7Xaqgdrtd5hfcTavVotFoyPHpDq4xGo1YrVZsNpv88Xg8hEIh+RMMBqVBVfis9wvtdptWqyUnqWKxSDabJZPJSI2wVCpJjajbqNdqtXYlO/CBK7uqqu8oijJ81+HvAV+98/efAW8B/2orT2yzNBoNLl26hNPpZHBwkNOnT294ryRWvHg8zr//9/+eH//4x8RiMW7evCmtzQeBdrtNpVKh0+nIvfbTTz/N0NDtLr96vV7uOXU6HRqNhmeeeYZgMMgXX3zBjRs31nxfrVYrbQAWiwWDwcCRI0c4deoUfX19GI1G2u02Op0Og8HAwMAA3/72t8nlctjtdq5cucLS0hLFYnFf+OktFgsvvPACx48fx+Px0G63yeVyzMzMyACsYrEof2w2GyaTCb1eT6VSIR6Ps7KysuNuyofdswdVVY3d+TsOBLfofB6aVqsl3WoajYYTJ05sWNgbjYb0uy8vH9wCuZ1Oh0ajQafTYW5ujnK5TDAYpF6vr7I8m81mLBYLjUaD0dFR9Hr9fZNbhOFPuJVMJhPBYJDh4WH8fj86nY52u42iKDJv3u12Uy6X5bZC7P/3Gqqq3qNxGI1GxsfHabVaJJNJbt68idlsZmlpiWq1SrPZpFqtUq1WqdVq1Go1OT4iWCmfz++4xvjIBjpVVdX71QBTFOUPgD941M95EBqNBqfTSTAYxOFw3HPjiCi5UqlEoVDYk6r5To1Vp9ORtonZ2Vk+/fRTvF4v4+PjuFwuOXZms5mxsTGcTidLS0vSDVcoFFZZ0sPhMOPj4zIyz2azMTQ0xMjICHa7fZUbS3y+2AI0m02p1m6G7RirTqfDwsICn3zyCU6nk/7+fkwmExaLBaPR2P3Z0pPR39/Ps88+Szwep1qtkkql5HZpeXmZX//617jdbvke8Xic6elp8vk8ZrOZoaEhHA4HTqcTvV4vA5xyuRzFYpFCocDS0tKWZF8+rLCvKIoSVlU1pihKGEis98SdKuav1WoJBoOMjY0RDAZXuZVEGOTY2BiZTIapqak9Kew7NVadTodkMkk6nZYuJhHvbrVaZe6/w+Hg2WefpVqtUigUqFQqZDIZZmZmVqmgp06d4rd+67fwer0y8UjkeYvVvDu4RAiDUHkbjcam97DbMVbtdpsvvvgCgMHBQV588UXcbjeRSGSVsANyjE6ePMnw8DDRaBSDwcDy8jJXr15lamqK69evs7S0JGMOdDqdtCvp9XrC4TB9fX2Mj49z9OhRrFYrkUgEvV7PjRs3mJmZYWpqinQ6vavC/lPgB8Af3fn9k0c+k0dEpLYKNfJu1Uuj0WyogMVa7yvixu9+vTC2CCNMs9ncF9ZkuC3wwsqeTCbRarUkk0mZW+B0OtFoNNLX7PP56O/vx2az0el0Vgl7f38/gUAAt9uN2+3G6XTKx7pdnrVaTaq4wgAqgpz2QqEQVVUplUqsrKxgMplIJpO0221sNhsGgwGtViu3huIeEOPjcrkIhUKoqiqThoQGI+wVYjz1ej1Go5FwOIzL5ZKBXFarFb/fj16vJ5vNUqlUpEtYjN2j2DQ24nr7c24b43yKoiwB/4bbQv7fFEX5J9zuV/Y7D30GW0R3bPzdFUMeBb1eT39/P3a7Hb/fTygUkl90p9MhHo+TSqWkurXffPKJRIJPPvkEl8uFTqdjcHCQp59+mhdeeEFmshmNRp599lnGx8elsHar3WL7ZDAY7sln754Qp6ammJ+fJx6P89lnn8k0T6EC77a21el0mJ+fJ5VKMT8/T6FQwO128+STTzI8PCyDtsRKLdR5kSH3+uuvU61WOX36NHNzcyQSCS5fvkyr1eLYsWOEw2GZrGUymeT/4ker1cqFymw2Mzo6isfj4erVq8RiMeLxOIVC4aGvbyPW+N9b56HXHvpTtwFFUbBYLDJv/e7VW7iF1jq+3vsBUp31eDz09fUxPDwsJ5J2u41Go5GuFa1Wu++EXRiSyuUyU1NT1Go1hoeHpWFKjEN3YMyD6F6hu/fn6XSaxcVF5ubm+PTTT8lmsyQSiXvCl3eTQqFAoVCg2WzicDhwu90Eg0GZLh0IBKSQa7Va+bcQ2Ha7Ld2X8/PzRKNRGo0Gg4ODDA8P43a7CYfDMvdCBDTB6nEzGAy43W7i8Tgul4tyuUwmk3mkazswEXSNRoOPP/5YFrE4c+bMqn1WJBLh2WefZXFxkcXFRSqVCoODg0QiEfkcjUYjjSlWqxWXy4XRaMTn88mJxO12rxL2UCjE0tIS09PTzM/P77vQWhHW6nA4CAQCMo3zUUkkEnIlmp6eplgsMjMzw+LiItlsVq7me7XsV7VaZXFxkVQqRbPZ5Nq1awwMDLCwsIDT6eSxxx7D5/PdkwEn7EOKosgYhXa7LbMpzWazLIohDJbdiO1VKpUik8kwNzcnw7YfNbjrwAh7rVbj7bffZnJyktdff53jx49LYVcUhcHBQV555RVu3LjBO++8QzqdZnx8nGeffVa+h16vZ2xsTNarE26n7hXubkPT8PAwS0tLWK1W3nrrLfL5/M5f/CNgMBjkChYOhxkYGMDlcj1ygEssFuPChQtEo1HOnTvHysqKjIlXVVXuPXd7n74ewi0IMDk5iaIojI6OMjMzQyQSwefz4XA4VtUBgC/j6z0eD6qqcubMGYBVWmX3PdSNqqoyWCcej0sD3fz8PMlk8pHH6sAIu3AniZI/xWIRjUaDyWSSeyFhRBGz8rFjxxgYGFilsgeDQVnAQFQQvZtGoyHTOxcXF5mZmZGJIHsZ4QcXhiadTifHxOVySUObzWa7r7ArikKn06FQKFCr1eRN2Gq1KBaL1Ot1bty4wezsLIlEgmw2K2Pg9/oYdSMmJPG7VCqRSCTQaDREo1Hsdjtut1uW84L1BfluhOFSxD7UajUajQaZTIZarcbNmzflqt5oNLZkUjwwwt5ut4nFYqRSKYaHh5mcnMTv9zM0NITdbsfj8WCz2RgcHOTYsWPU63Xsdvsqg5KiKLJSzd1ZYd3k83neeecd4vE47733HhcvXqRcLu/5Vd3j8fDEE0/IstEul4uhoSEef/xxLBaLLLVkNpvXvXZxM7daLa5evcrMzIxUPYvFIp988gnxeJxsNitdRsVikWazueey3DZLMpmkXC7LxeDWrVs89dRTPPfcc5s2CHeHzS4vL7O4uEgymeT9998nmUyysLBALBajUqlQKpW25PwPjLADMkVTBCOYTCZarZasCCqKJfp8vge+11pZWN03dTQaZXl5mZmZGW7durVdl7RlCNek3+/H7XYzODiIx+NhbGyMkydProo2FOrk3VVmu+l0OmSzWaLRqByrfD7PjRs3pE3koCQQCUS5LlVVSSQSWCwWCoXCZuMD5H1Ur9dlJmIymSQajTI1NUU8HicajZJIrBu+8lAcKGEXlEol5ufnaTQaMu57M6iqSiwWY3JyUlrXVVVlbm6OqakpisWiNDrth/p0ovTU6OgoL774omz+INRQUSdNBLekUikSiQRms5mRkZE1LcaNRoOrV6/y5ptvSmt7vV5neXn5QCUPPYjN2DZExaR0Ok2hUODSpUskk0kWFxeZn5+nWCzKMOatWs27OZDCXi6XicVisnPJw5BKpbhw4YJMglFVlQ8//FDe3OLYXke4JN1uN/39/Zw9e5ZwOCxDWAVi7yhytScnJ+V+vlvY4fZ1N5tNpqam+Oijj2T2134Yj63kYYyYlUqF5eVlEokE586dk1V/lpaWtr1c14ERdnFTGwwGmWgh4o0fRC6XY35+nmq1KhtFzMzMMDk5KV1DqqrKiKr9cFN3R2uNjIwwNjYmO5YYjUbpIxYpryKWW7jIbt26JaPm6vU6DocDq9Uqb3CNRoPf72dkZESq8/t9T/4gXC4X4XAYj8fDxMQEg4ODeL3eTQl9qVRicXGRRCJBMpkkl8vJ6MHtvq8OjLCLCDqv18vExAQTExN4PJ57VqW1mJub44c//CGxWIy5uTnpW+0O4RRlm/ZDCibctrx7vV5sNhtvvPEGb7zxhrxZRYinqqrk83lmZmbIZDK8/fbbsu7e3NwcfX196PV6hoaGOHXqFOPj4/L9DQYDp0+fptPpcOXKFTkRHmTGx8f5zne+QyAQ4KmnniIUCm26cGQsFuPdd99lZWWFa9euye63O7GAHBhhF3XjPR4PLpdLWtrXcp3Bl6poq9Uil8sRjUZZWlqS4ZL7HeF2FGMSiURkkQiNRiMtwcVikWQySSqVIhqNygCOVCqF2WymUChQKpXuCX4RWYaBQACn0yk1hf2g9TwsRqMRr9cr/egul0tqjt2Lwv2iNIVhTvzsZFDRgRF2g8HA448/ztmzZxkZGeHo0aOyx/hadDodbty4wdTUFFevXuX69eskk8ltMYzsBkajUTaB6Ovrw+12y2SMVqvFrVu3SCQSXLlyRQYDLS4uyuw2UVOu2WxKw103olWWx+OhUqnw7rvvylbOB3WFF16KTqcjYxWEt0IsHp1OR7onRfJUN16vlzNnzrC8vCy/g53iwAi76F92+vRp2Vtcr9ev2gvdPcPGYjEuX74sjSQ72YpnuxFqvPCnizxpuG1JTyQSTE1NceXKFd5//31KpdI92xThUru72CTcHu9QKITb7ZYtjURt+YMs7CIP4m5B7i7KKYS9O35eIGI9RLLLTrLvhV2Ee3o8HoLBoKxrptFoqNfrLC0tUSqV7mnZrNFoiEQiPP7447RarR1vxbObtNtt4vE4U1NTxGIxKaCbVcFFaKdY7Q6yCg+3i3kEg0HZMqubRqPBysoKtVoNk8mEwWCQUZvdsQrdTSLW22JuF/te2K1WK0NDQwSDQcbHxxkfH5fJCdVqlQsXLrCwsMDTTz+N3+9fJexHjx6VRqednmV3E5Fu+tFHH8nGlZvN1hMRYKLgpAgUOcg4HA7GxsZkYlQ31WqVqakpcrmc9AQ5nU7sdvsqoTaZTPh8Psrl8o7Xk997Rb82icFgwOv14vP5sFqtUnWv1+uyMEM0GiWTycjKKN3VVA8jYn/5oIII3aro3ZF0qqpSrVbJ5/Oy7dNBX927a+0JY2Sr1aJer1OpVGQw0v3G4+6WUDvJRopXDAD/kdtFJVXgT1RV/eO9Ujve7/fz2muv0dfXR19fH6qqUigUpGX517/+tSxCOTAwgNPpZGBgAKPRSDKZJJlMsry8fGgivjaC0IxEeLHoittNs9nk+vXrsna6KBp5UPfr6yEi4ubm5vjFL35BLBbjm9/8Jn19fffs1+G2ViUKUe70WG1kZW8B/1JV1RPAV4D/XVGUE+yR2vEWi0UWBhBdMUU3F5FQMD09TTQaldlXrVYLVVVlTbVisXjoblK4v2Yj6r+LGnV3+5JFk4iFhQVSqZTsE3eQV/a1xkvkYmQyGebn55mZmSGfz6/Kc+82EgsPx26UMNtIpZoYELvzd1FRlOtAH3ukdrzZbCYcDsuCiXA7JLG7T5uohd7f3y8zu1RVJZfLsbS0JCuCHhZEYtB6zRn0ej0mkwmn08nw8LCsOttNq9Vifn6eS5cuEY1GD6xmJOIJLBaL3Kt3lz0TTSorlQput5tOp0MoFCIQCKzKHhQCn0gkuHjxItFodMezJDdloLvTLOIJ4GP2SO14s9nMwMAAQ0ND8qYVHVij0aiMjRc3rqjx1Wq1ZCWQlZWVA3uzroVI5RV9x9cSdhFPPz4+zvHjx9dUR2dmZjh//vyafviDgggL9vv9sihktxCLvXq5XJZ2o/7+fiKRyKq9udi/x+NxPvzwQ1nMYyfZsLArimID/ifwL1RVLXR/+ferHb8TtdDXUpm6faJ3zuOeEkJ3P2e32eqxEhby7ugu+PIGHhoaQqfT3WONF/XUQqGQLP4hEIa9QqEgX7cb+QI7VWMfkL3sxFh2X6uQA4PBQDgcptVq4XA4VqUHdycZCZV/zzaJUBRFz21B/8+qqv74zuEN1Y7fqVroB4GtHCuxNxR76U6nI0sjGY1GXnjhBY4dOybbXHULuyh1HAgE7lHfRXpvIpEgnU4/cnnjh2Wn7itVVanVapRKJVkBt3tyE8E1gUCAU6dOYTab5aou6HQ6UsBnZma4fv06uVxux+sVbsQarwA/BK6rqvpvux7aE7Xjhfuj2WxK66eYVUWjAhEmutZr7179DgrCvSZ+Wq2WHA+tVitVToPBIB8XiDFzu93SviFoNpuygaFotXzQxq6b9eIJ7hZ2s9ksi3UK21G3RiUmjFKpRLFYpFwu7/i1bGRlfwH4R8BlRVE+v3PsX7NHasen02k++OADFhYWZG1uEZJotVp57rnnGB0dlcE2AlVVSafTzM7OHsg9e6VS4caNG0SjUSKRiOyiOj4+jtFolO2YNBqNbNUsEJOlyWSSOe/iBk8mk3z88cfSAHoYhF3U1ctms5TLZYxGowzC8vl8nDx5UvawE3747te3Wi2i0Sizs7PEYrFds29sxBr/HrCej2bXa8fncjk+++wzVlZW8Pv9hMNhLBYLkUgEu90uG+mJeGSBSO9cWloinU4fOANTrVZjZmYGvV7P8PAwXq+XoaEhGWMgfqxWK4FA4IHvJ5JAstksly5dkl6Mgx41p6oq5XJZtvSuVCqyPjwgu+Dc7/WtVotEIsHMzMyupgLv+3DZZrNJLpfDaDTKvuqtVgun04nRaKRer+Pz+fB6vTLjq1wuSx97JpO5p1HhQaLT6bCyssL169epVCr4/X5ZOddgMMh6+PcrmCjqmAu/ejqdJp/P79ma79uFKBtVrVbvKVa6FuVymZWVFQqFAlNTU0xPT7OysrJrE+S+F/ZyuSwDGUZHRzGZTLjdbkZGRmT8e6fTkb7RcrnM/Pw82WyWmzdvcvPmTZnZdRBpt9tcunSJGzduMDg4yPLysmxW6Ha7GR4e5vHHH78nsePu97h27RoXL17k1q1b3Lx5U06qh4nl5WV+9atf0dfXRzAYfGDh0kQiwZtvvkk8HufnP/85V65ckVb53WDfC7tYqQ0GA+l0mpWVFTQaDaFQSJZm6na5dTodKpWKNJIchtppotKr2WyW5YkVRaFer2M2m2U31/UQaqgo1S1Kdx02arUa2WwWi8VCpVKhXq/fk8baXSK6VCqRTCZJJBLSGr+b7Hthr1QqzM3NEYvFyGaznDt3jmPHjvH888/L+ujCOOX3+2Vjh2g0eqDy1zdCLpfj008/leq70WjEbrfLFsvrIRpYiuIe+63F1VZRqVSkge3q1as0Gg3ZRac7eGZubo6lpSWmpqY4f/48yWTykfu0bQX7XthFw0CAaDQK3K4MK8oxNZtNPB4PBoMBn88nI+eSySSVSuXAr+rdVCoV5ufnd/s09i3C2KvT6VheXpYhx/39/avcbKlUSu7RZ2dnyWQye6IC0r4X9rXIZrNcvXoVq9VKNBqVgu/3+8nn83z22WdkMpkDUWuux84h2n61220+++wzuXp//vnnq5p9zs7OsrS0JNX3vVJHX9nJlW2nIui0Wu2q/tndobKiGUJ3yaVd5KKqqk+t9UAv2nA1qqqum6K3U2PVHbAlGjqKPXs3ooKPiGLsbmS5E6w3VgdyZW+32wfWldZj9+jOudgLK/Vm2feVanr06LExesLeo8choSfsPXocEnrC3qPHIaEn7D16HBJ22hqfAsp3fu9XfGzd+d+veXxvrL7kfuMEvbHqZt2x2lE/O4CiKBfW8y3vB3by/HtjtTc/azvYifPvqfE9ehwSesLeo8chYTeE/U924TO3kp08/95Y7c3P2g62/fx3fM/eo0eP3aGnxvfocUjYUWFXFOWbiqJMKooypSjKrvSG2wyKogwoivKmoijXFEW5qijK/3HnuEdRlF8qinLrzu/1Kw4+3Ofuq3GC3lhtht0aq1UdVLbzB9AC08AoYAAuASd26vMf8pzDwJN3/rYDN4ETwP8P+MM7x/8Q+P8e5nHqjdXeHytVVXd0ZX8GmFJVdUZV1QbwF9xuDrlnUVU1pqrqp3f+LgLdTS3/7M7T/gz4rS382H03TtAbq82wS2O1o8LeByx2/b9059i+YAebWu7rcYLeWG2GnWyW2jPQbYC7m1p2P6be1rl6Lo079MZq4+z0WO2ksC8DA13/9985tqe5X1PLO4+v29TyIdmX4wS9sdoMuzBWOyrs54EjiqKMKIpiAH6X280h9ywbaGoJW9/Uct+NE/TGajPs0ljtnDX+joXxW9y2PE4D/5/dtopu4Hxf5LYq9QXw+Z2fbwFe4BxwC/gV4DnM49Qbq/0xVr0Iuh49Dgk9A12PHoeEnrD36HFI6Al7jx6HhJ6w9+hxSOgJe48eh4SesPfocUjoCXuPHoeEnrD36HFI+P8DSre7ZPllhdgAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD7CAYAAACscuKmAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAB1uklEQVR4nO39WXBcWXbej/5OzvM8Yh5JguBUxRpYY3dVdVe3Wt1uKSwrLDkk2eGwrLAdcR2hB+v6Pvi+Xd374AhH+En+S39ZctuWZA3dUnd0d3UNZI1kFUeQIEECIMac53k+94HcuxIsksUiARAA84tAAMhMZJ6zsdfea6/1rW8pqqrSQw897H1oHvcF9NBDD9uDnrH30MMTgp6x99DDE4KesffQwxOCnrH30MMTgp6x99DDE4JHMnZFUb6tKMqcoijziqL8wWZdVA899LD5UB42z64oiha4DnwTWAM+BX5DVdXZzbu8HnroYbOge4S/fQ6YV1V1EUBRlP8NfB+4p7EritJj8GxESlVV/92e6I3VRqiqqtzrud5YbcS9xupR3Ph+YLXr97Xbj/Xw4Fh+3BfQw5ODR9nZHwiKovwu8Ltb/Tl7Ab2xenD0xuqr41HO7C8A/29VVb91+/f/J4Cqqv+f+/xNz93aiLOqqj5ztyd6Y7URPTf+wbEVbvynwKSiKKOKohiAfwr86BHer4ceethCPLQbr6pqS1GUfwf8DNACf6Kq6pVNu7IeeuhhU/HQbvxDfVjP3boTPTf+AdFz4x8cW+HG99BDD7sIPWPvoYcnBFueetsJUBQFt9uN1+vFaDTicrnQ6/XUajUajQb5fJ6VlRUajcbjvtQeetgy7HljVxQFRVEYGBjg2LFjuN1uDh48iM1mI51Ok81muXHjBqlUqmfsPexp7GljVxQFg8GATqfD6XTi9/ux2Wyoqkqj0cBkMuHz+UgkEuh0OhRF4UnW5NPr9Wg0GnQ6HQaDAUVR0Gq18rtWq0Wj0aDVagHkWDUaDarVKq1WS37fbVAURX4X86DT6dzzdRqNBkVRMBqNmM1mtFotJpMJjUZDp9Oh3W7TarWoVCp0Oh1UVUVVVdrtttxUtnuu7Wlj1+v1DA0N4XQ6OX78OF//+tdJp9O8/fbbZLNZXnvtNZ577jkajQY2m41SqUSz2aTdbj/uS9926PV6AoEAVquV/v5+hoaGMBqNOBwODAYDXq8Xp9OJ2WzG5XKh1WppNpu0Wi1u3rzJ+fPnyWQyfPbZZ8Tj8cd9O18JiqKg0+nQaDSYTCYMBgONRoNisbjB4MVCKAxbr9czNTXFkSNH8Hg8TE9PY7fbKRQKlEolIpEIZ86c2TCv0uk0a2trtFotms3mthr8njZ2rVaLw+HA6/USDAbp7++n2Wyyvr7O2toaL774In6/H5fLhdFoRKfT7cpd6WEgdijxs06nw2az4XQ66evrY2JiArPZjM/nw2QyEQ6H5WIQDAbRarXU63VarRYzMzMUCgWsViuzs7uv6FHcv1arxWg0YjKZUBSFSqUid2T4orEbjUbC4TAHDx4kGAzy8ssv43a7SafT5HI55ufnicfjZLNZOVbtdptEIiF3+e7FZKsNf9cZu5ik9xsYrVaLXq/HbrczPj7O4OAgtVqNd955h1gsRjQaJZ/Pk06nicfjVCoVPB4PrVaLRCJBsVjcrtvZVnRP0omJCQKBAHa7HZ/Ph9FoxOPxSAMPBoPo9XqsVis6nQ6Hw4HNZpPuvXg/RVEIhUI888wzxONx1tbWMBgMZDIZUqnUjj4WiSOJy+Xi2LFjuFwuwuEwPp+PfD7P8vIy5XKZ1dVV0uk0TqeTYDCIzWZj3759eDwehoeHGR8fx263YzKZADCbzQCMjo7y2muvyaNNp9NhaWmJUChErVaTC0Cz2aTZbFKr1UgkEjJw3Gw2N/V+d5WxK4qCRnMrWyjOQXeDVquV7uaBAwfYv38/Fy9e5NSpU+RyOVZXV2k0GiSTSSKRCJVKhUAggE6no1Qq7Vlj1+v1OBwOHA4HL7/8MkePHmVgYICDBw9Kz0aj0Ww4l3efZbu/A+h0t6ZPf3+/jH0sLy9jNBq5fv066XR6Rxu72MkDgQDf+MY3GBkZYWpqirGxMRKJBBcuXCCTyXDy5Enm5ubkWPn9fr75zW8yPDwsx0uc9QEsFgtmsxm3283Y2NiGz5ybmyMYDFKpVOQiUKlUKJVKZLNZLl68SC6Xo1gsPlnGLiafy+XC7XZ/wdiFwXcHQDqdDiaTCZvNhsfjweVyYbFY5I5msVjwer20Wi0sFosMsvh8PvR6PYVCQf7jxFf3P1N8vkajQVVVyuUylUqFVqtFrVbb0ZPbaDQSDAZxu92EQiGCwSAej0fu3mIcxY7T6XTkhLPZbFitVhqNhrzfYrFIrVbDbrfj8XiwWCz09fVRqVRIp9Po9XqazeZdA107AXq9HrPZjM1mw+v14vf7sdvtGI1GrFYrPp8PrVYrH2u322SzWQBWVlbodDpYrVZsNtuG9+0OZBqNRjlnAOx2+4advd1uU61WpXdZq9XI5XKsr68Tj8c3dV7tWGPXarU4nU5MJhOvvPIKb7zxBlqtVt60OO+0Wi05aGKSWiwWeQ4PBoNYLBb6+/uZmJig0WgwOjoKwNjYGGazmXA4jMVioV6vMzo6SjKZRKfTodfrpZcgfjcYDGg0GgwGA51Oh5mZGebm5sjlciwtLe3o9F0gEOCNN94gFArx8ssvMzk5icFgwGQy0W63yeVyVKtVcrkc6XSaWq1GKpWi3W5z/PhxpqenyWQyzM7Oks/nOXv2LMvLy7z88sv85m/+Jm63m2984xs8//zzaDQaZmZmqFar1Gq1HWnwNpuNcDjM8PAwhw4dYnJyUrriDoeDQ4cOUSgUuHLlCmtra+Tzeebn59Hr9czMzOB0OmWATnhC4n0tFgt2u53+/n4MBoN8Toz9nZtVp9OhVqsRi8UolUq89dZbfPzxx5s6r3assYugicFgwOfzMTk5iVarpdFoyNSGMPZarUa73aZWq9FqteRKLc7uwjitVqvc3RVFwWq1otFoMBqNeL1ems0m5XJ5Q/pJq9XKnc9kMmEymeTZt9PpEI/HWV9fp16vb1jBdyJMJhPBYJC+vj58Ph8ul0sGisS9l0olMpkMiUSCarVKLBaj1WoxMTEhU2uZTIZ0Os3S0hLXr19nYmICVVUxGAzSc/B4PBgMBprN5gbXfydB7Lxidxc7dKfTkcFdRVEwm83SS0kmkyiKQqvVwmq1YrFYZMASbs3ber1OvV6n0+ng8Xg2LHSKosj3FUcAgUajgd1up1wuMzs7i9vtptVqbdq82rHG3ul0qFQqMl+p1+vJ5XK8/fbbcsDh8yCLoigyHTI0NEQgEABgbW2NcrlMKpWiXq9viKw2m02q1So6nU66W51Oh2q1CtwKAnb/U0KhEP39/XKXF25usViU+dSdCJ1Oh06nw+VyMTo6ysDAgOQbrK6ucuXKFXK5HJcvXyaVSlEqlWS6SCx+4hyaTqdZXl4mn89TrVa/MGHFAisWXL1eLz2vnQaRXstms6ytraHX6+VzFosFv3+jYphY7NrtNu12W7Iwl5eXN8Q0zGYzJpNJvoeIbSiKgs/nY3h4GLvdztTUFF6vV76/ODIYDAampqZoNBrMzc2xuLhIrVZ75PvdscauqqrcscXAlkolTp48yY0bNyTJw2AwYLfb0ev18sxltVrRarV0Oh1isRjJZJJ6vS53GbEKC6/AbDbLXbzT6cjjgPAiWq0WqqpisVgYHBxEq9XKM26r1aJcLu/o87rwUhwOBwMDAwwMDGCxWACIxWJ89NFHxGIxPvjgA9bX12WEGJA79uDgIOFwmHw+TyQSkffcHZgS3piiKPIopaoqqVTqsd37/dBsNqlUKhQKBWKx2AZ32+Px4PF4NrxeHBVF3AIgGo1y6dKlDa/T6/XyS3iPApOTkzz//POEQiH6+vq+YOwivjQ+Pi7nWPd1PQp2tLELF7NarZLP56nVapIJVyqV5G4qgmxarVa6YplMhkajwcrKCpFIZMMEFguFSHc4nU4ZgEkmk6yurqLX6zEajRgMBvr7+7FarZIw0W63KZVK1Go1VlZW5M87dWcXxxLhwRgMBkqlEoVCgUgkwtLSEqlUinK5LHPB3QtXp9MhGo1y5coVyuWyDBzZ7XZcLhd+v1/GUxqNBo1Gg3K5TD6fp1Qq7chdHT7fqdPpNJcuXSKRSMhFrd1uk8/nabfbhMNhjh07JlOV5XKZlZUVGTG/8zzdbrclC+9OzyeVSrGwsEChUGBkZIRqtYrH48Hn823wUoENQeLNwJcau6IofwJ8F0ioqnro9mMe4C+AEWAJ+HVVVbObckVdEBHhTCbDzZs3qVQqjI2N4Xa7pcsJUCgUMJvNTE9P09/fj6IozM/Pk8/nee+997h58+YGcoRwzQcGBgiFQgwODmK1WgGYmZnhk08+IRwOy1z0yy+/zPj4OFevXmVmZoZEIsGHH35IKpXaEIDaqZNaGLnFYsHpdGK1Wrl69SrRaJTTp0/z3nvvycj6nYYOt/4P586dY25uDrhl/BaLhe9973scO3aM8fFxeawRR5pYLMbS0pKMo+xEVKtV6vU6hUKBaDSKxWLhn/2zf8bw8DCNRoPl5WW0Wi3PPPMMX/va18jlcsRiMeLxOD/4wQ+YnZ0ll8uRyWQ2jFk3WaZer2/4zFKpxPLyMg6Hg2w2y8DAAC+88AJf+9rXpHe5mQbejQfZ2f8U+K/An3U99gfA26qq/uHt5hB/APyHTb86Pnfnc7kcnU4Hu90uI+TdO2mn08FoNGKz2eh0OuTzebLZLPl8nnw+/4X3VRRFEiE8Hg/tdlvuTuKsLlwxwZpqNpvk83kZwNqp7um90D2JRFCuXq/LnO/9uAvCbRfBSZHeFLudoigy3iG8LnF02qkQnqMI7hoMBtLp9Ib0q06nIxQK4Xa7ZXZGq9Xi8/nweDw0m00KhcIXFvvurFE3xGeJOepwOCiVSnL8xTFI1BuIQN9m4EuNXVXVU4qijNzx8PeBr9/++b8D77GFxr66usoHH3wgd1mbzUYqlWJubk66SoIt9/TTT3P58mXeffddstmszIveDZVKhUwmQ19fH3a7HZvNxquvvir59CJA88EHH/CLX/yCpaUl5ufnqVQqu4p4I9KTlUqFXC6H2WyWbLmVlRUGBwfJZrMy3XY3iN3K4XCwf/9+fD4fR44c4dChQ1gsFnQ6HcVikYsXL7KyssLCwsKOPdbcC61Wi5MnT7K0tITf7+fgwYM4nU7p0guX3Gq18vrrr3PkyBHOnTvHxx9/TKVS+UqVkwaDgeHhYQ4cOECr1eL06dNyDhuNRi5dusTp06eld7QZeNgze1BV1ejtn2NAcFOu5h7IZDJcv34dQAaYgsGgjHJ2M6GGhoaYm5vj5s2bZLNZGUi5E4I8IqLOJpMJh8PBvn378Pv9Mpqaz+f59NNPWVxcJJlMEovFdmwg7l64cxev1WpYrVYcDgd+vx+v14uqqhQKhXtOLOHxGI1G+vr65PFnYGBAPt9sNllZWeHq1auS/72b0Ol0mJubY25ujtHRUSwWCz6fD6fTKYOOgvtx8OBBma24fv06Op3uvhvLndBqtXi9Xhn0XFxcxOl04vV6sVgsrK6uMjs7SyqV2jTv6JEDdKqqqvfTANsMfe96vS7d50gkIquT9u3bJ3+2Wq10Oh3W1tZIJpOUy+X7ukAineR2u3G5XDgcDux2u0z5pVIp8vk8xWKRtbU1uXBs5QTeKi10YeyZTIZLly6RSqXYt28fwWCQwcFBvva1r5FMJvn000+JxWIUi8UvHH1ElHhwcJCnn36aUCgkI8nCha3X66RSKSKRCIVCYVeOlUCpVGJhYUHWSgge/OHDh2V9gF6vZ3x8nDfffFMSborFIrlcjkKh0H2tWCwWjEYjtVqNcrmM3W4nn89LwoxYiN9//33gVuwoGo1uaoDzYY09rihKWFXVqKIoYSBxrxeqqvpHwB/BwwsDCkqqyWTi2rVrlEol7HY7L7zwAkajEafTKSvWZmZmuHnzJvl8/p7GKaKeosIrHA4TDAax2+2SEjk/P8+ZM2dkakak4bYSmzFWd0Or1aLVarG2tsbPf/5zgsEgDoeD4eFhpqenGRoaIplMYjKZuHr1Kjdv3txQ3qkoioy6Hzp0iF/+5V+WrMPuGu1SqcTS0hLXrl37QtBqs7FVYyWQzWY5c+YMOp1OpmZfffVVBgcHcTgcklX5/PPP89prr1EoFJiZmSGbzTI7O8vCwoK8f51OR19fn6yIW11dlWnhdDotWYzFYpGrV69SKBTIZDLk83k5vpuBhzX2HwG/A/zh7e8/3JSruQeEC1mv18lms5LS6Ha7ZcGBoijEYjEZkLtbVBluDbwgLvh8Pvx+v3TTutN8hUJBRqgbjcaOjbR/FdTrdTKZDBqNhmQySSKRkASYRqOB3+8nk8mQyWQwGAyS0KTRaLDZbDIo1c1lgFvklFwuRy6Xo1wuU61Wt71We7PRnVNvtVrodDoymQyxWIxKpSIrAMPhMA6HA41GQyAQwGAwkMvlNkThtVotoVAIp9NJq9UiEonI9K0QWDGZTBQKBbLZLIVCQdYfbCYeJPX2v7gVjPMpirIG/CduGflfKoryL7nVr+zXN/Wq7oFCocDHH3+M0+nkhRde4NixY9jtdsLhMLVajTNnznDq1CmKxeI9AyUul4tXX32VQCDA2NgYg4OD2O12arUahUKB2dlZPv30U9LpNMViUab/9gIEz9tqtWIwGLh8+TKHDh3i9ddfx+128+KLLzI5OYndbpfHFrFDT09P88orrzAyMoLdbken00le99raGmfOnCESibC4uLip58zHBVVVabVachPQaDRcvHiRcrmMxWKRtf2vv/46/f392O129u/fT7PZZN++fRu8SkHk0mg0fPjhh5w+fZpCoUA+n5eLgvi8QqEgRUE2Gw8Sjf+Nezz1xiZfy5eiXq8TiUTI5/M899xzUj0lFArJ0tSFhQXgi/XuIuVkNpsZGhpicHBQUkcByYRLp9OyGGEnV2w9DBqNhlzEbty4Qa1Ww+VyybRlX18fDoeD69ev43Q60Wg0FItFVFXF7/czPj4ud69u6aZCocDy8jKRSEQW0+wFdHMz2u02qVSKWq22YawOHToE3GLNCcZdMBj8wvsIVqbT6ZSko0wmIynhwhPdyvm2Yxl0d4MInonB63Q6Uh22WCxuWCUB6X4Kvvzo6CgOhwOfz4eiKFy4cIH3338fv9/P4cOH5UAbjcYvkCH2EtrtNvF4XEblfT4fDoeDcDiM1WplampKKrXE43Ha7TYvvPACY2Nj2Gw2dDodzWZTBrBEmkicM/cqBOOu2WwSi8WkGs3ly5dxOBz09/dL4YpudDodmb+PRCIkEgm5KArPcTs2lV1l7OKcI2iugqAgzjndhS7weZms3W7nxIkTvPnmm6iqSjqdplwuc+bMGd5//30OHz4s67rh1u5frVZ3bLXWo6LdbrO+vi457sVikWAwyPe//31cLhdHjx7l2WeflQIfzWaToaEhwuEwgFwIrly5wszMDDMzM5w6dUoSQ/YqRKATbh2JNBoNs7OznDt3jlAoJLkLd6LT6UihlJWVFZnx6AlO3gfdZa+CVij42M1mUxbFCIh6dpfLhclkolQq0Wg0iEQistpJBGGEK9V9vtrLEC5qtVollUqhKArRaBSz2UwgEMDpdKLX6+XYmM1mNBqNrBQTu5SQbNorQcwHgfAYhZSX2+2WzM57wWAwyKi+IOfcj7G4FdhVxi7KNEUdsUajka5VuVyWrCe4NZltNhvPPvssoVCIfD7PZ599tkH6J5fLSSMXQZFu5dC9urN3I5PJUK1WsdvtaDQawuEwr7/+OqOjo1KEUlVVWf6ZyWQ4d+4ciUSCt956i7Nnz0rX9kmByWTi8OHDhEIhXnnlFV5++WXJ9bgbNBoNfr9fKvmIFO92y27vKmMXBBqh0y1KTAWH2Gw2S6KHMHafz4fP56NQKJBKpUilUqyvr0uufbecleDEPwk7u0Cr1aJUKgG3DFmv11OpVGRdeneNN3we5EskEsTj8V0nG/0w6K4pEHPQ6/USCoUIBAJ4vV50Op1MVd6pSCvKhOHWEdFoNMpa+O3ErjJ2i8XCgQMHpArNwsIC5XJZUlhHR0c5fvy4FJWo1+usra0xPz/P6uoqS0tL0gu4MyjS/Q96kuByuejr68Pv9/O9732PiYkJWUt9N9RqNaLRKOvr6/ekIu8laDQaGc8RwV2Px8Mbb7zByMgIIyMjaDQaqtWqFEpJJpOk0+kNUtx9fX24XC58Ph8jIyNYrVZu3ry5rR7RrjJ2k8nE2NgYoVCIVqvF6uoqmUyG+fl5DAYDJ06c4JVXXpGGnkgkuHjxIpcvXyYWi7G+vn7PANKTauwOh0PKbb/xxhscPnz4vq8X4ypkq/Y6hOCpz+cjFAoxOTmJ3+/nlVdeYWxsTHqB9Xpdxi9EbYbb7WZiYgKn04nb7SYcDuNyuaTaUTQa3UCr3WrsCmMXQTmh5Gmz2aQCTbPZ3EBfFIYu8u6CattoNO5rzN169Hvd6DUaDV6vF5vNxsTEBEeOHJF0YVFeWa/XqVarrK6uUq/XZVajUqkwPDyMxWJhZWVFioTcmQnZ7dDr9bIeYGxsjIGBAbxeLwMDA1LMVFVVyYNPp9NSY2F1dVUacrvdlh6BVqulVqtJpaByuYzX6yWdTpNMJntNIgBZsBIMBmVnktnZWc6ePStz5G63G4PBICPFgg4q6s7L5fKXGns3UWQvp5AMBgOHDx9mcnKSo0eP8uabb8puMKqqUiwWSaVSrKys8Bd/8RdEo1GOHTvGgQMHcLlcvPbaazQaDbLZLOVymWw2SywW21PReIvFwujoKG63mzfffJOjR49KWqvBYMBms9FsNrlx4wbnz58nEonw1ltvEY/HpaBJ9wZVLBZZXV3FYrHwwgsv0Gw2OXDgALlcjg8//JB33nlny4N1u8LYjUaj5GN3nyU7nc4GMUTBnRf87Hq9LgsZGo3GlzZufJBuM7sZQmVXaOeLAiC/34/ZbJZlqqVSiVQqJTu8RCIRAoEAbrcbnU4nsyFCTkl00tkrxt7dS8Dn8xEIBAgEAlJ7UKPRyGh6NpslGo0SjUblxiL6uglt+Hq9Tjwel2Pe19cH3GLaWa1WPB4PJpNJppC3av7teGNXFIXh4WFeeOEFTCaT1DXz+/289tprUvtbURTef/99EokEPp+PoaEhNBoNr7zyCs8//zynT5/m/fffvysFtltBtntn32tG7/P5OHz4MD6fjzfffJNDhw7JnvWtVotoNEqxWOTjjz/mvffekxVc5XIZgNXVVQ4dOsTY2JisT5icnOTjjz8mmUzuCYqx0OqbnJzkd37nd+jv72dgYACPxyO9v2q1yuzsLMlkktOnT8t6jEwms+H+BcOz0+nw2WefsbCwwFNPPYXf78fhcHDgwAGMRiOVSoVsNksmk+Hq1asyO7Lp97Yl77rJ8Hq9TE1NyQlZr9dxu90MDAzIrh7VapW5uTnOnz/P/v37sdvtOJ1O9u3bh91uJx6P89FHH32hmZ6A6PoC928ttZths9mYnJwkHA5z+PBhjhw5IlONgomYSqWYmZnh7bffplqtSlZcs9kkHo9jsVgolUryvL9//34ymQwmk2lH6809KMTuLVSRhoaGgI3eXqfTIRKJsLCwIFmEd7tvUdwiOt0uLy/jdrslryEcDuPxeFhaWmJiYoJoNMri4uKTZ+x6vZ5QKITNZqOvr09qzrndbtlbXVEUstksV65coVgsEolEqFarJBIJZmZmZGthUcr6jW98g3w+z8LCgtT9qtfrG3Z2kbvfSy5pMBjE5/MxPj7O0aNHCQQCcqcSTSHy+Twff/wx6+vrskhG5IwBKcMdj8f57LPPCIVCHD58mIGBAQKBAJOTk6RSKZaXl3eVZFc3hK57IBCgv79fcgzEGAjhiWQyyY0bN7h69SrxePxLPRlRxqrX66WGgs/nk7n3cDjMs88+y8LCAp999hnpdHpL7m/HGrtgKQ0MDEi3UcgiddcaRyIR/u7v/k66UK1Wi4WFBbmK6nQ6mQ99+eWXWV9f56/+6q9YW1sjkUjITi6CQNLdWWYv7O5arZZ9+/bx1FNPMTk5ybe+9S3cbrfsbCMYcdFolL/6q7/i+vXrkovQff9ivBcXF/nhD39IIBAgHA5z5MgRxsbGeOGFF2QEercau0ajYXh4mKNHj3LgwAEMBsOGMSiVSqyurrK2tsZHH33E+fPnH0hCXDSOsFgshMNh9u/fLzcigP379zM6Osr58+f54Q9/yMrKypbc344zdtH4QXQUCQQC2Gy2L3QRrVQq5PN5crmcVDMVEK6TKCO02WxSckq06BXN9IrFolQNFTu7oNDuZohgnMFgwOPxEA6H8fv9sgVWtVqlWCySSCSIRCLEYjFZUHQv4Q9Rh1AoFGRASVVVTCYTPp+PRqPxBcbdboKovRAMt266tFCMqdfr1Go1OX8eZp7c2VhDbDRCukoIh2z2HNxxxu52uxkeHiYQCPDSSy/JZoxClrhQKFCtVjl79iyXL1+mUCjIANKdqFQqnDlzhsuXLzM+Ps7S0hImk4ljx47x1FNPcfr06Q28ZdGbTAgv7uad3Ww2y9TRq6++yje/+U2sVitWq5Vms8mnn37KwsICN27c4JNPPqFQKLC+vv6l0eBms0kul0On08nSYqfTyYsvvsjq6iqnTp2SmgJ7DUKRRzQsedDIuTi7i04yuVxOFtN0d3sRyjeil14ul9vU638QpZpBbmnGBwEV+CNVVf/LVjWKELxjv99PX18fAwMDpFIpmdoRZI9oNMqNGzckH/luaLVaxGIxAFng4vf7mZiYwG63s7S0hMPhkMotWq1W6qnt9kCTTqfD7Xbj9/sZGBhgdHRUxiUajQbRaJS5uTlu3LjB3NzcA2uUi/ZYIpdcr9cxGo309/fTarUwGo3bdIdbh3sRq8T8625p/VXes7vrcL1elxp+AkKm2m63b8lR6EF29hbw+6qqnlMUxQ6cVRTlLeCfswWNIoRRGo1G2Ysrk8nI4hXRhHBlZUWmOR5kdc1msywsLJDNZrHZbLhcLkKhEN///vfxer04HA5p5Dv9zG40GmXhhdhd7px4ovddOByWMlKidVMul+PSpUucO3eOZDIpq68e5H5Ffrn7Swh47naINlfd3IzNghgjvV4vm2yIYqtKpUKpVJLFRYlEYkvqDh5ElioKRG//XFQU5SrQzxY1iuhW8xQEj2QyyfLyMtFolJMnT5JMJr8yyy2dTpPJZKS4pM/n45d+6Zd49dVX5fk+m83SarV2dIGH6FYrSETdFXvdxmowGKS2uwgGVSoV5ubmiMfjnDlzho8//vgrSyG1220qlQoGg4FKpSJ/FiKguxmdTofV1VWSyaTM+mwWhLELUpMIkMKtwF8sFiMSiRCJRIhGo1uy0XylM/vtzjBPAad5wEYRD6rvLfLcoluJ0OrK5/NSF05ogD2Miy2MQQSYNBqNbMgogiH3ysFvFx50rMSOLq73bhNDtP8VTSsVRaHZbMrOL6L18ENco2wUKVohdXMUtgtbqbHfaDSkAGmxWJT6BkajEZfLRa1WY2xsTGrx34/XLjI9oVAIv99PKBRCr9dvIHAJJp4Qm3zsDDpFUWzAXwP/XlXVwh2Ryns2ingQfW9BTzQYDAwMDPDMM89gNBpJp9NEIhE+/fRTPvroI2q12iOfZWq1GvPz85jNZiYmJgiFQrLp4cNGVzcLDzJWQl1GBBDF4nTnBDGbzYyMjLB//34phJjP57l8+TLr6+tkMpmHukbRVlgUJImuuduNrdTYb7fbZDIZ2aNgbGxMds45duwY5XIZj8dDMpnkJz/5CX/9139911LV7pbiv/RLv8SJEydkb3aR5hVxpZmZGVmCvVV4IGNXFEXPLUP/gaqqf3P74QduFPFAF3K7ss1sNuN0OtFqtXJSCrGEzTDEdrtNuVyWUeVMJiN1w7ZbOeRh8SDjoNFoZG5X1BO0Wi1ZKPSwddSi1ZYoCOmWlN4LEB5grVaTcyMcDtPpdNDr9XKOjo2N4fV6OXfunAxK3i1uIhpg9vX1MTExgcfj2fD/EEfVdDot+x1sFR4kGq8AfwxcVVX1P3c9tWmNIrRarVw5zWYzkUiERqPB6dOn5TlmsyeT6B6Tz+dlbrXVarG4uLipn/O4UK1WuXnzpmw9FAqFZPBTKP18FYicfSgU4vjx41J33263U6/XKZfLu56b0I1oNMrf//3fS5Wj6elpWZMu+rRZrVaef/556e5Ho9EN6jM+n4/9+/fjdrt55pln6OvrQ6/XyzLsubk50uk0H3/8MSdPnpSpzK3Cg+zsLwG/BcwoinLh9mP/kU1sFKHRaHC73fT392MymUgmk7KdzuLi4pbUmHc6Ha5fv86NGzc2PL5TI/BfFUKlR1EUxsbGgFvjbDQaMRqND2XsYpd7/vnnCYfDsi5bBEv3Uk1BMpnk3XfflbXoRqORoaEhAoGApL06HA4OHz4smYgzMzNSjEIUcL322mt4PB76+/txu90b9BauX7/O8vIyn332GadPn378Ja6qqn4A3Cv6simNIkSjAZFyECkdQdnc4p5hW/bejxOtVotMJoPRaJQy20I/32w2k8vlMBqN5PN5eUS6cyxEIE6n0zE4OEh/fz9jY2MMDQ3Jarl2u006nWZ2dpbV1dVdS5W9E92MuZWVFWw2G/V6HZ/PJ3PhgukZCoWwWq0bMjmKosgaBHFGB2Sj0Ewmw40bN1heXiaVSj05uvGtVovl5WXW19dlikJEKffKWXC7Ua1WuXHjBqlUimPHjlEoFLDZbLz22mtSbWZtbY1Lly7xi1/8QgYnheimoHE6HA4sFgtf+9rX+NrXvkYgEGB6enpDnGN2dpYf/OAHknq7FyAq/YrFIidPnuSzzz7jxIkTskfgwYMH8Xq9BINBPB4PnU6HZ599dsN81el0Mp8uzumrq6v87Gc/IxaL8e6777K6uvpA/PrNwI4wdrhFRdzMvOaTDpEP1+l05HI5stmsjKQbDAaCwSCqqhKPx/F4PJLEJPqaCW69EFsMhUKyJFN02RHUZdHwMJVK7alOOmJ3F/cplI+Emo/FYpERd0VRsFqtd01BClGQdrtNPp+XqryZTGbTKbH3g7KdbuxWtNbd5Tirquozd3viUceq27CfeuoppqamGBoa4sUXX5QNDTQaDdFoVFa6CTadIMmYzWYGBgawWq0MDQ3JHLHRaKTRaPDBBx9w48YNLl++zDvvvEO5XJYCFpsNVVXvmcjf6nklFr9gMMj4+Dher1e2bxbVfyaTSS6ad6JerzMzM8Pa2hoXLlzgZz/7Gfl8nvX19XvWdTwK7jVWO2Zn72Fz0W63KRaLKIoi1XUPHz7M9PQ0JpNJtivq7+9ncnKSWq0ma9HNZrPUThsfH8discj3FTr9lUqF69evc/r0aVZWVojH43u2UYQIPsZiMTKZDC6XC6fTST6fZ2xsTJ7dRRn2nWi326yurnL58mWuXr3K/Pw8lUpl28erZ+xPAKrVKrlcjps3b/L222/jdDqlOy6KWkTzB7Gzi1x6IBDYsFt1M8zOnTvHysrKtgWYHjdE9Vq1WmV+fp58Pk80GmVhYQGj0YjX691QxSbQaDSYmZlhfX2d1dVV2Spru4PDPTf+8WLL3Pg73msDN1u4pXfKZ3d3xRF/d68UXXcbYqEBsJV4nG78XT5vgwaC6Dt4vy5C4swutBa2OMPUc+OfVIhAk9iVe3g0iBqL3YYno6FZDz300DP2Hnp4UtAz9h56eELQM/YeenhC0DP2Hnp4QrDd0fgUUL79fbfCx+Zd//B9nuuN1ee43zhBb6y6cc+x2tY8O4CiKJ/dK7e8G7Cd198bq535WVuB7bj+nhvfQw9PCHrG3kMPTwgeh7H/0WP4zM3Edl5/b6x25mdtBbb8+h/pzK4oyreB/wJogf9LVdU/3KwL66GHHjYXD23siqJogevAN4E14FPgN1RVnd28y+uhhx42C4+SensOmFdVdRFAUZT/za0uMfc09l7V2xeQUlXVf7cnemO1ETup6m2n415j9Shn9n5gtev3tduPbYCiKL+rKMpniqJ89giftVex3P1Lb6weHL2x+urYclLNVnXu2IvojdWDozdWXx2PsrOvA4Ndvw/cfqyHHnrYgXgUY/8UmFQUZVRRFAPwT7nVJaaHHnrYgXhoN15V1ZaiKP8O+Bm3Um9/oqrqlU27sh566GFT0dOge7zYFg26vYBeNP7BsRXR+B566GEXoWfsPfTwhKBn7D308ISgZ+w99PCEoKcbvweg0WhkC2Hx1Y1SqSS7tNbr9T3bpno7ITrdCmi1WtmxVXwB8rt4vejNLlpKbSd6xr4HYLfb+da3vsXIyAjDw8OMjo7KSdZqtTh58iRnzpwhnU5z48aNPdVp9XFAURQMBsOGjjAOh4ODBw/icDiwWq2YzWbZgUer1WI0GtHr9czOzvL+++9TLpcpl8u0Wq1tu+49Z+x3a5l7v9fcucvtxl3PYDAwPDzMoUOHmJqa4ujRo9LYm80mqVSK1dVVVFVFp9M9lLHfqxXxk4A7712j0aDX69HpdGi1WrRaLXa7nYGBAbxeLw6HQ7a1FkYvOupWq1XOnj1Ls9mkWq1u633semMXPbb0ej3Dw8N4vd4N/be6e5uJldbtdqPX66nX67KxYSqVolarsb6+TjabpdPp0Gw2ZQ+0boguqKJ1sWh0mMvltrzn2d3QbDZZX1/HZDLh9Xqp1+uyF5miKAwPD/P8889z/fp15ufn6XQ6srng/SAmqV6vZ2hoiHA4LBsbtlotEokExWJRvl50jt0L3VxNJhNutxuDwYDP58Nms2E0GjGbzej1eux2O0ajEZ1OJ38/cOAAdrsdk8kkd3S9Xi/np1arZWlpCYvFIt357cSeMHadTofZbObQoUMcOHAAnU6HwWBAp9NhtVrlz+KfMjk5idVqJZfLUSgUSKVSzM7Oksvl+Oijj2i1WjQajQ3NDrt3MbPZzMTEBE6nk2KxSLlcJpvNUiqVHpuxr6ys0Gg0GBoaolaroaoqRqMRjUbDxMQELpcLi8XC+++/T71ef6BmjDqdDqfTidVq5bnnnuPZZ5+lVquRTqepVCqy57iAWPj2grGbzWYGBwex2+1MTU3R19eHw+HA5/NhNBrx+XyYzWbZ8dZgMMgurt2ewJ1ewfXr17HZbFSr1fs2gtwK7FpjFwEPq9VKKBTCbrczNDTE0NCQXFG1Wi1msxmdTie/rFYrDocDk8lEp9ORXUoHBgZwOBxks1lsNhuZTIZoNEq9XqdQKNBoNKSHYLFYGBoawu/3k8/nKZVKGI1GVldXaTab2x54abfbFAoF9Ho9mUyGTCaD1WrF4/HIhc9ms+Hz+WS/9ZWVFdLp9H2NXiyker0ep9NJMBik0WhgsVioVqvU63WcTqd8fb1ex2KxkM/nqVarlMtlOp2OXFzEwrmTIc7cgUCAffv24XA4GBkZIRAIYLVapVfocrnkOdxgMGz4fidUVaVWq9FsNmk2m3JMe8b+gBADNj4+zve+9z2CwSBPPfUUw8PDciEQLv6dLYiNRqNcCDqdDv39/UxMTNBut/nmN79JvV7n3Llz/PjHPyadTjMzM0M6ncZgMGA2mxkeHuYf/+N/zL59+0in0+RyOc6dO8fi4qL0CrZzh280GiwsLLCysoLf76e/v59AIMDTTz+N0+mUE1gYfjKZ5K/+6q/49NNPqdVqlMvluxqhRqPBbDZjt9uZmJjg+eeflx1hO52O7OsuUKlUuHLlCqlUiuvXrzM7O0u5XCYajVKtVqnVaju6+6lWq+XgwYMcPnyY0dFR3njjDVwul3TLNRoNOp1Ofr9zjt2rvXW73WZ9fZ1UKkUymcRms9FoNNDpttf8dq2xa7VadDoddrud4eFh+vr6GBgYIBQKbXidmMR3uuKAXIVNJhMOh2PD3+TzeYLBIIDcrYxGI1arFZfLxcDAACMjI9hsNhwOB2tra/Kc9iBBws1Ep9OhXC6jKAqZTIZkMolOp6NWq2Gz2eRYuVwuxsbGpDtqsVhQVZVKpXLPHVdMYoPBgMVikUGp7gVUoFwu02w2cblcVKtVEokERqORQqGAoih0Oh3Zm3wn7vCKosj/7dDQEOPj47hcLvnc3a65O6Yj2mLfiWazST6fJ5VKUalU5P/jfvOkO30nPvdRPaNdaezin+Lz+RgdHWX//v2EQqENBgu3BqnVatHpdMjn8+RyubsOljgKdK+0AwMDfPOb3ySdTuN0OolGo4TDYQYHB+nv78fn88lrEcE/8bXdxi6gqiqLi4v87Gc/o6+vD1VVCYVCDA0N0dfXh06nw+/3YzabefXVV/H5fMzOznLy5ElqtdoX3k9E8svlMu+++y7lcpm+vj6eeeYZGYjqdlsNBgNDQ0P4fD78fj8HDx6kWCyysLBAPp/n6tWrLCwsUKlUSKfT25p2ehBoNBpCoRAHDx4kFApt4CsIj6Y7aKuqKtlslnQ6TaPRoFAobIhXiMWtVqtx7tw5lpeXqVarFItFarWaXCTEsbN7Lg0PDxMOh2k2m1QqFer1OisrK2QymYe+v11r7A6Hg3A4TH9/P6Ojo3IXvhOtVotWq0U2m2Vtbe2u52mfz4fP59tg7MFgkJdeeol8Po+iKKyvr7Nv3z4OHjwod3dxLd1Eiu5jw+PA2toayWSSvr4+3G43AwMDGAwGAoEAWq0Wt9uN3W7n2WefZWBgAI1Gw0cffXRXY2+1WmQyGbRaLWfOnGF9fZ0jR44wOjoqd6duY9fr9YTDYQDGxsZQVZViscj169fJZrMy9ZTJZMjlcjvO2BVFwefzMTExgcPh+ML5W5CSRJyj0+kQi8VYXFykUqkQiUQ2jGO73aZarVKtVvnwww+Zn5/H4/HQ19cn/x6QnpOI2ovj6ZEjR6hWq6TTaUqlEvl8/skz9m50n88FSqUS2WyWer1OPB6nXC4Tj8eJRCJ3NXav10uhUMBmsxEOh3G5XKiqil6vx2Kx0N/fL9NtIuUCt/6Z8Xic5eVlVlZWqFarjyVA1w2xm5RKJW7evEmpVMLj8WC32+X9aTQabDYbXq+XkZERnn32WbLZLCsrKxQKBTmZxQ6mKAqlUolUKsXy8jJnzpyRk9btdsvjjQiAil1KURQZ3NNoNNIz0mq1LC8vf/nNPAaImIs4bnQ6HbLZLOVymUwmQyQSkYG2drtNIpGQgdx0Or1hZ2+32zQaDZlmE55BrVZDq9UyNDSEoijY7XYcDgc6nU7GB/bv38/IyAipVIpMJiP/H4+CLzV2RVH+BPgukFBV9dDtxzzAXwAjwBLw66qqZh/pSjYJqqoSjUY5c+YMqVSKM2fOEI1GyWQypFKpuxqi2+1mbGwMj8fDr/7qr3L8+HEsFgsOhwOz2cyJEydotVoy4io+p1arceHCBd59913W1tbkmexxGnur1ZKL0C9+8QuMRiOZTIZEIsHo6Civv/46DoeDUCiEz+eTMY9oNMqf//mfMzs7K3cjQEbRY7GYJOdcvnwZm83G8ePHGRkZIRQKMT4+js1mY3R0dEOE3mQyMTw8TLPZpFwuYzKZuHLlCpcvX6ZSqTyuYborxP+0UChgMBgk12J2dpbFxUWuXr3KqVOnKJfLVCoVafDCtb/TIEVsQlVV6RFUq1Wy2Sxut5tvfOMbjIyMyEXQaDTicrkk5Vmv13P58mVmZ2epVCqP7Ak9yM7+p8B/Bf6s67E/AN5WVfUPFUX5g9u//4dHupKvCPGPaDabcoKL3aTValEulykWi3LlFWeru62OtVpNupi5XI5qtSpTI1qtFpvNtuH1zWaTQqFApVIhmUwSj8fJZrOPfVcXELGKQqGATqcjmUwSi8Ww2+2Uy2WZlhSTa2BgAK1WSzAYJJFIkMvlNvAM4PPjUKvVotlsYjabCYfDGAwGVFWVuWO/3y/JJoJOKrIfFosFq9WKyWR6rEed+6HRaFAqlbBarXKuNBoNKpUK2WyWSCRCqVSSwcgHQXeQ02QyYTabsdlsBINB+vv75XHUYDBgt9vR6XRyXovUZb1ef+QMz5cau6qqpxRFGbnj4e8DX7/9838H3mMbjV1VVVKpFPV6Hb/fTzQaRaPR4HQ6MZvNmEwmfD4f7XZbFifcb3JVq1XW1tYoFossLS0RDofp6+vD4/HcNZ0SiUT4H//jf7C0tMSNGzdYWlrasWmldrvNtWvXSKVSLC4uotVqCQQCHDx4kP7+fiwWi6R5/t7v/R6ZTIZf/OIX/MM//APVapVSqbRhR2m32zJnfPHiRRYXF6UX5Ha7+da3vsXo6ChDQ0OMjY1tiNqLXXCnndUF2u02c3NzmM1mpqampLfidrsZHBxkZWXlK+XGRYpOr9czMDCAx+NhaGiIw4cP43a7eeqppwgEAvI1jUaDubk5qtUqCwsLrK6usrq6ymeffSYDzI+Chz2zB1VVjd7+OQbcPTq2RRCBn0qlQiqVIp/P43A4sFgsG+iMYhf7MmNvNptyZ04mk6RSKex2+4a0XTdyuRzvvfceMzMzlMvlbec4fxWoqkosFiMWi1Gr1STtta+vT+7MVqsVgP7+fjqdDplMhlOnTqEoyhdcbVVVpUfVzZ6DW7EPEXyyWq2Mjo5ueF7EE3YquUZVVeLxOFeuXJGUVpvNJsk0Vqv1K3kkgpQkAqQDAwMcPHiQV155BafTyfDwMHa7nVqtRqVSoVqtEovFyGaznD17lpmZGTKZDDdv3tyU4qVHDtCpqqreTwNMUZTfBX73UT/nLp8rJ0+9XqdWq0k3x2Kx0NfXh8Vi4aWXXmJkZITZ2VkuXLhAo9GgXC5vcInMZjMejwe3283o6Cijo6Myet1ut6XLJoJ88/Pzkku/mbvUVo2VQLFY5OrVq8Tjcex2O7lcjlAoxMTEhIw8K4rC0NAQX//614nH45w+fZpMJiOPSndDN+dhaGiIyclJfD4fiqLII0+1WuX69etcuHBBUnsfBVsxVqqqUigUiMViZDIZGo0GnU4Hu92ORqNh3759vPrqqxQKBaLRKKVSiXQ6TSKRQFVVualYLBZMJhN+v5/p6WkZF/H5fPT19REIBDCbzSiKQqPRIBqNsry8TDqd5vz582QyGRYXF2VwebMIWg9r7HFFUcKqqkYVRQkDiXu9cKvE/EXgSEQ6u89QLpcLp9NJq9VidHSUSqXCD3/4QzKZDPl8/gsMN4fDwfT0NMFgkOPHj/PMM89IF6zRaJBOpykUCnz44Ye88847pNNpVlZW7sk8e1hsdeODZDLJyZMnMZvNJJNJRkZGeOGFFxgaGtqQZjpy5Aher5fr168TiUTkmfVeHoyIwns8Ho4cOcKLL74o+Qa1Wk3mhz/66CN++tOfbggAPiy2YqzE8TCTyTA8PCw1ALxeL4FAAIvFQjAYpFAocOnSJRKJBOfPn5eBX0HJ9vv9+P1+jh49yr/4F/+CQCCAzWbDZDLJhVFVVRqNBtVqlbm5OU6ePEk0GuX9998nlUrJxVUE/jYDD2vsPwJ+B/jD299/uClX8xCo1WrE43HJWVdVVVI8xW5jNBoJBAIyhSbINSLq6fP5CAaD8p9iMBjk2bRWq5FKpchms8TjcRKJBPl8XkZgdxPE4ijIIBaLRU7uZrMp02ei4svr9RIKhahUKsRisQ0GqiiK5Ibb7Xa8Xi/hcHhDahKQHAdx3CqVSjsmkHk3iE2kUqlIBqDX65VVb6LYRZCwIpEIfv+tdn2iQjAcDkvass/nw+PxyJSaQKPRkMVT4piVTCYpFAqUy+UtubcHSb39L24F43yKoqwB/4lbRv6XiqL8S271K/v1Lbm6B8DS0hJ//Md/jN1u59ChQwwMDHDgwAFeeeUVeX43GAycOHECv9/P8vIyf/mXf0ksFmNiYoLh4WHJ9nI6nfT332pXl8/niUQiZDIZ3nvvPVZWVrhx4wZzc3Myd7pb0Wq1WF1dJZvNSrfT7/fz4osv0tfXJysF9Xo9v/mbv0k8HudHP/oR77zzjlzgdDod+/fvp6+vj9HRUZ5++mk8Hg/Dw8MbPqtQKPDxxx/LYKZITe70hXJlZYU///M/JxgM8o1vfIODBw+i1WoZHByk3W4TDoep1WqMjo4yPj6OyWRibGwMm82Gy+XC4XDIFKcgzHSjUCjwt3/7t1y9epXFxUWuX79OrVbb0rLXB4nG/8Y9nnpjk6/loVAoFLh8+TIGg0EyvkwmE08//bRMdxgMBrnriIomEayamprC6/UyPj6O1WrFarXS6XSo1WoyP72wsMDCwoI0/p0+Ub8MnU6HYrFItVqVMYhyucyxY8cAJIsLYGpqilAoxCeffPIFGSaPx8PAwACTk5McP35ckkMERH45EomwvLwsg6C7AYVCgdnZWRKJBNPT0zKYZrPZZOZH3J+oQTh06BBOp1MG9e4n+FGr1Zifn+f8+fNEo1HW19e3fF7tegadQLvdlhFnuDUZfT4fzz//POFwGFVVsVgshMNhXn/9dXku6+/vx2az4ff70Wq1rK2tUS6XuXnzJufPnyebzTI3NyddrN1u6AKCIZZIJLh8+TLJZJKpqSlZdyDKYz0eD0ajkenpaV566SXp5ppMJl599VX27dtHOByWdd5ikRC8hsXFRdbX14lGo1vmnm4FarUasViMYrHIL37xC+bn5+nv7+fAgQPYbDZGRkZwOBwEAgGmp6elKMqd9QJ3IpPJsL6+zvr6OisrK8TjcUql0rbMqz1l7Gtra6yvrxOLxbh586Y8M9ntdiwWizx3ffe735VnVCEbpNfrZcHC1atXZYFIuVyW9ex7xdDhc5JMLBYjn8/LSQu3eO1CpcXv9+NyuXjqqadkVVez2cRkMkn3VqfTYTQaN9CW0+k0165dY3FxkeXlZdbX1+/Kv9+pENwLjUZDJBLBaDRy8OBBvva1rxEKhXC73bhcLkKhkKzLuJO2fSdEAPCzzz4jEomwuLh4Twr3VmDPGDt8Tk+s1+vk83ksFotk0Ingm0ajkatv904k0njpdJr19XWSySTlclmm9PaSoXdD8LcrlQpra2uYTCZZB6DX62UEWRTVCOai0WjE4XDI86iY5CIlWigUiEQixONxKWO1U4Ny94KYT2IzMJlM2Gw2LBaLzDbcz7i7C2YKhQK1Wo3V1VW5IVWr1W2NX+wpYxcol8tyAn/wwQdEIhGef/55gsGgjNB350VFdZIQofj5z39OsVgkn8/fs0Z5r0BUcqVSKX7yk59gs9n45je/iU6nw+12y1jG1NQUw8PD0gCEfLUoehEQfPEbN27w05/+lHQ6LTkJu3HB1Gg0BAIBAoEABw4c4MiRI7Jy8MvQbDYl+evTTz/l5s2b3Lx5k3PnzlEsFkkmk9u6AO5JYxc7sRCBFJppqqpKVlM3RE6z0WiQy+WIx+NSS203TtCvCiFAGY/HZVCyWCxiNBo3GPa9Jni3uIKgDWezWWKxGLlcThaB7DYITrtg0LlcLtxuN06n874qM93j0Ww2qdfrJJNJVldXWVtbIxaLyRr17cSeNHa73Y7P58Pr9XL48GHGx8fp6+u7L69ZBJ4E0WEvu+53gyCD2Gw2yWsXOfNuF/1uEN5BJpPh7/7u75ifn2dubo6VlRXq9fquicB3w2Aw4HA4sNvtnDhxgiNHjjA0NCS5Gt1cgjvRbrflsUUoEBcKBXk8LBQK1Ov1ba8R2JPGLuiywWCQyclJ9u3bRyAQuOf5SpwzhbHv5hz6w0Kr1eJyuSS/vb+/X6qnCtxLmkkQkBKJBH/3d3/HqVOngN2tKy9EJb1eL0ePHpV8dpG1uR9EEFO8j06no1QqEY/HpRDF4ygG2pPGLqrefD6fdLtEWaUQGWg0GhvUQIWLL9RmdqpO2mZBBJdEoYYQlRQFMndTP72zVlscdSKRCHNzc6ytre0JHgLc0jh4+umnJfNSZHLubDBSq9WkaImQpapUKtRqNRwOB8PDwxiNRkZGRnjqqae4ceMGyWRSVg72zuyPCLfbzdTUFOFwmLGxMamOoigKxWKRTz/9lEwmIxcCu90u3XxRbihcsb0KoZJqt9vxeDwEg0G+853vcPDgQcLhsCwNhruLdQoFl2KxyLvvvsv//X//32QyGWKx2OO4nU3H2NgYv/d7v8fQ0JCseBMBXTEenU6HVCrF+vo6uVyOK1euyFLUYrHI4cOH+a3f+i3cbjdvvvkmJ06c4K233mJlZYVsNivjGduFPWnser1e0hUFJ7nZbEphgmQySTKZlKWanU6HQCCAqqpSaVZQF/fCLnUnhFyU2NH9fr+MOIsUpZjU3WqwIlin1+s3TPhKpUI8HpeiF3sBop4iGAzKJiMC3eMhJM+EsEUul5M1AKJoRsh2mc1mfD6fLNIqlUo9Y39UuFwueU4XAZKFhQWuXbtGLBbjnXfeIZVK4XK5sNvtUqTAaDTy9NNPY7fbuXbtmuyeslcgjikGg4GJiQmCwSBTU1O88soruFwuKZ0suppUKhVZ3Se6vXg8Hvbt24fBYMDpdGKxWAiFQrIwJB6P72mPCD5Xmm21Wpw9e5Yf/OAHsiuQWOxEStdoNOL3+yXbcN++fXz3u98lFovx05/+lJs3b27bkXFPGrvZbJYaa3q9XjLFZmZmiEajXL58WQpUWK1W2u02J06cwO12MzIygsfjodFo8PHHH+85YxcEkUAgwNjYGMeOHePNN9+UAhYCQqRC7NjiHNpoNBgdHcVoNMoqQ6fTidPplPGQJwHC2G/evMl77723YZ6IenbhFYm6dqPRSDAY5NixY6ytrfHRRx99aaZjM7GnjF1on9ntdtmjTETX19bWuHz5MplMRtJfRcvceDzO3NwcXq8Xr9fLwMAA4XAYr9eLTqfb9ta6WwXB37bb7UxPT3PkyBHGxsa+4KLG43Gi0SipVIpPPvlElsC2Wi1yuRyjo6N4PB6sVitGo5FQKMTLL79MNBqlUChQKBQe411uDsrlMouLizSbTSkpJdBsNlldXZW9Ah0Oh6zRF4tAvV6nWCwSj8ep1WqcPXtWllUHAgFMJhNvvPEGY2NjXL9+nStXrmx5sG7PGLuQR7ZYLLI+3WKxEI1GKRaLXLlyhbfffltGQVVVlfXZWq2WDz74gGAwyPe//32mp6dZX19ncHAQi8XC2tratnfc3AqIZoV+v5/XX3+dr3/96zIaL6CqKgsLC7z33nusr6/zi1/8gkQiIQUkn3nmGfbv309/f79URJ2cnOS3fuu3WF5e5vLlyywtLT2+m9wkZLNZyWE3Go0bjL1arXLp0iWWlpZIJBIEAgHZ5kqQs0RLZtFJSFEUzp49y8svv8xv/MZvYDQaGR4eplgs8md/9meydHorsWeMXVEUKQ4ohCvEuTOfz8uSzu4BFa6T4NKbTCZU9Vb3U9GZ83E04Nsq6HQ62a5KlGEKdHfPKRQKxONxksmkDDYJYxfMLyHZBBsJKNvdv2yr0N315U4Xu91uk8vlJNOwu+FD99+Lo5CiKFSrVSkHLeoy7Ha77Dm4HWq7DyJeMcgtGekgoAJ/pKrqf9lp2vEGg4Fjx45x6NAhjh49KqvYrl69ytLSEisrK/d0k8rlMktLS1I80mg0yqIH0ZtrL8BmszE5OUk4HN6g7Q6fd3+pVCrMzs7y/vvvUygUpEcjJrQI1AljF7l6q9UqC0T2AkwmE8FgkFAohMVi2fCc6Bdw5swZ2Y9ASGzfCbFQiF553S2dt7ub64N8Sgv4fVVVDwIngH+rKMpBPteOnwTevv37Y4OQSB4bG9sgFplOp4lEIhSLxXsGQUTjPVH40t3a6Msa8O0miDO7qFEHvpBCKxaLMnecSCTkBBav6ZaDvrN90YMo+e4WdOvc362WIplMsrKyInd3UcF2N3STl8R7dXeA3S5jfxClmigQvf1zUVGUq0A/j1k7/k5oNBr8fj+jo6P4fD40Gs0Grvtu5GdvBe5slyXGJ5fL8c4777C8vMyFCxekcu6dC2Q+n5eBTr/fL3u7wa3d8ODBg5TLZSKRCCsrK7uWp9BoNMhkMpjN5oeuw7fb7QwMDOB0OnnppZfYv3//BiXf7cZXOmDdbhbxFHCax6wdfye0Wi2hUIjJyUnpTgo6Y6VS2XPiE5sFManX1tb4h3/4B86ePUupVKJard51vHK5HGfPnmVtbU3KWAmYzWaOHTuG1Wrl9OnTrK2t7dry4Hq9LgOTD6uE63Q6OXr0KIFAgDfeeIOjR49KLYXHMRcf2NgVRbEBfw38e1VVC3dwhO+pHb/VWuh3fNYGF1Kj0chWO3fymr/sfR4HtnOs7vjcL4zdvSajCCiJXu13vo/Iv99Z574F17ylYyVaiN0t7arX6xkeHmZ6eppCoUAul9vQ803k2fv6+hgfH8fr9UrJKnEsFC7/dtZgPJCxK4qi55ah/0BV1b+5/fADacdvtRZ6N0QHThEEMRgMDAwM0Gq1WF9f/8rdPLYb2zFWYmKJ76IXm9lsxul04na7abfb94xx2Gw29u/ff9cgXzfX/s6g1hbcx5aOlZClEkbfDY/Hw2//9m/zve99T2rJVatVkskkrVaLAwcOMDY2htPpZGBgALPZLKnb3edzIYyyY2SplFuz/o+Bq6qq/ueup3aMdjx8TmEUSilwa/JZrVZJ6xTu051SQHfb2fYiummeYgwEq06n00kvqFKpYDQaZdmvgKIoclEQtNo7IZph7vaxFJ2ASqWSbCrS3YZatNESLapFh9pms8nk5CQHDhzAarXi8/m+QFoS34Wwxd1iI1uBB9nZXwJ+C5hRFOXC7cf+IztIOx5u7erz8/OcPn2asbExXC6XdLecTif5fF7yl69evUqxWJSTWURe7+aa7iWI9k+ZTIapqSkGBwdRFAWr1UooFOJb3/oWhw8flp1pa7UayWRSeks6nY7R0VGOHz8uXdNuNJtN1tfXuXHjBqlUalfHSEQ6tlAocP36dYLBIE6nk2AwuKFBRn9/P1arVbakFkVVXq9XdsvtrpQTG1Iul+MXv/gFS0tLXLhwYVt29weJxn8A3GuZ3hHa8XBrJV5dXeXSpUvo9XqOHj2K0Wikr68Pn88n0yNCgbY7Qi9EKIW44l6tZS+VSiwuLlIoFKSgZreL+dJLL0k9OpFSunHjBuVyWZ5D+/v7Zf+yO/n0ogZhaWmJbDa7q8ewWq2yvr4uO/sODg5KtWJRMQi3MhCBQOCu73E3b1Go+mSzWT766CPOnTtHLBbblkDmntnGOp0OuVyOWCxGIpEgk8lgtVpl4YfX62VsbAyr1UoikSCVSskSV5vNRl9fH263W/YZFxLSj0tVZCsgyiq1Wi03btzA4XDg9/sZHh6WgSNR4quqqiwSqtVqklHo9Xqlgs2d+eF2uy215+7Ha9gNELtwo9FgfX2da9eu0W63CYVCmM1mzGbzV/ICxdFJlMJGo1HJUNwuie09Y+ytVkvuKCaTiampKdmOyOFwsH//fkZGRigWixw8eFCexYR+vCiHtdvtpFIpYrEYq6urZDKZXaV3fj/UajWi0SjpdJof/ehHnDlzhsOHD/PGG2/gcrkYHR2VYh6hUAhVVZmenpZne3G+F5mNO429Xq9z48YNzp8/v+vFOsWZulwu88knnzA/P88LL7yA3+/H7XbT19eHzWZ7oPcR8ub1ep35+XlOnTolW0MvLy9vm97hnjF2kVPXaDTkcjmSySSqqhIMBmUQReQ4+/r6ZNfXZrMpi2e0Wq0sXiiVSrKkczcqo94NYgJ3Oh3S6TSdTgefzyeZcm63e0MZLCANW6vVbgi8dQc6xQ4ouune2dN9N6M7MyFET1qtFiaTaUOdhdAJEGpH4jgoWIdCUjqdTssGoWLD2S7sGWPvdDrSQM+fP0+pVCIQCPDLv/zLjI+PEwgEZJO9cDgs3SoRoNPr9dTrdT755BOuX7/OzMyMrOPercSQe6HT6ZDJZCR5JhKJSN0+i8XC8PAwY2NjGxbI8fFxBgcHN7xHPp+XAhdCKyASiTzGO9t8qKoq7/PMmTPScxTHGQGn08mhQ4ek1v7Q0JBU8CmVSlI3fnl5mZmZGcrlMrlcblvvZc8YOyBdJcFZDgaD7N+/X0r/iiYRLpdrw9+JbjAiyHfu3DlWV1epVCp7kmYr5JTK5TL5fJ7l5WW0Wq2U8Dp27JhMJQlCksfjYXBwcEPqSFQULi8v88knn5BKpbZ9Am81hMcohCXX19fRarWyQYaAOPb09fXh9XoZGhqi0WiQTqfJZDJcuHCBCxcukEwmWVpa6qnLbhaEOH+xWOTChQuk02nS6TTNZlMWtwjpZKE3JwQA19fXpUrqXnHf74dud1zkkyORiMxqiJ09mUxy6dIl+XfdO/vq6iqLi4sUi8U9E9+4G8SmIIqGuiv8xPisrq6STCa5ePGi3NnL5bJsDipSvo8DynYGUbaaQXcnBLXTYDDw4osv8tprr2E0GrHZbBgMBqamphgfHyebzbKwsEAymeS//bf/xsmTJ+VZa4txVlXVZ+72xHaP1e3PBJCLYXfqSDzWje4zuwjIbRVBRFXVe7J0tnusxJjcSc0Wir13ntnF5iPYcltt7Pcaqz25swuIHm5CG02ojoi6YovFIgN6q6urpNNpqf39JEIYqQhc9nB33Ek5hs93/Z2MPW3s8LnowrVr10gkEjKq3C1jJYT9RU61hx72Iva8scOtFTibzZLNPjYhnR56eOzYG+JqPfTQw5eiZ+w99PCEoGfsPfTwhGC7z+wpoHz7+26Fj827/uH7PNcbq89xv3GC3lh1455jta15dgBFUT67V255N2A7r783Vjvzs7YC23H9PTe+hx6eEPSMvYcenhA8DmP/o8fwmZuJ7bz+3ljtzM/aCmz59T/SmV1RlG8D/wXQAv+Xqqp/uFkX1kMPPWwuHtrYFUXRAteBbwJrwKfAb6iqOrt5l9dDDz1sFh4l9fYcMK+q6iKAoij/m1stoe5p7I+jkmuHI6Wqqv9uT/TGaiN2UtXbTse9xupRzuz9wGrX72u3H9sARVF+V1GUzxRF+ewRPmuvYrn7l95YPTh6Y/XVseWkmu3sCLPb0RurB0dvrL46HmVnXwcGu34fuP1YDz30sAPxKMb+KTCpKMqooigG4J9yqyVUDz30sAPx0G68qqotRVH+HfAzbqXe/kRV1SubdmU99NDDpmJPa9DtAuwoDbqdjF40/sGxFdH4HnroYRehZ+w99PCEoGfsPfTwhKBn7D308ITgiVCX3Ux0dzPVaDSyb7l4TnRKqVarj/lKHx3d9ylaNut0Okwm04YGEvV6nXK5LHX691pvvL2CnrF/Beh0OvR6PXq9HpfLhdls5rnnnuPIkSNoNBq0Wi3lcpm/+Zu/4ezZs4/7ch8Zoq+92Wxm//79jI2N4ff7OXjwIGazWS4E165d4/333yeTyTAzM0MqtZvVofYuesb+FaDRaNDr9bKPu81mY2JigmeeeUYaez6f57333nvcl/oFdLcqAr60RZPY1a1WKzabjcHBQaamphgYGOCFF17AZrOh1+vRaDTY7XZWV1cxmUzcuHFjK29jx6F7XO8c4y/D3TrLbCV6xv4AED289u3bx6FDh7DZbAwMDGCz2ZienmZgYIBMJsO1a9dIpVLk8/nHfckSiqIwMDBAMBiUk7HZbLKyskImk7nr34RCIfr7+3G5XBw+fBi3283ExARDQ0M4nU5MJtOGXu0+n4/jx4+ztrbGhQsXWFtb27b7205otVp5lHG5XBiNRpxOJx6PB4vFQn9//4Y2zt3oHvtGo0G9XpftnOPxOJFIhFarRa1W27JecD1j/xIoiiLd90OHDvFrv/ZrcvLbbDbZ5rhSqXDt2jUikcg9jehxQKvVMjo6ylNPPSUnXLVapVqt3vU6xeJw4sQJ+vr6eP311wkEAjgcDmw2G4qioNFsjOsGg0FefPFFlpaW+OEPf7gt9/U4oNfrsVqtmM1mRkZGcLlcjI6OMjExQSAQ4MUXX8Tr9d71b0WMQ7S5LhaLnDt3jlgsxrlz56hUKlSrVZrNZs/YHxZiglutVqxWKzqdDovFsqEjqeiyCbdcdY1GQ6lUIpfLodVqCQaD2O12BgYG8Pl8OBwOLBYLRqORVqtFo9Egl8uRTCZJJBI7rm1xd+daq9VKs9lkcnISgFKpRDqdRlEUXC4XJpOJoaEhBgcH8fl8mEwmNBoN5XKZSqUi31NRFNkgs9PpYDAYMBgMX1gI9gJMJhM6nQ6fz8fg4CBWq5WBgQEcDgf9/f309fXhdruxWq0YjUbZX7Ab7XYbVVVRFAWTyUSn0yEQCKDVamVrskKhwOLiIuVymWazuemNIve8sYsg0sTEBEePHsXpdLJv3z6sVqt8Ta1WI5fL0W635QSemZnh7bffxmg08p3vfIfR0VGmpqY4fPiwPLcDRKNRYrEYFy5c4KOPPpKu2U6Boig4HA7C4TDBYJDp6Wn0ej1Hjx4lHo9z9uxZfvzjH6PX6/n617/O4OAg+/fvZ3p6Wi6IlUqFhYUFVlc/ly/Q6/Xs37+fUCiEyWSSTTLvbOu826HVagmFQng8Hp599ll+5Vd+BbvdjtPpxGg0YjQa5WJgtVpRVZVqtbphwe90OhQKBWq1GmazWXpJTz/9NKqqcujQIV599VVWV1f5P//n/7C2tkYymdx0D3FPGrtwmUTKSK/X4/F4GBgYwOPxMDk5idPplK+vVCqkUina7TY2mw2j0Ugul5MR98HBQSYmJujr68PhcKDRaGi327RaLUqlEqlUilQqRTqdJpPJbFvA5UEheoabzWaCwSAmk4l2u43L5SKZTOJyudDr9YTDYYaGhgiFQrjdbtrtNrlcjlqtRiqVYm1tTd6b0WgkGAzidDr33G4u5o84vjmdTrxeL/39/ezfvx+HwyG9RLgVYBN96lutFtVqlXK5LMeq0+mQy+Uol8s4HA6ZxnQ4HDIGIN7P5/NRKpUoFAqbfl97ytj1ej1arRaHw4Hf78fhcPD0008TDAYZGhpidHQUs9mMz+eTOzPcCpqEw2FUVZXvIVw1nU7HgQMH8Hg8cmKXSiWuX79OLpfj448/5vz588RiMYrF4o4z9E6nw/z8PDqdjoMHD7Jv3z48Ho+csK+88go+n49Go0Gn06FUKvHZZ5/xwQcfUKvViMViVKtVUqkU2WxWGoLNZsPv9+Pz+SgUCqysrBCJRCgWi4/7lh8J4kze19fHM888g9PppL+/H7fbzcjIiAxQigWuUCiQy+XIZrNcunSJXC5HsVikXC7L92y322SzWWnsfr8fl8vFq6++ysDAAFqtFo/HA8D3vvc9EokEf//3f08sFtvU+bRnjL17JfZ4PIyNjREKhfjVX/1V9u/fj81mw263P3B6ZHh4mOeff16+dzcqlQrXr19nfX2dd955h1OnTm1ZUOVR0el0WFlZoVAooCgK+Xweq9WK3W7HbDYTCoU4fvw4+Xyed955h+XlZa5du8bMzAzFYpGVlRVJEFJVVXoJTqeT559/Xh6BYrHYjjvCfFUoioLZbMbtdjM5Ock/+kf/iGAwiM/nw263YzQasVqtG+ZDqVQiGo2ysrLCj3/8Y9bX179g7J1Oh0wms8HY+/r6CIfDmM1mvF4vXq9XpjkLhQJXrlzZ9BTurjd2o9GIy+XCYDAQDAZxOByEQiEmJibkIJrNZvR6/QbWl6qqNJtNms2mzJF3M8Zgo5Grqirdq0gkIo09k8nsWEOHW9fdaDQol8skEgkuXrxIPB5n//79hMNhtFotOp1Osv+EG5rP56lUKrRarQ27i/B4PB4P4XAYt9tNo9H4yjnmnYhuj0UcbbRa7YYYjWAIFotFGo0GCwsLzM3NEY/HicfjZLPZu57Zm82mnHPlcpl8Pk8sFsPj8chIvFarxWg0yuPW+Pg45XKZZDK5KcG6LzV2RVH+BPgukFBV9dDtxzzAXwAjwBLw66qqZh/5ah4CLpeLp556Co/Hw/HjxxkdHcXv9zM6OorRaMRisUjyRze6jVev18vgkkil3Q3r6+tcuXKFpaUlfvSjH7G6urphBd+pKJfLVKtVLl68SLlcxufz8du//duS6mu32+VEbDQaZLNZ1tbWaDQaX6C+hsNhvvvd79LX18fzzz/P5OQkiqKwvLx8j0/fPVAUhXA4zKFDhxgcHJSBN5PJhMVikYYn0qyZTIYzZ87w4YcfUqlUyGazNBoNVFX9wgYgfq9WqzQaDZrNJufPnyebzeJwOHC5XPh8Pk6cOIHb7ebYsWOUSiWWlpZ49913N+V49CA7+58C/xX4s67H/gB4W1XVP1QU5Q9u//4fHvlqvgL0ej06nQ6Hw0EgEMDr9dLX10d/fz8+n0+mNQREOqTT6chJnMlkyOVykvrZvYILiH+cOM8mk0kZKc1mszt6VxcQ11+pVIjFYjSbTXkPIo0o4hUmk0kujiIQKSDSRoFAgGAwiNVqRavV0ul0ZO5+N/Liu4+AdrtdptFarRb1eh1VVaXnJwJxtVqNcrlMLpcjHo9Tr9ep1+tfOh9UVZXvm8vlSKVStFotObaAXGAEj2OzAqBfauyqqp5SFGXkjoe/D3z99s//HXiPbTR2jUbDgQMHmJiYYHh4mFdffRWXyyVZX90DJPKbIgfeHUiJx+Ok02kmJyf57ne/i9frRafTbTD47oj0pUuX+OlPf0o6nSaXy9HpdHZcQO5+qNfrpFIpSqUSP/rRj7h48SJPPfUU3/72tzEYDBw7dowDBw5gNBppNBpkMhmuXr1KqVSSi6vP52N6epq+vj4ZD7h06RI///nPSafTpNPpx32bXxkWi4Xx8XGcTifPPfcczzzzDJVKhdnZWXQ6HXa7Hb/fj8lkwu/3Y7VayWaz0iDr9boMcD4o6vU6V69eZW1tjf3798vFRWSRyuUy8XhcpoQ3Aw97Zg+qqhq9/XMMCG7K1TwgNBoNfX19HDlyhJGREZ5++mmcTidms1m64N1pj06nQ7FYJBKJEIlEeP/994nFYkSjUZLJJOl0mhMnTmAymTacjcSuXqlUKBaLrK6uMjMzIwkmu8nQAVqtlgwenT9/nvn5ebRaLS+++CJut5uhoSEMBgOxWIyFhQUikQg3b96kVCpJz8dms9Hf3084HCaRSJDL5VhdXeXy5cvk8/ldcay5EwaDgXA4TCAQkIy45eVlzp8/Lz06QBZBCbpsp9ORxKqvapDNZpNIJIJOp8Pj8dBsNje8R61Wo1AoUC6XN817fOQAnaqq6v00wBRF+V3gdx/1c+54T0kUESyv7nO5cK+q1aqMRK+trbG0tEQul5MRU4fDISP3fr8ft9std/VGoyEH/PTp06yvrzM7O0upVHogd+0h72vTx+puEMQPVVVZXFzk5MmT+P1+jh8/TiAQwOl0Mj09jcvlYnV1FZvNRigUwufzceTIEUmbjUajLC8vs7q6Ks+i27UAbuZYNRoNIpEIpVIJg8FAPB5Ho9EQCASwWCzYbLY7P1sG0iwWCxaLhVqtdt/7F8Fhi8UiefXhcBibzcbo6ChutxubzbalpKSHNfa4oihhVVWjiqKEgcS9XrgVYv6KohAIBNi/fz9er1emRcSZKpfLce3aNZLJJD/72c9YWlqSxQadTkee0Y4fP86hQ4c4cOAAY2NjuN1uNBoNqqpKIsn6+jp//dd/zYULF8hmszL6vhWTersaH6iqSrFYpFQqcfbsWRKJBP39/VitVgwGA6FQCK/Xy9raGul0mng8zlNPPcXU1JRMRbXbbebm5vjkk09YXFykUChsq7Fv5liJgJuiKFy4cEHOjX/7b/+tjAF1Qxhtp9PB4XDgdDrR6XTk8/l7Rs1Flsfn87F//37cbjfPPvss4XBYvqfH45FEna3Aw77zj4DfAf7w9vdtr34Q7rkwXkVRaDQatFotMpmMpBwmEgmSyaRkMIkabYvFQjAYJBwO4/V6MRgMMtjUbrcplUrEYjFisRjpdJpsNkulUtmVAai7QbC+arUamUwGk8lENpuVAUur1YrT6SQcDqPX6wmFQpKoBJ8fCdLpNKVSadfFL7ohMhFwa5cHyOfzZLNZzGazTMOJ83Sn05HsTJvNhsfjkVoG9zJ2kd612+2SSy/ITSK41263JQuv0Whsurf0IKm3/8WtYJxPUZQ14D9xy8j/UlGUf8mtfmW/vilX84BQVZVMJsPi4iLNZpPR0VG0Wi1LS0skk0nOnDnD3/7t35LP52WqRBRr9PX18b3vfY/+/n6mp6cZHx/HarXKiLRw0y9cuMCPfvQjEokE169fJ5/P7xlD70a1WiWRSNBqtfjkk09IpVIcOXKE48ePMzw8zK/92q/RaDQk4w5u7YS5XI6FhQUuXbok8/F7CUtLS/zpn/4pLpeLl156iYmJiQ0R8sHBQQKBAEeOHJGpyp///Od3LYISkXaz2cyRI0f45//8n2O1WmWVW6lUkv8D4R2sra1x/fp1SqWSXIgeFQ8Sjf+Nezz1xqZcwUNCED88Hs+GIFwymWRlZYXLly9TLBbl2dpgMGAymXA4HBw4cIDx8XFZoy0g0nIiRXXlyhW5q4sVf6+h1WrRarXQ6XREIhH0ej0jIyOSe+B2uze8vlqtSi8nm82STCZ39a5+LxQKBS5fvixJNqK81eVyYbfbGRoawmKxSE4H8IW0rYAQPTEYDPj9fqanpzGZTCwuLspoe6VSwWg0UqvV0Gq1FItFMpnMpsaHdiWDrtPpkEwmuXHjBgaDgVarhVarxe/3o9PpWF9fZ2pqimw2SywWo1KpyN2qr6+P6elpWaMNSNGASqXCBx98wI0bN7h69SqRSIRyubxnDb0bjUaD+fl50um0FOMwm83Y7fYN58hkMsmpU6eIxWKsrq7K1OZeQ7vdljn2y5cvk0qlJF3W4/HIRVFRFPbt24dGo8Hv91MsFqlWq9Trdex2O/39/fKIqNFocDgcKIpCrVaTBC1xZEgmk7TbbQwGA/Pz81Sr1S8wGB8Fu9LYVVUlHo8zOzuL3W6n0WjIUkS/308mk+Ho0aMkEgnq9TqtVovjx4/zr//1v5Z0WqPRKKP3rVaLQqFAJpPh5z//OW+//bZcWffirnU31Go1Zmdn0Wq17N+/n2QyidPpxGKxbDD2aDTKj3/8Y1ZXV7l58+aePNoAG4hC586dk0FdQcsOBAKygOrgwYPodDpCoRD5fJ50Ok29XsfhcHD48GGsVqs8HrpcLllMdf78ec6fPy/nl0ajYX5+HoCrV69uenp31xq7SIsVi0WKxSI2mw2dTieLNEZGRrDb7VQqFXw+nxQbEKWE3SmOWq0mc+6ZTGZDeu1JMHS4NdFEea+IyougVDd0Op0sKtLr9Y/parcXYkET86FSqZBIJFhfX5fpMpvNxuTkJAaDQVa+BYNBJiYmMJvNVCoVGo0GwWAQrVaLVqvF5XLh9/vJ5XKydl1kg0RqdDOxa409nU5TLBbx+XzcuHGDSqXC4OCgrFjyeDzUajVWV1cplUqyCk4sCN2IRqP85Cc/IRKJcPXqVUmDfVIMHW6psUxPTxMMBjl48KCse79zrNxutzwOJRIJIpHIY7ri7YeI6eRyOT766CPm5+el+MTAwAD/5t/8G5kRarfbkoQkIviqqsoAn6qqvPDCC4yOjvLOO+9w8eJFyZkXR4jNxq40dkAOjHC3LRaLlIwym80MDAzQbDYxmUxydxd654DkOIs02/r6Ouvr6xQKhU2Lfu4GiHSSwWDA6/USCoUk6UOn021Y9BRFkanLZrMpi4eepIVRpOnS6bSMnrfbbcxmM6Ojo3flsd/pHYnUncPhoNlsYjAYZKVcT3DyLhCTa3V1lb/4i7+QskGjo6P09/czNTUla9tF7bYYdJHLvHjxInNzc8zPz3P+/HkymcyOUobdDni9XkZGRvD7/fzSL/0S4+Pj9PX1yQjx+vo6tVpNSim1Wi0OHjzIwMAA165do1wuk81miUQie/b8fifEeV6j0RCNRpmbm8PlcjEyMoLFYvnC64X2HNw6MhaLRbLZLCdPnuTmzZtcunRJpuG2ctHctcYOtwZRaMCZzWby+TwHDx7k6aefZv/+/RiNRhlx797RRX3x7OwsP/vZz4hGo1y9enVX8rofFW63m6mpKfr7+3nllVeYmpqiXq/LSXnjxg3y+bzkjjudTiYmJmg0Ghw4cIBUKsXy8jKxWOyJMXYRM4Jb2YmlpSX8fj/hcPiuxi7+RlEU6vW6rGX/7LPPuHjxIqlUilqttuXe0a42dgHBBhMuqTDsuwkqCEOv1+tks1mi0SiZTGbPkUK+DEKYwefzMTk5SSgUkpz3XC5HJBIhlUoxOztLLpcjkUjg8XgkmURRFOx2O8FgkGw2u+d06OBzpWERuBQlwEajkb6+Pux2OwcOHJBHH71eL0tYRUm1WABF/YYg0ZRKJRlcFim+rcaeMHb4/DwpBvVeyintdptyuUyxWOTmzZucP39eijY8KVAURWqtTU1N8b3vfQ+PxyMJSqI4JhKJ8M4775BKpbDb7VitVk6cOCEDoP39/dLd/+STTx73bW0quokw4+PjBINBXC4XoVAIu93OsWPHCAQC+P1+AoGATMsBUnCy2WxSqVTQaDSEQiH0ej3VapVYLCYrMKPR6LZ5RHvG2OHzXmx3RpDvXDWFJyC+niQI6S2bzSa7mXi9XhwOh3RPuzXlhGputVrFbDbLeniz2Swlwex2uywP3upz51ZDeIZ6vR6z2YzJZMLj8RAMBnG73YTDYakXHwgEZBswQO7kIo7RaDQolUpoNBopkNIdZb+bos1WYk8YuyA8CLloUb3WDUGpVVUVi8WCRqPhyJEjfPvb3yYajXLhwoUNTRD2IroVUL797W9z9OhRJicncTgcdDodZmdnSafTnDp1ivfff3+DcKJQ91lfX+eTTz4hFAoxODjIsWPHKJfLzM3NkU6nWVhYIJfLPd4bfUiIRhlCJmp4eBin08nLL7/Mvn375GYiiDVWq1VyDYSHU6vVOHnyJJ988omkdGs0Gqanp+nv75facna7nZGREdLptFSo7Z3ZHwDirC4qkLoVQLub5wljF27+wMAAhw8fxmQyMTs7u+eNvbtS6/Dhw7z++usyVVkqlVhbW2N5eZm5uTmuX7++QVBBcOhFAUylUmFsbIzBwUGGh4elTPf6+vpjvstHg8VikTu5KKF+9tlnOXTokJSTEvXs3R5kp9ORUlXXrl3jvffeo1KpkMlkZMPPkZERnn32WU6cOIFer8fn80nhiu1YIHe9sTudToaGhvB6vYyPj0uNb6GfJlRAl5eXWVhYwGq1cuDAAaxWK16vlyNHjmCxWIhEIqTTaWKxmJSc2mtBO9HwwO1243Q6cTgcNBoNbty4QS6X4+rVqywvLxOPx+/JeS8Wi8zNzZHNZmVwSlVV+vr60Gg0UkdtN0H0CTAajRw5coTDhw9LcRSLxUKj0WBlZUXWCgiWW7PZlDoJQhwyn88zMzNDLpeTclVarZZUKoVOp5MCnVarlSNHjmA0Grl48SLZbFYurlu1w+96Y/f7/bzxxhuEw2Gee+45pqamZO2w6JSZy+X4yU9+wt/8zd8wMDDAv/pX/0rm4w8fPszExAQajYZ4PM6pU6e4fv26dFt38/nzToguLoFAgFAoRCAQ4Pr165w+fZp4PM7JkydZXl4ml8vdswAjnU7z4Ycf4nK5OHDgAMFgEFVVOXDgAE6nkw8++OAx3NmjwWAwyLTit7/9bX7lV35lg9R4NBplfX2dwcFBpqen0el0kil35coV3nnnHeLxOB999JHkxYvYhdDaX11dlQsk3FJF/uY3v8lzzz2H0WhkdnZWcvF7xn4PiEaNYmU2GAxysIRYZDKZlIEmo9FIJBKRrxVVXYFAQEZNc7kchUJBCgrsFYM3GAy43W68Xq8U5RQLYiKRkBpy9xNMEMqq1WpVpo9UVcXhcFCpVLZUaWWrILoIeTweXC4XTqeTVqtFpVJBURSp9S5SZMJjrFarJJNJYrEYiUTinqQssXAI7kIymZQegtVqlS2wu9tgbwUeRLxikFsy0kFABf5IVdX/slO048U5VAxYd5S9VCrx8ccfc/XqVS5fvkwul6PRaPA//+f/xOVyceLECY4ePYrD4eC5556TnTWXlpa4ePEib731lhRm2A2S0V8Gv9/P17/+dQYGBujr6wOQXW1EL7dSqXTfVJDII9dqNdbW1pidnWVkZIRjx47JyPxug/j/ixZhQuJMURTa7TaFQoFEIoHL5ZLqMZ988gnr6+ucPn2aDz74gEqlck9SlshydDodZmZm+LM/+zPZ097v98vmEEJddqvwIMtwC/h9VVXPKYpiB84qivIW8M95zNrx8Hkq6c5VUXRCiUQiLC4ukkwmpet19epV2eZH0BxF4UepVMJisUgv4G6NEnYrLBaLbMcs0kWlUomVlRVZWPQgdQHdu5uof/d6vTQajXs22NjJEOqyg4ODuFyuDV2BVFWlXq/LSLuQi1pfX2dhYYHl5WXW1ta+dIFst9s0Gg1SqRSXL18mGAyyb98+fD6fzCaJzjxbhQdRqokC0ds/FxVFuQr085i14wXK5TJLS0vU63UOHToEfJ7vFK2MRMmqiMiL8tVr165RqVRkoEmoyw4NDTE2Nsa+ffvIZDKsrKzs+oaFcIvFJWiv6XSaaDTK0tISpVKJarX6lbwXIVop8u6qqmIwGBgcHOTAgQOk02lSqdSOPgIJAzOZTPILkMcY8bvb7aZUKpHL5fj5z39OqVSSO/v6+voD3aM4DmazWRYWFqQ0uWhNJuZapVLZskKsr3TAut0s4ingNI9ZO16gVCpx48YNCoUC+XxeGrQgeJTLZXn+hs9TJLVajYsXLzIzM0M0GmVycpL+/n6ZTkqn0xw6dIh4PE4mk9kTxi6qAUOhEJ988gkLCwty7ETzxgdFp9Mhn8+TSCQoFApS429sbIxSqSTz7jvd2IUctCDQCOFSrVaL2WyWjTGazSbXr1/no48+IpfLcf36dbLZ7AMf8USFpWjrnU6nWVpaku3JDh48SCwW4+bNm1s21x7Y2BVFsQF/Dfx7VVULd7jM99SO32ot9GazST6fx2AwkM1myWazaLVaDAYDRqOR/v5+JicnpUvebDblLtatXbeyskKr1ZLRaovFImV+76UtttnYDt148X+rVqsUCoWHKqkURyen00kgEMBqtW4IQOXz+bsKL24mNmOsRGxHbA4iAyFceFFHIXQNRb1AsVikVqvRbDa/8tiJzxTqvCLlJgLGW1lj8EDGriiKnluG/gNVVf/m9sMPpB2/1VroYmcXHUrtdjvhcFieh/7JP/knfOMb3+DUqVO89dZb5PN5SQoRiEQi/O3f/i1+vx+Px8PQ0BDhcJjXX3+d1dVVPv30U5aWljb70r+A7dCNF+dHUa0lBCMfFOJ8abFYOHr0KC+99BJer1dWcl26dIkzZ85sWSONrvt45LESIhHVapVisUihUKDdbmMymaRXmMvlePfddzl58qT0ZAS55lEyNY1Gg5s3b9JoNHC5XJIM9liNXbm1FfwxcFVV1f/c9dRj146HzwtbFEUhk8nIog1xhhwYGMDn83Hz5k38fr/kKXefi9rttjxfilJD0cCwWq3uyqDT3SB2FJE/FhP2QYJCIjrd3VbY4/EQCoUwGAzU63XZini30GXFwidiO+K8LHb7drsthSrW1takN7QZR5NOpyPHS7jyd+s2vJl4kJ39JeC3gBlFUS7cfuw/8pi14+9Es9nk8uXLVKtVnnnmGQYHByV32WAwcPz4cZxOJ+l0mgsXLkgJ31arJSWmHQ4H4+PjcvBFU7/dmDu+G3K5HBcuXCAQCODxeHjppZfQ6/XMzc3JIF03a1Ds4qJwxmq14vf7OXjwIF6vl6effprBwUFSqRTz8/Osr6/vKk0A4Xmk02neffdd3G63POJZLBbJRxBHwWQyKQkzj6rOI1J6Op1ONiqpVCqPt/2TqqofAPda+h+rdnw3Wq0W8/PzJBIJrFYrL7/8MoD8h01PTzM1NUUmkyEcDpPNZiWd0WQy4XK5MJvNsi+3MHbRlngvoFgscu3aNbLZLOPj40xOTpJOp3E6nTJVeaexi3EQZJzx8XHefPNN/H4/U1NThEIhMpkMy8vLRCKRrxzoe5wQO3sul+P06dNSmsvn8xEMBvF4PBiNRgKBACMjI8AtXoKI9TwKRMNIQb11uVzkcrkd2f5px0G44BqNhrW1NT799FM8Hg+Tk5Oy37YQIQgEApjNZunSGgwGbDabbCQBt85UhUKBQqGwZzjy5XKZxcVFisWilOpyOp08//zzFItFYrHYhp1Zr9fjcDhkcwNRIOLxeDCZTDLtNj8/z8LCAolEYlcXE4l0YiKRwGAwyIYNTqeT/v5+qfpaLpdJJBKy3dPDzA9RTCOUbUQefyvjHHvG2EUqqFgs8uGHH7KwsIDP5+M73/mO7P4iCmCmp6e/IKQoVEnEyloqlTZ0KN0LiMfjvPXWWzidTklEGhwc5Pd///dpNBrMzc1JSWO4larr7++XlWAul0sGtWq1GjMzM6yurjI3N8eHH35IqVTa8Pe7DZ1Oh1gsxuXLl6nVakxOTmKz2WSp6759+zh48CDZbJZTp05JxuHD6BZ2S0krikIikSCdTm+p2OmeMXb4PJcp+NqNRoNYLIbVasXtdlMsFmVNslarRafTSTdKGL8IWmWzWVKplEyN7AWINGW73SaTyZDJZKTH0+l08Hg8UrxBBDL9fr+s9rJYLLJGu1wuk0wmiUQikotQq9V2tRckdu5cLkculyObzcqIe3cTR41GI4k24ogn4j/dugnduN8ZX4hciJ6EWwVlO0kPW9mGuBvCkEUDPofDwf79+zl06BAOh4OxsTFsNpskmAjR/3K5zOXLl1lfXycWi7GwsEChUODSpUukUqmtuNSzqqo+c7cntmKsRDRdr9czNDSEx+NhdHSUY8eOYTQaMRqNG1RshE56q9WSC5/oblutVmUlV6FQkK2LtqpwSFXVe6YMNrMVuOD3i9bKNptNllAL6alWqyXVe8RRUJT+FgoFSqXShuOQ2Dy6jzh6vV72Z7fZbDgcDorFIrOzs49MqrnXWO2pnV1ATDqh5Am3Iq75fB6fz0en08Hr9eJ0OgmFQjQaDdnA8cKFC1y5coVEIsHi4qJ0WfcCROqt1WoxNzcH3HLtm80mDoeD0dFRnE6njG3U63XS6TTlcpmrV6/KxW9tbY16vS5pyHsFgs6azWZJJBLE43Gpu9fpdHA6nVK7T/QVFF5QKpWSPQhTqdSG9GOr1aJcLm8wdrEAlMtlMpkMBoOBRqOxpXNtTxr73ZDP51lZWSGTydBsNrHZbCwsLBAMBjfs7FeuXCESiZDP52WfuL1Q8XYvFItFlpeXMZlM5HI5LBYLdrtdNjAQWYtIJEIikZA1190qNnsRQmaq3W6zuLgodfdEKlYo1QSDQUKhENVqVVb8BYNBKZ4iGJtC209AlL12cx+2eq7tSTf+bhCCFnd+Fx1NxJlKTOJ7nb02Gdvqxt8NIijZLcMtfu4uF+520cWE3M65sx1u/F3edwPXoHtsRHr22Wef5eWXX0aj0dBsNlEUhfHxcYaGhmRGJ5vN8kd/9EecPHnyrp8hvm+WAOoT5cbfDZuRG92LEOfyHr4IYXx3jo8QtNDpdNLl1+l0klefy+Ww2+3yLH+/lmLdGolbjSfG2HvoYbMgFoBmsymPfd07tKii63bRV1dXH/NV94y9hx4eCt1U23Q6/Ziv5sGw93r29NBDD3dFz9h76OEJQc/Ye+jhCcF2n9lTQPn2990KH5t3/cP3ea43Vp/jfuMEvbHqxj3Halvz7ACKonx2r9zybsB2Xn9vrHbmZ20FtuP6e258Dz08IegZew89PCF4HMb+R4/hMzcT23n9vbHamZ+1Fdjy69/2M3sPPfTweNBz43vo4QnBthq7oijfVhRlTlGU+dv94XY0FEUZVBTlXUVRZhVFuaIoyv/j9uMeRVHeUhTlxu3v7k3+3F01TtAbq6+CxzVWG8oYt/IL0AILwBhgAC4CB7fr8x/ymsPA07d/tgPXgYPA/w/4g9uP/wHw/32Sx6k3Vjt/rFRV3dad/TlgXlXVRVVVG8D/5lZzyB0LVVWjqqqeu/1zEehuavnfb7/svwO/sokfu+vGCXpj9VXwmMZqW429H+iu81u7/diuwDY2tdzV4wS9sfoq2M5mqb0A3QPgzqaW3c+pt3yuXkrjNnpj9eDY7rHaTmNfBwa7fh+4/diOxv2aWt5+/p5NLR8Su3KcoDdWXwWPYay21dg/BSYVRRlVFMUA/FNuNYfcsXiAppaw+U0td904QW+svgoe01htXzT+doTxO9yKPC4A/6/HHRV9gOt9mVuu1CXgwu2v7wBe4G3gBvALwPMkj1NvrHbHWPUYdD308ISgF6DroYcnBD1j76GHJwQ9Y++hhycEPWPvoYcnBD1j76GHJwQ9Y++hhycEPWPvoYcnBD1j76GHJwT/f+loW9MwH8H3AAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 288x288 with 18 Axes>"
       ]
@@ -2113,16 +2251,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "c5ac3b68-d02d-4d7c-a28c-3c8dfd447e55",
+   "metadata": {},
+   "source": [
+    "# tSNE\n",
+    "\n",
+    "Map all embeddings to a 2d plane to get an idea of how the data is clustered"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 28,
    "id": "5a7928da",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T14:05:55.426524Z",
-     "iopub.status.busy": "2022-08-16T14:05:55.425462Z",
-     "iopub.status.idle": "2022-08-16T14:06:15.832314Z",
-     "shell.execute_reply": "2022-08-16T14:06:15.831317Z",
-     "shell.execute_reply.started": "2022-08-16T14:05:55.426500Z"
+     "iopub.execute_input": "2022-08-16T14:56:22.829670Z",
+     "iopub.status.busy": "2022-08-16T14:56:22.829505Z",
+     "iopub.status.idle": "2022-08-16T14:56:43.896557Z",
+     "shell.execute_reply": "2022-08-16T14:56:43.895433Z",
+     "shell.execute_reply.started": "2022-08-16T14:56:22.829651Z"
     },
     "tags": []
    },
@@ -2133,7 +2281,7 @@
      "text": [
       "[t-SNE] Computing 91 nearest neighbors...\n",
       "[t-SNE] Indexed 10003 samples in 0.000s...\n",
-      "[t-SNE] Computed neighbors for 10003 samples in 1.824s...\n",
+      "[t-SNE] Computed neighbors for 10003 samples in 1.742s...\n",
       "[t-SNE] Computed conditional probabilities for sample 1000 / 10003\n",
       "[t-SNE] Computed conditional probabilities for sample 2000 / 10003\n",
       "[t-SNE] Computed conditional probabilities for sample 3000 / 10003\n",
@@ -2145,14 +2293,14 @@
       "[t-SNE] Computed conditional probabilities for sample 9000 / 10003\n",
       "[t-SNE] Computed conditional probabilities for sample 10000 / 10003\n",
       "[t-SNE] Computed conditional probabilities for sample 10003 / 10003\n",
-      "[t-SNE] Mean sigma: 0.021153\n",
-      "[t-SNE] KL divergence after 250 iterations with early exaggeration: 69.586418\n",
-      "[t-SNE] KL divergence after 1000 iterations: 1.319757\n"
+      "[t-SNE] Mean sigma: 0.020139\n",
+      "[t-SNE] KL divergence after 250 iterations with early exaggeration: 68.921059\n",
+      "[t-SNE] KL divergence after 1000 iterations: 1.298541\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAegAAAHSCAYAAAAnsVjHAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAB330lEQVR4nO3deXxU1fk/8M+ZJcmQQAYkIQthC1sA2UwBi4DiLiLoV0FrW7QutS5F7Q/FHRUrVqvSzdZqK7Yq4gZitIogiAtoIKwJW8KaBBKWSUiYSWY5vz/u3MnMZPa5M3eZ5/168SJz5+beM0zIM+ec5zyHcc5BCCGEEGXRyd0AQgghhHRGAZoQQghRIArQhBBCiAJRgCaEEEIUiAI0IYQQokAUoAkhhBAFMsjdAG89e/bk/fr1k7sZhBBCSNJs2rTpOOc8x/+4ogJ0v379UF5eLnczCCGEkKRhjB0MdJyGuAkhhBAFogBNCCGEKBAFaEIIIUSBKEATQgghCkQBmhBCCFEgCtCEEEKIAlGAJoQQQhSIAjQhhBCiQBSgCSGEEAWiAE0IIYQoEAVoQgghRIEoQBNCCCEKRAGaEEIIUSAK0IQQQogCUYAmhBBCFEhR+0ETQpKnaeVKNLz0Mhz19dBnZ8PZ2grY7Z7nWZcuyH9yAbKnT5exlYSkLkl60Iyx+xhjOxljOxhj7zDGMhhj/RljGxlj+xhj7zLG0qS4FyEkfk0rV6L+scfhqKsDOIfTYvEJzgDAz5xB3fyH0LRypTyNJCTFxR2gGWOFAH4LoJRzPgKAHsD1AJ4D8BLnfCCAUwBuifdehJD4Na1cibr5D4HbbOFPdjrR8NLLCW8TIaQzqYa4DQBMjDE7gC4A6gFMBfAz9/NLACwA8IpE9yOEBNC0ciXqn/k9uMUCANCbzej1yMMAIAxn19VFfU1Hfb2UTSSERCjuAM05r2WMvQDgEAArgC8AbAJg4Zw73KcdAVAY770IIcE1rVyJuoceBhwOzzGnxYK6B+eD6fXgfkPYkTLk50vVREJIFKQY4u4OYAaA/gAKAGQCuCyK77+dMVbOGCtvbGyMtzmEpKyGl172Cc4eLlfMwRkAsqZMjr1RfuqffBJVw0egamgJqoaPQP2TT0p2bUK0RooksYsA7OecN3LO7QA+BDARgJkxJvbQewOoDfTNnPNXOeelnPPSnJwcCZpDSGpK1FB0y7qvgz7XtHIl9k69EFUlw7B36oUhE8rqn3wSlneWAk6ncMDphOWdpdh35ZVSN5kQTZAiQB8CMIEx1oUxxgBcCKASwFcArnWfMwfACgnuRQgJgmVnJ+S6gQJ/08qV2DPhXNTNe8CTCe6oq0PdAw/iwM03BwzalqXvBry+fV819aQJCYBxzuO/CGNPApgNwAGgAsCtEOaclwLo4T72c855W6jrlJaW8vLy8rjbQ0gqqX/ySSH4SfB/ORDWpQu41Rrz9ZnRiPzfP4O6eQ8EP0mvR8nOHTG2kBB1Y4xt4pyXdjouRYCWCgVoQsKrf/JJWJa9JwwVM5awwCwlvdksrLUOoeD5P3gKpxjy85F7371UJIWkBArQhGiAZx5XaxgDMxg6J7O5P4AYCgooYBPNChagqRY3IQoSLunKsuw9mVqWYJwHzjR3dyAcdXWom/cADtx8c5IbRoh8KEATohAHbr65U9JV/WOP+wZpMQNaZZjZLMl1rN9voIQykjIoQBOiAAduvhnW7zd0Os5tNsWX2mRdugC6EL9KDAbku6uZScHyzlIK0iQlUIAmRGZNK1cGDM4ixZbaZAyAkABW8NwimM6d0OkUQ0EBzNddi/pnfi/prSlIk1RAAZoQGTWtXIm6Bx4MeY4hP98zN60Yen2n+WFr+SaAMRgKClDw/B9QsqsKWVMmw/LOUk9tcClZ3lkaUYEUQtSKsrgJkUnTypWof/iR8GU4TSbAak1OoyTCMjKQffXMpGWcs4wM5D/9FGV5E1WiLG5CFKbhpZcjq5GtsuAMCHPnyVwOxm021M17AFVnj6TeNNEMCtCEyESxc8tqZrejbt4DFKSJJlCAJiSBQu3eRNs4Jo7SM98JiQQFaEISJNjuTWKQzr3vXjCjUcYWapejro62tCSqRwGakAQJVvVLPJ49fTryf/8M9BIV8SAB+H0oIkRNKEATEoWmlSuxa8K5Qu9saAn2TDjXZ77Tu1Rn0KpfXsezp0/H4A3fw3zD9QFPNQ4shqGgQNLXkIqCbXVJiJIZ5G4AIWrRtHIl6h56GHA4PMecFgvq5j2AunkPCNsynjkT0bWqhpYAEKpw5T+5QDjotzOV+Ybrkf/EEx33DrVdYzh6PVhamrBtZCpS0HJSQiJFPWhCItC0ciXq5j/kE5z9RRqc/b+nbt4Dwlx1ooKIToeCRc+C22yJuT4hJCEoQBMSRtPKlah/7PGkb1QhzlV77h8rlwv1TyyAPjtbopapkMkkdwsIiRoNcRPi1rRyJeoef6KjMAhjMF8/Gy3rvpan9+l0omnlSqGgSZz352fOwBlJURQtYgwFT1GSGFEfCtCEwKsmtvcwM+dJrYYVSKc2xSMVA7T7QxaVACVqREPchMBd2EKJiURKbJOacA7Le+9TZTGiStSDJgRUdlPTHA7UzXsApz78EPaDh+Cor4chPx9ZUybj+MpPoW9pBgCcTuuCltvm4sJ7filzgwkRUA+aEFDZzVRg/X4DHHV1AOdw1NXh1DtLYWhpBgPAAHRrP4Oef3sOq//8ptxNJQQABWhCAAhlN0lqYQGOpXEX0t74e9LbQkggFKAJASiJiHj0aD0ldxMIAUABmhCSDCxQf1WZTmZ2l7sJhACgAE0ISQaVZKNzAO033SF3MwgBQAGaEEJ8UBY3UQoK0IS4sS5d5G4CkZmOtv4kCkIBmhC3/CcXAHq93M0gMsq+/DK5m0CIBwVoQtyyp09HwaJnwQL1ovT6wMeJprSs+1ruJhDiQQGaEC/Z06dj6IbvUfD8H2AoKAAYg6GgAAWLnsXQDd8Lx9TAaJS7BapEFeWIklCpT0ICyJ4+PeDa6Nz77kX9Y48rf2/lVNwYQwJUUY4oCQVoQqIgBu2Gl14WelsZGR3bUxJ1MxioohxRFBriJiRK2dOnY9Ca1SipqkRJxWaYb7he7iaRaPkVTmFmMwqe/T1VlCOKQj1oQuKU/8QTsu8bTSLHdQzDKivlboZsymrKsHjzYhxtPYq8zDzMHTsX0wZMk7tZJADqQRMiBVqepR4udVQ1S4SymjIs+G4B6lvrwcFR31qP+evn4+wlZ2Pcf8ehrKZM7iYSLxSgCZGAedZ1CbmuPsWWdjGTKeH3aM/tmvB7KNXizYthcwZOcLQ6rXho/UMUpBWEAjQhEsh/4glhLjrYphA6XdS9bJaRAZcEbVMNgwFITw/+fAwbbvj3lZ3pBmTc86uor6MV9a2hl5FxcCz6YVGSWkPCoQBNiETyn3gCJVWVKHj+Dz5FTfRmMwqeW4SCRc961lZHEqy5zQZusSSuwQoiJmnxpqbgJ0W74QZj0D09F225XcEZ0JbbFYZH78LQ61JzM4xIe8aWNgsWbliY4NaQSDCuoF1mSktLeXl5udzNICThqkqGqWaHJ0no9TDPug4t676Go74ehvx85N53b6es6b1TL4Sjrk6SWxoKCjBozWpJrqUFl7x/SdgetLfZQ2bj0QmPJrBFRMQY28Q5L/U/LkkPmjFmZoy9zxjbxRirYoydyxjrwRhbxRjb6/6bNlklxC0RBTGUWuWMdemCgkXPIv+JJzzL0watWR20EAwLVAXNEOWCE8ZoTbOfaIIzALy3570EtYRESqoh7sUA/sc5HwpgFIAqAPMBrOacDwKw2v2YEAIhEEUddEJgGRmJD0jeQ/N6ffiELr0eJbuqMHTzpojXF2dPn4783z/jkxwnDn9HzGRCwR+eozXNEIa1L3n/Epy95Oyov9fFXZ2GxcXrjVwyEpe8fwkllCVY3EPcjLFsAFsADOBeF2OM7QZwPue8njGWD2At53xIqGvREDdJJU0rV6Ju3gNRf5+hoAC5993rqWbmPVx84OabYf1+Q3QXNBph7NsH9n3VIU8z33A98p94wqf9ocqe+p8fr6qhJUGf05vN6PXIwxSUvZTVlOGxbx+D3RV72VcddMgwZOCM40zA5w3MgIXnLaR11HEKNsQtRYAeDeBVAJUQes+bAMwFUMs5N7vPYQBOiY+DoQBNUs2useeAnwn8yy8ggyFsxatogrTp3Ano9+9/h/4+9/xxoGDbtHKl8EHBe944xPnx2DPhXDgDJM2xLl0wdPMmSe+lBZOWToKlzZLw+2SnZeObG75J+H20LJEBuhTABgATOecbGWOLATQDuMc7IDPGTnHOO81DM8ZuB3A7APTp0+ecgwcPxtUeQtQkml40M5uRH2Uvsf7JJ2FZ9h7gdCYscCZL08qVqH/4EXCvjUCY0Yj83z9DPecAYhnWjtX2OduTdi8tSmSAzgOwgXPez/14EoT55oGgIW5Cwqp/8sngpUIZg/n62aoNqlLz9NhDZIITQTIDdBdDFzx+7uM01B2jYAE67iwVzvlRxthhxtgQzvluABdCGO6uBDAHwCL33yvivRchWpT/xBPoMnYs6p/5vWfdM82pBhZsG1DSWXZaNpraQ6wrl9AZxxk8tP4hAKAgLSFJ1kG756FfA5AGoAbAzRAyxJcB6APgIIBZnPOToa5DPWhCCJFGWU0Z5q9P7uIZmo+OTcJ60ADAOd8CoNPFIfSmCSGEpIBk9dhTBZX6JIQQjRF3rSLqRgGaEEI0JtSuVUQ9pCtlRAghJCkWbliI9/a8Bxd3Qcd0uG7wdT51s4+2HpWlXeZ0syz31SoK0IQQoiK3fX4bNhztKCjj4i68u/tdrKxeCavDCpPBBN5po83kmD+OKjpLiQI0IYSoRFlNmU9w9iaW4wxWlpOoD81BE0KISizevFjuJoQ0f/18TFo6iTbRkAgFaEIIUQm55pajYWmz4LFvH6MgLQEK0IQQohJ5mXlyNyEidpdd8b19NaAATQghKjG592S5mxAxNfT2lY6SxDRm3du7sPObOnAXwHTA8PMKMOVnQ33OWfHSZhzZbfE87j3EjBn3jU1ySwkh0SirKcOKferZ0oAxhrKaMqrNHQcK0Bqy7u1d2PF1x7683AXPYzFI+wdnADiy24IVL20OG6T3bDyK71dUo+VkG7J6pOPcGcUYPF4dQ26EqJ3aio+4uMtTzYyCdGwoQGuId3D2Py4GaP/gLDqy24IlD38bNPj6B/+Wk21Y9e9K1FdbfHroFMQJkU5ZTRkWb16Mo61HZVvbHA+b04bFmxdTgI4RBWiV8w6Iofz1jjVgYTIOxGv4B989G4+GDP4APOetfrMKLif3XGf1m1UAQEGakCiJ9bTV1GsOhOaiY0cBWsX2bDyKL9+sBHdGdj53RXf9HV/XIb/YjO9XVIc9DwB2rK+D/4d8l5Nj7du7MXh8XkTz44QQgdqGtINRS+a5ElGAVrGvl+2OODjHKpLeORB8eB0A7G1OvHLXV56eNRB4fpwQ0kErPc+5Y+fK3QTVomVWKtbWmuDoDHjmkuPlHZy97VgfPLATksq00POcPWQ2zT/HgQI0CSuSHnTMuJCARgjxNXfsXGToM+RuRkzyM/OxaNIinx22SPRoiFvFMjINsLU65G5G3MS5bkokI6SD2PN8duOzaGpvkrk10fni2i/kboImUA9axXr2zpK7CZIJl4hGSCqaNmAavrnhG2SnZcvdlKgs3LBQ7iZoAvWgVSbSZVVq03KyDX+9Yw3SM/WYPGsI9aYJcSurKQNjTO5mROW9Pe/R8LYEqAetIns2HsVXb+3SXHD21tbqxKp/V+Kvd6yhuWmS8spqyvDoN4/C0maRuylRcUW7ppMERAFaRb5fUQ1He+r84O/4uo6CNElpz258Fg6uvjwTXbiqSCQi9K+oEns2HtV0zzmYnd/QMiySutSWHCa6bvB1cjdBE2gOWuH2bDyKNf+pgtOhvjq8UqCRMpKqymrK5G5CTIq7FdP8s0SoB61gezYexZdLUjc4i95e8L3cTSAkqcQ63Gq0//R+uZugGRSgFez7FdXgrtQOzgBw6qiV5qJJyli4YSHmr5+v2jrclCAmHQrQCpaKc87BhKr1TYhaLNywEKPeHIWzl5yNUW+O6rReeOGGhXh397sytU4alCAmHZqDVrCsHukUpAlRuLKaMiz6YVGnpVD5mfmYO3aupyKYf/B1cZfnsThn+96e95LT6ASiBDHpMM6VM4RaWlrKy8vL5W6GYohz0DTMLbjr71N9CrVkZBrAwdHW6kRWj3ScO6OYCpyQpCqrKcNj3z4Gu8se8rzstOygGdk6psPWX24FAJy95GzJ25gsOqbDdYOvowSxGDDGNnHOS/2PUw9awcRgs/bt3bC3JX7nKqXz37LSuw55y8k2fPWWME9NQZoky+LNi8MGZyD0cinvOVsd06luDteoM+LpiU/TrlUJQJMFCjd4fB5uXzwFd/19Ki6+eRiYXu4WJQ7TAYa04CUNg21ZKXK0u6imN0kqKfZs9p6zVdvwsDndTME5gagHrTIGgx52pzZ709wFDJ2QH1dCGM3Zk2TKy8xDfWt9XNfwDsrec9Eu7lJkj3rRpEUUkJOE5qBVQqzDrfVSn4Y0HQAOR3vsP5dZPdLRb8RZ2LvpGNpahQ8zGZkGTJo1mIa/iaQinYMWMTAwxjzBN9ScbVlNGRZvXhz3BwCpbZ+zXe4maA7NQatcqtThluI1tpxs69QLt7U6sOqNSgA0R02kI/YkA2VxB8LBse2X28KeJxYqUeJa6Evev8QnO50kDs1BqwQN3UqAA18v2y13K4jGTBswDeuvX4/tc7Zj0aRFMOlNQc/Nz8wPe72ymjI8/M3DigzOAFDfWo8F3y1QbSlSNaEetErQmmhpiEPehCTCtAHTMG3AtIA94Ax9BuaOnYvbPr8NG45u8Bw3MiMc3IG8zDxM7j0ZK/atUNy8sz+b04bFmxdTLzrBqAetEufOKHbPzxJClG7agGlY8NMFyM/MBwNDfmY+Fvx0Af659Z8+wRkA7NwODo761nq8u/tdxfac/UmRwU5Cox60SojzpmKRDhIbY3p069TWvb0LO7+pA3cJy8CGn1eAKT8bGvQ4ISKxNy0qqylDdbN2lgHmZeZ5EtmOth5FXmYezU1LjAK0igwen4fB4/Pw1zvWyN0U1dJF8RO/7u1dPslm3CXUBN+5vg7eix/E4wAoSJOgFm9eLHcTJNW3a1/MXz/f81icmwZAQVoiFKBVZs9GGlaKR1urE3+9Y42nNCgQ/ahEsJWJO76ug+XYGcy4b6wUTSUao6Uh4eJuxZ2G6gGam5aaZJOajDE9Y6yCMfaJ+3F/xthGxtg+xti7jLE0qe6VqvZsPIov36yUuxma0HKyDaveqMSXb1ZKOmVwZLcFK17aLNn1iHbkZWpjed+EvAkhh+rrW+s77dJFYiNl1tFcAFVej58D8BLnfCCAUwBukfBeKenrZbvBKQlZOhwJ+fc8stsi/UUV4sS3/4X1uRLwBWZYnyvBiW//G/9Fty0DXhoBLDADz/UX/iwwC8e2LYv/+goxd+xcZOgz5G5G3AL1nP29u/tdCtISkKSSGGOsN4AlAJ4BcD+A6QAaAeRxzh2MsXMBLOCcXxrqOlRJLDSae1YfLVUwO/Htf5G9+ncwuDqyjDkAru8C3YzFwMhZ0V902zJg5W8Bu7Xzcxmjga6XAgYzkNUVGDceGDQ41uYrQllNGR795lE4uCP8ySrnvUsXCS3RlcReBvAAgK7ux2cBsHDu+Sk8AqBQonulpHVv75K7CSQGtlYHVv27EvXVFvUlkG1bBqy8F7C3AgB6APDfyoQBYM4zwIe3AYc2AFe+GN09Vj8VPDhnXwPo3DNjLS3A1+uEr1UcpCsaKlIiOAPCLl0jl4yk7O44xD3EzRi7EkAD53xTjN9/O2OsnDFW3tjYGG9zNGvnN7FvIEHkt+PrOnUl+G1bBnx4uyc4A52DcyflrwOf3B/dfZqOBD7e9dKO4CxyOIAfNkZ3fYV5b897cjchqcT13VR5LDZSzEFPBHAVY+wAgKUApgJYDMDMGBN76L0B1Ab6Zs75q5zzUs55aU5OjgTN0SaFFxYiEVDVVpifPQhhADtK5a/7zhtvW+aeU84W/jzX3/f57N6Br6M3Bz7e0hJ9mxSirKZM8RXCEkXM7ibRiTtAc84f4pz35pz3A3A9gDWc8xsBfAXgWvdpcwCsiPdeqYxRETHVU1WBGevJ2L/3sweFv7ctA5bf6Xst60lgxV0dQfrCxxGwb+60BL52Vlbs7ZLRbZ/f5rNmOBVpaZlZsiTy1/6DAO5njO2DMCf9egLvpXnDzyuQuwkkTlk90uVuQnJYTwoBePVTQKBtGJ3twnPiOYF66qc/B1ztvsdc7UKimMos3LAwosxnrdPKMrNkkrRQCed8LYC17q9rAIyT8vqpTEww2rG+LqaRRyI/sTCKKph6xNeLXnGXEIiDaTosJJYFY9si/N31UmG422kRgvagubG3SSapNu8czOTek+VugupQJTEVmfKzoZjys6G03EqlVLXU6vLnhOHpQD3gSIQKzpGybekI1CqWqvPO/r4+8rXcTVAdmtnUKNr5SllUl0MwchYw829yt0ITdKp78xOjvrVe7iaoDv3kaFBWj3RccONQ9QUFiRjSwi4ISjpV5hCMnAXoFVahN9plXApw3eDr5G4CUSka4lahjEwDbK1Bih0wYa5THE5d9e/Uqt0tboLx5ZuViiiLqoqtKMVkrabDANML9U+zi4AeA6QZqpbSpn9HXwxFJgs3LMSy3cvAKWmExIgCtApNmjUYq9+sgsvp+x+f6YGLfjnME5wHj8/D2rd3w96mgEiVJC0n2xTxoWTEZIUHZdG2Zb4JXeKnmqbDwh+l4S6hzbGUFU2ihRsW4t3d78rdDEVh4UvdED8UoFVIDMDiNolirzFQEtL5PxsSMJiTxDGkMXUEZ0BYs6y0XnI4H94eW1nRJKLM7c60sFFIslGAVqnB4/Miygr2D+ZaxHTKqbRmSNPhghtVEpyB+JZSyYYD5f8C+kxQbE+aMrc7szlt4U8iPihApwDvYL7ipc2a2g7RkKaDo13aX4b6NAZne/QjDumZekyeNURdy6lUiwvz5goN0KQzKlQSvRTN801dM+4bi95DzD7Heg8xdzqmZMZ0PYCObPX0TL2k17/jTxfg4puHISOz4/OrPkxmeEamAbf+cYr6grOaU/2DbbRBFCdDn4G5Y9VXZEZu1INOQTPuG4s9G49i/bI9sLU6cGS3BemZelx88zBVDIWLSW+JTAgLNIWw7u1d2PF1gF3FmJC4p0pqHooNttGGAuRn5gdd92tkRth5jAVgVIiBYcFPF9B2kzFQ8cdnEqs9G49i1b8rfZZqtbU68eWbleg34iwwaTukqhKqQznlZ0MxYnKBz94OhjSGi28apr6esyi7SO4WxO7Cx+VuQVBzx84NmhSVSsEZELacpOAcG+pBp6DVb1YFPM6dwIEdJzB8YkHgnmIKCNehFMutqp732mcwqLLAu4Lnn8WAtHjzYqqgRWJGPegUFGrJVcvJNhzYcSKJrVEWcX5b07YtA5bf4bXO2evnQc1z0gozbcA0fHHtF3I3g6gY/W8kPrJ6pCt+DjqR7G1OrHhps9zNSIxty4CXRgi7SLkCFK/RpwEGlWyJaeohdwtIhGYPmS13E1SLAjTxce6M4tTZtziII7st2LNRxZvLi4F4gVn4e9sy4c/K34auDuZsB+zWpDUzZjqjsNuWSpjTzXI3ISmy07Jh0ps8jxkYZg+ZjUcnPCpjq9SN5qBTUO8h5oBrobvnmTzJTl+9tUvy9cVq8v2KanUmfvmX7mw6LDxOy1JH8A0nu0hIDlPw/LO/+ePm47FvH4M91q07VaK5vRnb5myTuxmaQj3oFBRsLfTPFpwLQFhilMq7YQFQ7zB/oNKdznaVVgzzk10E3LdDVcFZZGDa7wtRIRLpaf+nhgQ0476xIZ+PpCet0zNwcEXsGiU11Q7zayEQB6IzKnpZVTCpsmmGgRmoEEkCpHAfiYQj9qTFYJWeqfdU18rqkY4Lf1mCzGyVBrIQDGk6nDujWO5mEG/pXVXXcy6rKUuJ4Jydlo2F5y2ktc4JQD1oElK4TTliquTFgBGTCnBgxwnZh5LFrHVxw41QO4Mp3pKr5G5B4lhPAk92D7xQPS0TuPJlxQXwZzc+K3cTOpGqiplRZ8TTE5+moJxgFKBJXKJdluW9ocQUAEse/la2IJ3VIx1zfj9RlntLbslVwP51crcisYJVkWlvFbagBBQTpMtqytDU3iR3M3wwMEmCszndjPnj5lNwTgIK0CQu584ojjjje8Tkgk5VuOQKzpoZxvbP2k5ZXEiQU0iAXrx5sdxN6ITHUC1Ox3RwcRfyM/Mxd+xcCspJRgGaxCXS/aa755kClsgM1wOPdevHUDIyDZg0a7A6h7G9bVvm7jmqsExnIigoQe5oq/rW0TMISZ86psN1g6+j9csKQAGaxM17nnrPxqP48s1Kn8zu3kPMQbPGz51RHHQeW5wPjnqeO0hpaWO6Huf/TEP7NX/2IDQTnHVpgEs7owB5mXmqqsFd3K0Yy69eLncziB8K0ERS4ZLKAp1fX23ptDmHOAQ9eHxeRAFaE0le0VJQjzFueiMADsRTzENB5T8n954sawZ3dlo2GGOwtFkiOp+CszJRgCaym/Kzobjxdxej9ugR3yf+3PncHlm98NSNb3seG9J0uODGoakRkKOmol2q7K1AVj7QEmOvU5+mqPKfXx/5WrZ7Z6dl45sbvsHIJSMjOj8/Mz/BLSKxonXQRBFqjx4B5zzon7VvVeGvv1mNky3HPN+T1SM9tYNz2B6jSoKzKNbgzHTAjL8qJkEMkHcOWswej7SyFxUYUS7GuXL+E5eWlvLy8nK5m0FkwBiD98+i2WwGAFgslpDnpbRty4SdqVLdNf9UVHAGgEvev0TWOejtc7ajrKYMD69/GC4EX2FBm1koA2NsE+e81P849aAJUSuFBSXZKPDfYe7YuTDqjLLdv6ymDNMGTMPvJ/0eabq0Ts/nZ+Zj0aRFFJwVjuagiaKIPeempiafx/49aUIAKCoxzJu4XnjRD4siTtSS0uLNizFtwDTPH6JO1IMmRM2yi+RugbwUlBjmb9qAaVh//XrMHjI76feub61HWU1Z0u9LpEUBmiiKxWKBxWJBdnY2srOzPY9JEBc+DhhNcrdCHqW3KHJ429+jEx6VJUgv+G4BBWmVowBNiJqNnAWM+hnA9HK3RHqltwgJYJ0+gDDhuStflKVZEdm2DHhpBLDADLw0Ao92GYztc7Zj0aRFSWuCzWlTZMlREjmagyaKRL3mCG1bBmx9G5rblNs/AK9+Cmg6AmT3FkYNlNxz3rYMWPlbwG4VHjcdFh4DmDZyFpbvXY4NRzckpSlqLDlKOlCAJkTNVj/VEQi0wtTDNziPnKXsgOwv0HtitwrHR87CzEEzsenYJkl2lgon0rXQRJkoQBNF6Nu3LxhjEZ1HvDQdCX+O2ig48SsiQd6TMsdJPPXWeJxxnElaU6gIibpRgCaKcODAAbmboE6m7hqryZ2urt5yINm9hWFtL2WZXfBYTg/YkxicZw+ZTUusVI6SxAhRq23LAJtF7lZIiAEz/iJ3I+IXILN+cY/usEcwQhSt7LRszB4yG9lp2Z5j5nQzFSHRCOpBE6JWq58StvDSDI2UcBVHALwS244aAgfnnxgn4uqMG9BDdxZOuk7gI9s7+NH+bUS3MelN+OaGbwCAgrFGxd2DZowVMca+YoxVMsZ2Msbmuo/3YIytYoztdf/dPf7mEkI8tDj//OFtwCf3y92K+I2cBdy3A1hgAe7bgbwAO0b9xDgRv+hyO87S54AxHc7S5+AXXW7HT4wTw17eqDPiiZ8+kYCGEyWRYojbAeB3nPNhACYAuIsxNgzAfACrOeeDAKx2PyaESCW7t9wtSIzy14Xhew0JVJv76owbkM4yfI6lswxcnXFDyGvlZ+bj6YlP0/xyCoh7iJtzXg+g3v31acZYFYBCADMAnO8+bQmAtQAejPd+hBC3Cx8Hlt8BuDS2BhoAPntQ/cliXsRg+tD6h8DdQ/k9dGcFPDfQ8fzMfMwdO5eCcoqRNEmMMdYPwBgAGwH0cgdvADgKoJeU9yIk5Y2cBYy9Se5WJIaWMtPdpg2YhmcnPet5fNJ1IuB5/sdnD5mNL679goJzCpIsQDPGsgB8AOBeznmz93Nc2MA3YAYIY+x2xlg5Y6y8sbFRquYQon1iFTGiGtMGTPPU5f7I9g7auM3n+TZuw0e2dwAADIz2a05xkmRxM8aMEILzW5zzD92HjzHG8jnn9YyxfAANgb6Xc/4qgFcBoLS0VCNpnIQkgRariIkUuo2kFB6d8CjG5I7BQ+sfAs6gUxb3Xt1ObJ+zXe5mEgWIO0AzofzT6wCqOOfe1es/BjAHwCL33yvivRchxIsWs7hFaq8mFoY4XP3Yt4/hx9Mdy6qMOiOenvC0XM0iCiPFEPdEAL8AMJUxtsX95woIgflixtheABe5HxNCpKLELO7sImEHqnioZBvJeE0bMA1PT3wa+Zn5YGCUnU06YcL0sDKUlpby8vJyuZtBiLJtWyZkOQdMpNIBkKt4CQOueVUIrgvMiKnwSP8pwJyPpW4YIYrGGNvEOS/1P06lPglRk23LgA9/HSQ46yFfcAZ8AnLpr6L/9p5DKTgT4oUCNCFq8tmDCB6EFbAeevVTwt9XvigMVSOK+tN3b0xIkwhRKwrQhCjdtmXAc/2BBdnKXx/snbh25YtCqctI5qT7T0lYkwhRKwrQhCjZtmXAiruUH5hFgRLXRs4SkseCoXlnQgKiAE2Ikq1+CnC2y92KyF34ePDjflswwmgSetcUnAkJiAI0IUr1yf1A02G5WxE5U4/gy6NGzgKm/8ndk2bC39P/lBLLqQiJFe0HTYgSfXK/sKuTWhhN4YuLjJxFAZmQKFAPmhAl2vSG3C2IDvWGCZEcBWhClIgrYMlUpJiegjMhCUBD3IQoxbZlQlKYXDW2dWmAK4aEtHNukrwphBAK0IQog7icSs6M7ViCc/8pwnpnQojkKECT2O3dA3z7LdDm3tM2PR2YeB4waLC87VKjzx5U13KqtEzgypdpaJuQBKIATWKzdw+wZrXvsbY24Ks1wtcUpKOjhkIkTAdwl7BE6sLHKTgTkmAUoEl4e/cAP2wEWlqArCxg3PjOwVnEudCrpgCtLUzfkbjWdBhY+VvhawrShCQMBehE0cLw7/p1QGWl77GWluDBWdRmE16/ml4rCc0/q9xuFYblKUATkjAUoKXi3ctMTwfa24XepKitzTew+fdIYwlmgXq28QbF9euAqirftsfih40UoCO1bVnH8LGaWE8KbacgTUhCUICWwt49wtyrGNTa2oKfu24twBjgcAiPW1qAr9cJX++qAurqOs4tKACmzwh+T++A792zjTUwBuoxx6qlRZrraNm2ZUIvVA3zz8GsfooCNInZlpom7G+w+Rxj6NhZnAHol5uB0QOyk900RaAAHY9YApozQAEKh8M3wIvq6oCVKwIH6XXrAl//qzWhA3SgXjfgOxwvhaws6a6lRduWCfO4dqvcLYmPXGu2ieoFCs5AR3AWvxbPScUgTQE6VlL2NoHgQ8p1dYGDqtMR/Dr/eEXopXPuO/Tt39MXe93iuVLq00fa62nN6qeiC846I9CjGDi+K3FtikWg7SUJicCBAME5mP0NNpzVNQ1FOaag5xxutGLn4RZY210wpekwvCgr5PlqQAE6VlVVybuX/1C2uJQpFO8gLA6hf/tN4EAsdXAGgD17gLx8mocOJpqepzETmP6yMJSstE00gm0vSYgf7wCqY7495UiUVzejvLoZPbsaMGn4WZ2uXbG/GU53Goe13YXy6macON2u6p4344n45Ryj0tJSXl5eLnczIvOPV+RuQXSyspI/LxyoF08EL42IbitJMYnMe7mTEixokrsFRAX8A2i8/IP0/zY3wtoe/OKmNB3yzGk4amlXZA+bMbaJc17qf5x60LFKxLBwIsmRtBWoF09BWjDokuh6wmKGt5KCc+ktcreAyMh/SDlUANx5uEWy4AwAx0/7TvGFCs7i897z3WIPu7y6GYByk9EoQPuLdOlSSYm0c9Ba53DQ0ivRtmVAxX/kbkUcGFD6K6rBnaION1qx9UAz7F6fFQMFwM01QvAryjGFDaDxMqXp4rqHmIx2oMHmGXo36oFR/brJ2sumAO1t7x6hp+e9BGrNauFPVpaQ+HToUEfwLijwXRZFQqOlV4LVT6mr7rbIaNLWvs/1FcCeTwD7Gd/jGWag+BIgf0zwcwwmYMh04RwN21LT5BO0vJdAhePiwCavXmoi5ZnTAmaER8v7tdmd8Oll95ehh00B2tsPGzuCs7+WFt8ec0sL0NqanHZpBS29EqhlaRLTCYHIfkbI1tZS/e36CqDyg8BTBjYLUPURYDkI1JUHPsdhBXa+L3yt0SAdaBlUtJN6iZoE7Nm1I3QdbrTi0HEJl4gGIcdyLwrQ3qLt4alpDloJxDXXqS67d3QJYnI5azBw90a5W5EY1V+Ens932YHaHxA6xLiE62g0QEezDCqZstKZT4KY1PPboexvsFGAlsXePepL/FKTggKafwaAJVepIzgDyltzLSWbJYKTIvhdENF11EnO34RGvTBE7h94Aw0zJ3p+W04UoIGOuWcKzon11n+krRuuNkuuAvYHqQBHkosZAW6P/zoZ5vivQTqxO4UgrTcwtDt4yGVR8SaIKRkFaCD03DORhncynXexlVQK0hSck6e+QphHdnkFYWYEhl0tzC1LEZwBIZlMg9bvPCF3E2B3AgwcpcWhM6mHF2UlJRFNDqkboKXatYnEhnMhO/6HjanZm1aDnkPlbkFs6iuAne+h0yAttwM7l0l7Lw3NP3uva1YKDmDrgeaQAfrE6eSuiPh44zGMGZCc5VfaDtDBNoZYty54LWuSXFTERJl6DlVvglj1F0jaDGrVcqBkZnLulUBSV/qSkj1ILl+g9djJ4ORAxf6ONd6JpEvo1eUkbscoZmZ7r2mm4KwsYhETres/Re4WhGc0Adf8U73BGUhu4lbtD8m7VwIlMxNaCuIHimQHZ5HTJfybJZp2A7T3BhNE+VpagDf+JXyw0qo5Hys7SGcXaaMQSVITt7QxRaakYW1/aQbW6ZgSPlAk499MmwF65Qq5W0Bi0dYmJI9pPUgrcYOJ7CLgvh3qD85A8hO36iuSe78EMKUpNxR0M+k7HVPCB4pk/Jtpcw6aym+qF+dUszvZjCZtbRuZP0bI1K5N0jB91UeqSBbzLtvpvzlEZrpylyqdON15SlLupVV6nZA9nmjaDNBEMRozcnAoawDa9OlId7ahT0sNcmyNIb+Ht5xGwz//iLphvTFm4uwktTSFaWFY25+5L3Bsm1CSM9FcdsUni/mX7RQ3hwCE0pWBgqBScAAfbTgGQBjuHtm3K4YXZWFzTTNcMswwMABj+lMWd2y0PDyqMo0ZOajuNgQunTBE1WbIQHW3IQAQMkgzMPRydUHOjhM4YHkT/ab9MintTYhP7gc2vSGUlWQ6gBkAl4I2ysgu0l5wDrQGOtFqNwofChTakw5WtvOAu3SlWmbS2x0cm6qbcU5xN+h1gEuGJDGOxGdvi5Q78RCrVMgGVolDWQM8wVnk0ulxKGtARN+vA0PfIypOHvvkfmHPZ7HmM3cpKzjrjNoa2gY61kAnMziLqr9I/j0jFCwAqyUwe+MAth08LVsGdzLn67XXg6YtDRWjTZ8e8XEODobO2ZoMTEgeU+Na6fJ/yd2C4Ew9gMuf007vOdi2kMmk4LrcwbaJZBCWLKmNWP4zkfPQpcXdOq0NT9bcs0h7ATori4K0QqQ729BmyAh43F+g4OxDXCutpgCttP5J6S3AlS/K3QrpyTGkHYiC63L3y80IuF9yZjpTbZnM4UVZCSuu0j83wzOMLVZXC1UPPFESHqAZY5cBWAxAD+A1zvmihN5w3HhaA60QfVpqfOagAUDncqJPS03Q7wmZVEYfvGKn1eAMCEPLcgdnQNF1ucVsbe8s7sx0hpY2hX2IjMKJ0+0JCc5Z6czz71WUY0pqQPaX0ADNGNMD+CuAiwEcAfAjY+xjznllwm46aDAFaIUQA2ukWdxhk8qykje0pCnZRdoNzvUVChlaZopNEBONHpDts1XjcndmtFoFGhEINpQfjZY2ji01TUnd9zmYRPegxwHYxzmvAQDG2FIAMwAkLkATRcmxNYZdViUKlVSW4zjVUUudRE5ra5wBZcw3+zPlyN2CqKm37xycVK9pf4MNZ3VNk7X3DCQ+i7sQgPfu9EfcxwjpJGRS2eQpKpt/BpCWKe/9tVK601t9BVD5gbKCMwBYGzRRUYx0SEat7XBkTxJjjN0O4HYA6NOnT9Dzmpub0dDQALs9grmm0nGAU6Yc/BgZ7e3IPXQQ3ZrVmbAhhaBJZbwdGDRchhbFSZ8OoFWee4ulO7Wm+ouOZWtKs3OZ4oe5SeSUUFkt0QG6FkCR1+Pe7mMenPNXAbwKAKWlpQFHKJqbm3Hs2DEUFhbCZDKBsTAZvwBgsQB2Ba05DYFzDqvdjtr0DGDv7pQN0kGTynp3DtqqYD0lz321OKwtUsR8cwjrfg9MeVjuVkRE7nKZSmfsXAI86RI9xP0jgEGMsf6MsTQA1wP4ONqLNDQ0oLCwEF26dIksOAOA2QyEW7qjEIwxdElLQ2F+Hhr69JW7ObLJsTWiuHk30h02gHOkO2zoaa3HDwfs+Hb5TpS9tw2frd8vdzMjl907efdi7t8mWhzWFlUtl7sF4dlPq2aoO5nredUo4liTQAntQXPOHYyxuwF8DmGZ1b845zujvY7dbofJJO9kfTKYjEbYjWlyN0NW3kllDRk52NNtCLq7e9Td0wxoa2zFZ+v34/JJ/eVsZmQufBz48LbE36f/FGGXLK1Ty97L1V+oYqi7KMek2jXQydDukD+NLuE1yzjnn3LOB3POiznnz8R6ndg+zcj/DxwNJXxiUwzGsCtrIHR+Wd3peh1cR0/L1KgojZwlrD+WUs+hvo9TJTgDUM3/Z6UPw3uRomylTqO/tpSwBafsSWKE+Pj1bzxf6pcHHmzJVsLkUKTE9cflr0tzvbtTuda8FKtck0DBFcX85ZnTAq4njgZXwVsSrWSX9AxG/o8ICcI5R8XRM7hz5T6ULN6E/n/8ESWLN+Gulfuwpb4FXMKfqpOnTuHqOTchs18/9B17Dt7+4APJrp3KLEGq4TfJVSU/Vle+CFzzT7lboX6F4+RuQXg6o6Irivk7aok/kVYL8bm0uJunx2xK0yVtO8lwNNmDtjtduH/ZFnxZeQxtDpdnz1Crw4XP9p7CmpomXDTQjBcv6w+jPv7PKHfNn4+0NCOO7diJLTt2YNqNN2LU8OEYPnRo+G8mHYYN83moy+uKtsZWpHu9R21OF3R5XZPdsviNnAV89iBgPRn7NUw9pGuPGpXMBFqPA5ZquVsSWIZZCM4qmH8WJSOLW+njHmkGJntJz2A014PmnOP+ZVuwqvIYrHZXpw29XVwI1Kv2ncL9/9vv1ZOObSKltbUVH3xShqfnz0dWVibOmzAeV116Kf7z3nvxvZBUM2wYMGmKz6HLJ/WHLScTp9odcHGOU+0O2HIy1ZEgFsjlzwk9rFjo04TvT3WltwLDZc5Q13slchpMQnsuehY470FVBedk7WKl5OAMACP7KvcDv+Z60FsOW/BlZQNs9tCfDG0Oji/3WbD1aCtG53cFunYVNmPg0X2i3FNTA4PBgMHFxZ5jo4YPx7rvv4up/SlFpwPOvyBkhTDVBuNAxKVPq58Cmo4ATBe66AbTCT+P2UVCRrgWl07FwnJQ3vsbuwAXPClvGySw7aBKki0T7MTpdkX2ngENBujX1u9HmyOyOco2pwuvbTqGv9xQAGS4i2GcPo1On/mMaUGLnrS0tqKb3yYO2d264nSLTBWklGzqhcKWkS0twsYX48arr3xnvEbO6gi025YBK+4CnH4/WzojMPNvFJD9VS13L7WSuU+moiztUKReRqRj6DRiqQZKqbsdiOYC9JpdDRH/kLg4sLqmqSM4i3+3tgIuJ6DTA5mZwnGbDTjdec1gVmYmmv22QWw+3YKuWTLXYVYaxoRgnGoBORQxAHvPTZt6CEPZFJx9VS0HahWUwV61XJgTJx4urvz55mAq9gu/25UWpDUXoG1RZvja/HvbGRkdgdr/uN0O2HznbQYPGACHw4G9NTUYNGAAAGDrzp0YPmRIVO3QvJISuVugTN49aiJU4ar+QuilGrsIa3gcyZkrjYr4YUHFQdqoB6ReEKHG4AwAThewqVp5QVpzSWIZUa6RzTBEcX7XrkDXbkLPGgB0emSau+OaaVfg8eeeQ2trK77d+ANW/O9/+MV110XVjpilZwB6CT9nMSasRY61aIre79+TsYAJYIR0Ul8B7Hy/YwjZfkaZwVmklspmQYzq103uJigKB7C5pjlpyXOR0FwPeurQXHy2oz6iYW4dAy4syY3uBgF62H/769/wq1tvRe7w4Tirew+88qc/Yfiw4cIweaIVDwAqJdxeW8xqLykJfF2zWZhDdjh8jzMmfA8FYhKr3SsBqGnzBrX2FwVU6rMzFxeS55TSi9ZcgL51Un+s2dUAawRjN+kGPW6dNCC6G9hsneaoexQUYPmnn3Y+L1DCmZSzNHoDcOiQNNfy9o9X3NfXd2zbSQGYJIo4rK3k3nJA6q9xqdcJw7ukgxJqcIs0F6BHF5lx0bBcrKo8FnKpVYZRh4uG5WJU7+zIL+4fdF1O92N0nrcOlnAGBEw2ixpjwJQpwJrV8V8rGKczoqVQhITlPbfsXdCjvgKo+ghwRbDPe9JE+CFaDZXNQjjcaKXgHMT/NjfC2u6CKU2H4UVZsvWoNTcHzRjDi7NG4+JhvWAy6jsVctcxwGTU4+JhvfDirNHRbVDR2orO/3G5+ziEAH7iBNDYIPwRA3HXbsBZZ3UMj3ftJqxxjcbUC4WlSYDw9wVThaCZleB6sS6XsDSKkFiJQVicW7ZZhMdi0FZUcIYQeCMpKFP7A/DlQ8A3z6lmi0lvOw+3hD8pRYkV1qztLmyqlm9eWnM9aAAw6nX40/VjsPVIE/75dQ3W7GqAzeFEhkGPC0tycdukARhVZI7+wsHmlF3O4EPagXrZ/vPYQZZweWRlBV+iNG58YnvRgDDnTEg0vHvMgbjsoZ+XU8lMwNwX2LkszInu/+viBw5AVZXEklHmUws4gK0HmmXpRWsyQANCT3p0kRl/vXGsdBfV6QMHaZ0+SO9a5O5lB1q+BfgVSfFjMAhBOJD166RNEAsm0b10oi2RDluLw91KCtLiTlTRVisTP3CoKECb0nQUpCNkdwpTAskO0poN0AmRmRmgl8zcx8PMK3sH9gCJZp5edX29EBBDVduKNTB7J31FSqcL/gGBkECiGbZWUnAGOnaiimUJldJeSxjDi7IoizsKchQzoQAdjVCVxsRjwYhrpwMmmjV3BHibLXQJzEiDc7Agv3cP8PW6zsukgqEEMRItlQUqH7tXur+IIZNXRftAA7TMKlpOlzBvTwFayYJVGktL61RlzIeYwd3SgrD/+cU55UCBsaoqombixl8EPi5e89tvgLa20NeYeiEFZxI9pQ1bR8Nhdc8nx7AcUkX7QMeif24G9jfY5G6GrKztLmypacLoAVGs/omD5rK4ZWGzCX9CaW0Ves6R7pYVLHOaR/BLI1xm+qDBwE2/6rT/so+CAgrOJDZnqbzMrcsOsBj6Liqaf45Fqgdn0f4GG7bUNCXlXhSgpRAyQczN5Qzdw/YXLHM6kmVhkda9njRF6CX7lwodNgyYPiOyaxDirb4CqN8sdyvix+1A4XhooRhJKP1zgySupigdA9IM4d/zZH1Y0ewQN+ccp1oc2FvfimOWNjhdQtWcXuZ0DCrIRPdMQ3RroANxJ3v95Z+v4o2l72J7VRVuuPpqvPHnP8X/AoJlTgcrwSmKtu417TBFpBBuWZXaGEzCcquSmcJa50jOVyFxqJZ6x4J0ow6Xjc3xFCqRmyYDtMvFsam6GfWnbD6VcpwuoO5kG45Z2pDfPQPnFHeDzr+SSaROn/b0iAt65eHR++7F51+thTXcUHekgmVOi8HXO0jr9cCU8ynQkuSrrwB2Le+8p7XaOazCa8sfE9mc+pDpyWhVQlCQ7mBtd+GTH49FtMvXqooGXDwmyr0coqS5AM154ODszekC6k/ZsKkaKB3YLfqetM3mM1x9zZXTAADlW7fiSF19rE3vEC45a9IUqolN5FdfAVR+APAkbAojh53L3MVKtD3MDSgjSDMA/XIzcNrqwPHTEa4ySYBIt+BsaeMJXxutuTnoUy2OkMFZJAbpU60x/CAEKigSNyaUAO3alXrCRB2qv9BucPYRQWKmZ3mWeiUrMzkYDuDQcXX14hNdLlVzAXpvfWvEBeCdLmBfXWt0Nwi4Q5UUvGp6E6IGWplvloI4JK5ykSRIJZLTBVl7z9FK9Dy15gL0MUuYtb1+jkZ5flSZ2NFKxv7RhEhFZYU5Ek6sx61iStpqUQ1MaYkNoZoL0NFun6ao7dbEamOEqEHGWXK3IPmMXYI/p7RduaKUrLW9WsEglEtNJM0FaH2Uryja8wNxOByw2WxwOp1wOp2w2WxwRFpK04N1VBsjRA0sNXK3ILn0acCUx+RuRcIcoCzuqJxT3C3hZT81F6B7mdOjOj8vyvOR0fkNWfjiSzD16YtFf/oz/vv++zD16YuFL74U/Bo6vXAdsces0wvJYcF2uyJEkVJsOLRrkfuLYPO06s72TrF3My5GfXI2zdDcMqtB+ZmewiTh6HXAwIIoe61duwp/e81FL3hgHhY8MC/ya5yVgkODRINiqFetZpZq4NuXEPQ1F45LanOkFs27qdcpbHowyUb165aU+2iuB909y4D87hlhh671OiC/ewa6Z8bwGUUM0oSkMpUHpJhYGwIfLxwvVB1TsX5RlP3snmnwJEipe9wgeqVJGNoWaa4HzRjDOcXdsKkaQddDi8H5nOIYipQA4TfGCNlAzX0mIgEsr6jF85/vRp3FigKzCfMuHYKZYwoDHgcQ8FzFM/cFaoNs6pJSmOqDM9CxDvpAgw0coXvUJ047MHNCL2ypaUqpCmTJDM4AwHgkuyMlSWlpKS8vL+90vKqqCiWRbgDhxjnHqVYH9tb51uLOE2txZxlja6TN1rF3cyy6dgs51xzLayWJEyzQ+nt0+Xa8vfEQXFH+d9IxBPyedIMOz/3fSOUG6qrlFJy9XfSs3C1IiI82HAv6XP/cDE8wTxVXT+iVkOsyxjZxzkv9j2uuBy1ijKFHlhHjB5ulvXCwXaYiwigRTCWWV9Riwcc7YbF2LJ2ptVgx7/2tAOATOB9dvh3/3XAopvsEC+htDhfufXcL7n13CwqV1quur6Dg7EO7g7yhetGp1HMGEr/mORDNBuiEsNki3885EJq7VoxQPePlFbV46MPtsAYoymt3cty/TAicyRLsg4Fsqr+QuwXKouG5+H65GSkXiIHOI1t6XeLXPAdCAToasZbi1OmFNc7Ue1aE5RW1mPfeVtjd/wNrLVbcv2wLHvpwG6z28B/Aoh3GloLdyfHkyp3KCNCpWuJz+CzAchCo/QEQZ2kLx2li/jkYJWyiIYexA7ph5+EWWNtdMKXpMLwoK6lzzyIK0NGIthRnhol6zQq04OOdnuAscnFEFJzldOqMQipVRbL9otYUjhe2nswfo+mAHMjoAdkpFaBNaToU5ZhkCcj+KEBHQ6ePPEgb0yg4yyDY0HWsSVwkgOJLhLrTKi9tGZEMs/B688fI3RKSJHIMZQdDAToamZmRZXBTz1kWyytqcf+yLZ4gXGux4t53t+CvX+3F3gb17xRmVMoKPTFYVX8h9KQNJsDl0GbAPu9BuVugCP1TZC46WRXCIqXdAM05ULsJ+O5PwN4vALsNMGYAgy4FfvpboHAsEO0a6IwMIYvbK1Gsra0Ndz74IL78ej1OWiwoLi7Gs88+i8svv1ziF0TCefjDbQF7yGoJziajDt0yDDh2uj3g83YXcOM/v8dbt52b5JYFIA73equv6AjaWlFfQb1npM5cdLIqhEUqrs/kjLHnGWO7GGPbGGMfMcbMXs89xBjbxxjbzRi7NO6WRsNpBz64FVgyHahaCditALjwd9XHwJIrheedMXziz8qC97IKh8OBooJCrPvsMzQ1NWHhwoWYNWsWDhw4INWrIRE6o/A55HCsdheOnW5HlxBd5W+rT+LR5dsxcdEa9J9fhomL1mB5RW0SWxlC/hjt9TgpY91j9IBsWZYaJZOSes9A/D3oVQAe4pw7GGPPAXgIwIOMsWEArgcwHEABgC8ZY4M554nf8Jhz4KM7gN1l7sDs/7wLsJ8BdpUJ5/3fa9H1pMVM7NZWwOVEZtduWPD0057jV155Jfr3749NmzahX79+8b8eEpT/fLNWhPug4b3mWsxABxSwBEvsQWuJlkYDJDC8KAsV+5s1WYe7Z1flDSjH1SLOuff/xg0ArnV/PQPAUs55G4D9jLF9AMYB+D6e+0WkdhOw+9PAwdmbwyqcV7sZ6H1OdPfIyAi6ZOrYsWPYs2cPhg8fHt01SUQeXb4db208BP8CeLWWMO+3hrm4MLwva4CurwB2vg9AY7+5M8xyt0BRxB7m1gPNCFAmQLWy0hkmDVfeJkZSjlf8CsBn7q8LARz2eu6I+1gnjLHbGWPljLHyxsbG+Fvx3Z8BR4TzJA4b8P1f4r+nm91ux4033og5c+Zg6NChkl2XCMSKXVJXpzUZdfj5hD7QqbgglOzD+7tXQnPBGQAylPdLW25FOSZc+ZNeKC3upvohbz0T6mtfPCZX7qYEFPZflzH2JWNsR4A/M7zOeQSAA8Bb0TaAc/4q57yUc16ak5MT7bd3tvfzyKt9cRew53/x3xOAy+XCL37xC6SlpeEvf5Eu6GvR8oramOZQ39l4OPxJUZpY3ANVT1+Or3Y10hKseDg0OoJhqRbqjpNOinJMuGysBL+zZaTXM8XNO3sLO8TNOb8o1POMsZsAXAngQt6x80YtgCKv03q7jyWePcosQwl+sXDOccstt+DYsWP49NNPYTTGuBFHCvAvo1lrseKhD7cDgGe3pydX7vQpytG9ixFPTB8Op8Rd54nFPTwZ0XUqHyKPZVO2uNVXCD1nrQZnUe0PKVecJFKHG+V/7+PZlbzdoexP5XHNQTPGLgPwAIApnPMzXk99DOBtxtiLEJLEBgH4IZ57RcyYEX7+2Zsh/k9Pv/nNb1BVVYUvv/wSJpNyP43J5dHl2/HOxsNBA6zV7sSCj3d2CsyiU2fsnlrUUvq2+iT6zS9DodkEcxejcip1xeDG8X2Se0OtzjkHpOxf4nLaeTiezYOkoeV3J94JhL8A6ApgFWNsC2Ps7wDAOd8JYBmASgD/A3BXUjK4AWGdc6R7LjMdMPiyuG538OBB/OMf/8CWLVuQl5eHrKwsZGVl4a23oh7t1yRx3jhc79ditYcMkHZn4v4b1lqsqg7OP5/QBwtnnp3cm1Z/gdQIzm71FXK3QJGs7er+GTDq5W5BaPFmcQ8M8dwzAJ6J5/ox+ek97sIkZ8Kfa8gAzr07rtv17dsXStpTW2kSMW9MfCU9OAOpt/yo+gsqWBKAKU2n2iDNoLzCJP6Ut/ArXoXnAEOuENY5h5obM5iE8wrHJq9tKcB/bbLU88ZEIVJtw4xUeq1RGF6Uhc01zapMsDynuJuiE8QAaZdZKQNjwNV/B4ZOA4xdOg93M51wfOg04TxZsmu06dHl23Hvu1tQa7GCI7XXJmte8SXQ4q+P4Oj3RCBFOSaMHdANaQZ1/fuIO1YpnfZ60ACgNwoVwmo3d9TidliFXvPgy4Cf3i30tIlkllfU+lS4IhonDvfuXCZvO5JGhV3EJBG3ZjzcaMWm6uaI/6XkGh7X65S1Y1Uo2gzQgNAz7n0OMGuJ3C1JCY98tF3uJqSkQjlLnOaPASwHgdqN8rUhWaiiWFhijzTSIC1HcDal6TC8KEsVvWdAywGaJFVru4bq/qmEUc8w79Ih8jaiZCbQelwo6KFlxZfI3QJVEANfeXUE2/LKQG2FVShAk6CWV9Riwcc7YbEKS5Ay0/Qw6nVostpRYDZ5gsPzn++Ws5kpSSzeIvsGGQBQeiuw7unIVk6oUeF4yuCOQlGOCSdOtytua0o1liWlAE0CEtcvexN6yR0VwO59d0vyG0aQmaaH5Ywd897b0uk9KHR/cEpa4BZ3sNJycKYqYlEbPSAbZ3VNw87DLbC2u8LON189oRcON1oTtlOWjqln3tkbBWjSCSV8KZs4nRBofwz/0qkJVV8BVH0EuNRb5CWshu0UoGMkJo+JPvnxWMAdsMRiITsPtyQkOOsZMGaA8pdUBaK+Pj9JOBqyVjer3Zmc97D6C20HZ0C7IwMyGNWvW6fFat7FQhKVNHbV+F6qDM6AlnvQnAPNh4GD64Hju4VfJDoj0HMo0HcS0K23ZGugf/7zn2P16tVobW1FXl4eHnjgAdx6662SXFsOat84giRpDToV7yBREIOk97C3d0Z1IpZd9c/NkPR6yabNAO1yCuszG6sAlwOeNYwuO9CwAzi+C8gpAYbPAnTxF2N96KGH8PrrryM9PR27du3C+eefjzFjxuCcc9S51lrtG0dEw6gDwFhCa30ny/mHN+Gmys+QY7Wg0WTG6sITuPCeXybuhqlQTUyCzXRIB/9hb2/Di7Ikn4MePSBbuovJQHtD3Jx7BWc7OhcY4MLxxirhPAlKUQ4fPhzp6ekAAMYYGGOorlbnspPlFbVoSpHgDAjzuA6NBOe5W95HL6sFOgC9rBb0+PsLWP3nNxN301RYetRrpNwtSBlFOSaM6d95GDxWSt8IIxLaC9DNh72CcwhikG4+Islt77zzTnTp0gVDhw5Ffn4+rrjiCkmum0zLK2rxu2VbU2mPIgDaqBF1U+VnyHD6/sxnOO1Ie+Pvibtp/hghy1nLTlA+RjIV5ZhwTnE36COMTF2/W4Xi383GkJsuQPHvZqPrd6s8zzENlHHWXoA++I17WDsCLgdwaL0kt/3b3/6G06dPY/369bjmmms8PWq1WF5Ri3nvb6XNLVQqx2oJeLxH66nE3rhkpjBVZOyS2PvIRetD+Aok9qTD6frdKuS/8QKMJ46BgcN44hjy33jBE6TbHer/Xaa9AH18FyLvE3GgcZdkt9br9TjvvPNw5MgRvPLKK5JdNxmeXLlTE/OwqarRZA54/GRm98TfPH8MMOUx4KJnhWCtpbKYWnotKlKUYwo7RJ37wWvQtbf5HNO1tyH3g9cAqLMwiT/1vwJ/0S77iLS3HQWHw6G6OehUSQrTqjeGXQ6b3uhzzKY3ov2mO5LbkPwxwHkPaiOw6YypMc+uUIGWZXkznGgIeVyNhUn8aS9A64zhz/E5P75E9oaGBixduhQtLS1wOp34/PPP8c477+DCCy+M67qERGNt0TlYPPpaHDOZ4QJwzGTGyTv+X2KzuEPRQmAruZpKfMpInI8OFqQdZ+UGPV6qgr2eI6G9ZVY9hwpLqSIa5mZAztC4bscYwyuvvII77rgDLpcLffv2xcsvv4yrrroqrusmm9lk9NTcJuq0tugcrC0SlvYVmk349p6p8jUmf4z6t6Kk4Cw7McgGWn7V8H+3Iv+NF3yGuV1p6ci68x5NBGdAiwG673nCPHQkQ906A9BnUly3y8nJwbp16+K6hhIsuGo41dbWCKNOAbtcqZ1Wk95UKGiBkwk/R00vE1pf+TP0xxvg7JmLzN/cgwE3/p/MLZaO9gJ0tyKhCEm4pVY6o3Bet97Ja5uCzRxTiAfe34p2ShRTNQbg+etGKWOXqwD2HMrD9zsGouVMBrK62HDuiH0Y3Oeo3M3qzKD++UstCVbgZMCN/wdoKCD7094cNGNCJmlOiXs+OkD1VzE4D58lWblPLfjDtaPkbgKJ00uzRysnOJuLfR7uOZSHrzYNQ8sZEwCGljMmfLVpGPYcypOnfaFYG4Dy1+RuBUlx2gvQgFC+c8T1wDm3AbkjOgK1zgj0GiEcP/sGScp8asnMMYUwm6JMsksCPX2IiojJqFNOcAaEfaK9fL9jIBxO3/9zDqce67fEMxyfwJ8Ni7pWYhDt0d4Qt4gxILsIGPkzuVuiKkqci54woDu+rT4pdzMUzahjePYaBZal9KrX3XIm8MYFtnYj9hzKi36oO8MMnDUEqN3Y+bnC8UIVMCo0QlRMmz1oErOZYwoxsbhH0OcH5WYmss8SEAXn0ArNJuXOOxdf4ln6mNXFFuQkhu93DIzuuuIa5ZKZ7nKj4k8lEx6XzPS5t4/C8dovUUo0Qbs9aBKzt247F48u3453Nh6Gk3PoGcMN44uwcObZAISyoM9/vjs5WxqSoExGPZ695mxlBmaRuFSp+gucO2IfVv0wAoGGpYP1rn0xAFzoORdf0nHtkpnCnxD3hs3S+fsAoPYHBF2S6TeHTkiyMa6g2sulpaW8vLy80/GqqiqUlJTI0KLkU9NrnbhojeKCtJ4xODkXf5VrVqHZhHmXDlF2cA7gtblfoq2t88BdVhcr5lzxTehvvujZBLUKQkKY95yzubjTHDohicIY28Q5L/U/Tj1oErN5lw7Bfe9uUUwgFHuUWu/dv6ykTO0oTf7ZCHz130o4vFZAGvROnDtiX+hvTPS+zBSMiQLRHDSJ2cwxhbhxQp+kz0kHIw731mk4OCsuUztKg8fn4YKfD0NWj3QAHFldrLjgnEoM7nPMPaQc6FcSA4ZMT3JLCZGfZnvQnHNsP74db+x8A+uPrEebsw3p+nRM7j0ZNw2/CSN6jpB8v9C9e/fi7LPPxrXXXov//ve/kl5bqRbOPBulfXvgyZU7A264YdQB9jg3mJ5Y3AObDzXBaneGPE8MXAVmk2Z70IrM1I7S4PF5GDw+yNrn+gpg90rA4X7/jF2AwVdS2U2SkjQZoO0uOx5Z/wi+OvwV2p3tcEGIEDanDV8e/BLra9fj/N7n45lJz8AY7eYaIdx11134yU9+Itn11GLmmELMHFPoSR6rs1hR4DVHuryi1ieAm4w6ZBj1OHXGHnau+MCiaQCExLT7lm1BJCkT8y4dgoc+3B42oKtN9y5GVfeeI5I/hoIxIW6aC9Ccc09wtjk7L+twwQWrw4qvDn+FR9Y/gucmPydJT3rp0qUwm8346U9/in37wsynaZQYqCM9DgiB93fLtsIZIPIWmjvmHcXvD7ZG23tpWLhzlSjcZiV6HcMT04cnsUWEELlpbg56+/HtWHtkbcDg7M3mtGHtkbXYcXxH3Pdsbm7G448/jhdffDHua6WamWMK8cdZo2Dy253dZNR32vBh5phCvDx7NIx+P7UTi3vgrdvO7XSuWphNRiy4ajiMusAfFDPT9PijUtc5E0ISRnM96CU7l6DN0Rb+RABtjjYsqVyCF6a8ENc9H3vsMdxyyy3o3Zs23oiFGHgCDY8HOldrgUocin/+ulER/RsQQlKD5gL010e+9sw5h+OCC18f+Tqu+23ZsgVffvklKioq4rpOqtNi4I1Um8OFee9vxfPXjsK382Xcw5kQoiiaC9Btzsh6zyKbI/RQeDhr167FgQMH0KdPHwBAS0sLnE4nKisrsXnz5riuTVKH3cnx/Oe7U/ZDCiGkM83NQafr06M6P8MQSYnB4G6//XZUV1djy5Yt2LJlC+644w5MmzYNn3/+eVzXJfFL1M5cL88enZDrann9NiEkepoL0JN7T4Yuwpelgw6Te0+O635dunRBXl6e509WVhYyMjKQk5MT13VJ/AIlXukYgiZjReLnE/pg5phC/HxCn3ib10mBOcHVsgghqqK5AD1n+BykGyLrRafp0zBn2BxJ779gwYKUKVKidDPHFOL560ah0GwCg7Bs68VZozF7XFFM1/v5hD6eDUMWzjwbL88eDZN/Snkc/LPWCSGpTXNz0Gf3PBvn9z4/6DpoUYY+AxcUXYARPUcksXUk2QIlnz3/+e6or1NoNnmCc6Bre+/w5V98xWwyYnhB15DbZoo9c0IIEUkSoBljvwPwAoAczvlxJlT+WAzgCgBnANzEOU9KxhRjDM9MegaPrH8Ea4+sRZujzSerWwcd0vRpuKDoAjwz6RnJy30S5Ytlrjdc7zaSLPRHl2/Hfzcc6nTcu2dOCCGiuAM0Y6wIwCUAvH/zXA5gkPvPeACvuP9OCqPOiOcmP4cdx3cItbhr18PmsCHDkOFTi5ukpmhrdUvVuxXrltNaZ0JIJKToQb8E4AEAK7yOzQDwJhc2m97AGDMzxvI55/US3C8ijDGcnXM2/nj+H5N1S6IS8y4dgnnvb4XdGb6wt9S921Re700IiU5cGS6MsRkAajnnW/2eKgRw2OvxEfcxQmQ3c0whnr92FLp3Cb0MK03PaOiZECKbsD1oxtiXAALtDfcIgIchDG/HjDF2O4DbAXiKfRCSaP4JXr97byucro4etV7H8IdrR8nVPEIICR+gOecXBTrOGDsbQH8AW92JVr0BbGaMjQNQC8B7LUtv97FA138VwKsAUFpaGsFmgoRIK5pa4IQQkiwxz0FzzrcDyBUfM8YOACh1Z3F/DOBuxthSCMlhTcmcfyYkWjQ3TAhRmkStg/4UwhKrfRCWWd2coPsQQgghmiRZgOac9/P6mgO4S6prx4Jzjob2emxr+hGHrDVwcAcMzIA+pmKMyv4JctLyJFsDff7552PDhg0wGIR/zsLCQuzeHX0xDEIIIUSkuUpiAODkTnx1/FMcPFMNJ3eAu+s6ObgD+8/swSFrDfp2KcYFPa+Anukluedf/vIX3HrrrZJcixBCCNFcLW7OOb46/ikOnNkHB7d7grPneXA4uB0HzuzDV8c/hdDZJ4QQQpRFcwG6ob3e03MOxckdOHimGo3tRyW570MPPYSePXti4sSJWLt2rSTXJIQQkro0F6C3NZWHDc4iJ3dga9OPcd/zueeeQ01NDWpra3H77bdj+vTpqK6ujvu6hBBCUpfmAvQha3WnYe1gODgOWWvivuf48ePRtWtXpKenY86cOZg4cSI+/fTTuK9LCCEkdWkuQDsi7D13nG+XvA2MMZrbJoQQEhfNBWgDiy4x3cBC12MOx2Kx4PPPP4fNZoPD4cBbb72Fr7/+Gpdddllc1yWEEJLaNLfMqo+pGPvP7IlomJuBoY9pQFz3s9vtePTRR7Fr1y7o9XoMHToUy5cvx+DBg+O6LiGEkNSmuQA9MrvUXZgk/NC1nukxKvsncd0vJycHP/4Yf6IZIYRIbf3Bt1HlOgIOgAEo0fXGpL4/k7tZJEKaC9C5afno26UYB87sC5nNrWcG9O0yEDlpgTbqIoQQae1tqcQPp9ajxdmMLH03jOs+CQACHvv2xGq0cRsAIF1nwsQeUzEoa1hU91t/8G1Uuo4A7oqJHBAeH3ybgrRKaC5AM8ZwQc8rAlYSA4RhbT3To2+Xgbig5xWSlfskhJBg9rZU4usTn3uSWFuczVh7/H/gcHl+P7U4m7HmeFmn721zWbHmeBnWHC9DOssAGEObywoGBg7uCez+AbzKKzh7MIZK1xFUH/oL2lxWn6eCXYfIR3MBGhCGri/seSUa249iq6cWtx0GZkQf0wCMyv4JctPz5W4mIURh1h9fhaqWreDgYGAoyRqFST0vjvo6/r1lu6u90woTF5xRX7eN2yD2N7wD+9cnPgcAn+AaKgvHPziL1/nq+KedrkPko8kADQg96dz0fFyce5XcTSGEKJh3MPXGwVHZsgV7WnfCwe0R9zD3tlQKZYS9AmiiObgDP5xaH1lgDTFqyMHx7YnVFKAVQrMBmhBCQtnbUukz1xuMmHAqDkGLw9D+AXtvSyW+PbkmYO80GcQPAuIoQKhAHEq4fw+SPBSgCSEpx39OOBZiwP725BoUdxniGRqX0z8OPC/r/Ym0KEATQlLOD6fWxxWcvbW5rKhs2SLJtZQgXWeSuwnETXOVxAghJJxkzAurlcNlx96WSrmbQUA9aEKIhgRaaxwo4SlL342CdBBOOLDmeBk2n/oes4tukbs5KU2zPWjOOaxbt+LI3Huxa/QYVJUMw67RY3Dk3vtg3bZN8s0sli5dipKSEmRmZqK4uBjr16+X9PqEkMD2tlTircP/wD8OPI81x8s8gVdcfhSoNziu+6So6/anGovzJFbWvyt3M1KaJn9Cud2OuvnzcXrNV+BtbYDLJRy32XD6iy/Qsm4duk69AAWLFoEZ49ssAwBWrVqFBx98EO+++y7GjRuH+vr6uK9JCAnfI/Zf0uTPwR2ezGvv7xevEWh5FelQ13ZI7iakNM0FaM65EJxXrwG3BVgu4HKBW604vXoN6ubPR8ELL8RdTeyJJ57A448/jgkTJgAACgsL47oeISRw9S0x2IpFRKpbd0WcOe1f0MM7UO9tqQxYxYsQOWkuQNu2bRN6zoGCsxdus+H0mq9g274dppEjY76f0+lEeXk5rrrqKgwcOBA2mw0zZ87E888/D5OJsiEJCSVY5a5wPWOxiEi0/At6ePfQ01kGrQEmiqK5OegT/35DGNaOAG9rw4l//zuu+x07dgx2ux3vv/8+1q9fjy1btqCiogILFy6M67qEaN3646tQ2bLFE4TFoPvu4dex5nhZwtYUi0PaYg9dfEzBObB3D78udxNSluYCdMvatZ4557BcLrSsXRfX/cRe8j333IP8/Hz07NkT999/Pz799NO4rkuI1lW1bA143OI8mdD7Zum7AZB2LbSWWZwnKUjLRHMBOtLes+f8MEPh4XTv3h29e/f2mcemHbIICU+uqlvilo6UHBa5RH9oIoFpbg6apadHFXRZRkbc97z55pvx5z//GZdddhmMRiNeeuklXHnllXFfV2vKaspwYqsNxWyocIAB2Wd1wYjz+svbMCILcbvEZBPnn2ktdHTWH18V085eJHaaC9BZ55+P0198Edkwt06HrPOnxH3Pxx57DMePH8fgwYORkZGBWbNm4ZFHHon7umrXeNiCQ1UNaLMKe3KbeT+Yme8IQ9OJM/huhdc6VQb06mNG8egCGVpMEsUnGUtnAjiXrQf91uF/YFz3SRjXfVLc9bhTiZiUR0E6eZjUBTviUVpaysvLyzsdr6qqQklJSUTXsG7dioM33QxuDb+jDDNloO+SJXFlcUstmteqZI2HLdhXUR9XQRiDUY/+Z/dCTpG507X3VtT5bHjb7SwT9cQVSoqNKaRmYAZMPutSAAiZLU58MTDc3u//yd0MzWGMbeKcl/of11wPOmPkSHSdekHwddBuLCMDXadORcbZZyexddrh3TsGA8CBdJMBfUpykVNkxv7tx+Ku1uawO7GvQij60nziDI4dsgTdhb75hBU7vtlPQVphwi2XkouDOxTZLqWjf6/k0lyAZoyhYNGigJXEAAA6HVh6GrpOnSpUEqOErqg1Hragems9XE73f1b3X21WB/ZursPezXWS3YtzHvH1mk9YfT44eH9gIMkn9pyV+ktdqe1SMgb6fZlMmgvQAMCMRhS88AJs27fjxL/+jZZ168BtNrCMDGSdPwVn/epXMFHPOWaHqho6grPCeAfzNqsD1VuFHjgF6eSjZUzaU5I1Su4mpBRNBmhA6EmbRo5E75dfkrspmtNmVc8vXZeTY2+F0KunHnVyUYa0+jh3dgdfVwg0pwHd2sGm1EI//JRPlTeSPJoN0CRx0k0GVQVp/yH4YwdP0Vx1EtAyJnVx7uwO/llfwKEXDjSng3/WF0adCb+6/EZ5G5eiNFeohCQB10m+XWcyNZ+wonqLdPPkJLBuBrPcTSBR4OsKO4KzyKGH9ase8jSIUA+aRGfPxqM4fcqKNJM+/MkKduygBZaGFkomS6D6tsNyN4FEozktuuMk4agHTaLy/YpqGDMU8GMjQTKpOEwvJpM1HrbEf1HiQVnSKtOtPeDhDLO6P4yrmQJ+0xI1aTnZBrvNKXczAA706muW7HIuJ8ehqgbJrkdoSY7asCm1gMH3/7bOCEy6eqhMLSLaHeLmHGhoALZtAQ4dAhwOwGAA+vQFRo0CcnIBidZAZ2Vl+Ty2Wq2488478ec//1mS6yvJoHN7wJihB+fcZw25/+NkOHbQIun1wiW+NR62oGZ7PZx2oWcYrNIZEZRkjYppz2YiD/3wU3ACPlncF/7fGAwenyd301KWNgO00wl8tQY4eED4WkxocjiA/TXAoYNA337ABVMBffzDNy0tLT5f5+Xl4brrrov7ukqz45v9yDIHno/SSsGXHd/sR6++3X2KnZhzs3Ci7jQcdt/ehcPuxN7NdWg+cYZqhwcwqefFqLMeop2QVEQ//BQw/BQAYFjWaAzuScFZTtob4uZcCM4HDggB2T/bmHPh+IEDwnkSZyN/8MEHyM3NxaRJkyS9rhI0nwhf31ztmk9YsXdznc/89LGDlk7B2duxgxaavw5idtEtGJY1moa7VYZBR2ueFSDuHjRj7B4AdwFwAijjnD/gPv4QgFvcx3/LOf883ntFpKHB3XMOs07X6RDOa2wAcntJdvslS5bgl7/8pWZ6lCQyezfX4VBVg082OJUdFUzqebHnl/1bh/9Ba6NVgCOC3QBJwsUVoBljFwCYAWAU57yNMZbrPj4MwPUAhgMoAPAlY2ww5zzx2UXbtgrD2pFwOoGtW4GLL5Hk1gcPHsS6devw+uuvS3I9oi5tVgf2VtRh//ZjnXrcYpGUVB8Opy0eCYlcvEPcvwGwiHPeBgCcczENdgaApZzzNs75fgD7AIyL816ROXQw8mFrzoXzJfKf//wH5513Hvr312iVKhoUCI8j7HB4KhdJGZQ1DJPPuhRZ+m4A4PmbENJZvAF6MIBJjLGNjLF1jLGfuI8XAvCuUnDEfawTxtjtjLFyxlh5Y2NjnM2BML+cyPNDePPNNzFnzhzJrqc0g8akbs9PSqk+Zz0oaxhuLPo1ft1vHm4s+jUFaQUaljVa7iYQRBCgGWNfMsZ2BPgzA8IQeQ8AEwDMA7CMRTn5yjl/lXNeyjkvzcnJielF+DBEOWof7flBfPfdd6itrdVk9rYop8iMQWMLkG7SZvJ/Mu3dXIdNX+xJ6UAtGtd9EnSgYhjxSteZMCxrtOcDT6jEvHSdCb/uNy9gIB6WNZoSxBQi7G9azvlFwZ5jjP0GwIdcKMz8A2PMBaAngFoARV6n9nYfS7w+fYWlVJEMczMmnC+BJUuW4JprrkHXrl0luZ5S5RSZkVNkxg+f7g45lEvCo807BIOyhgEAvj25Bm0u7a8UkFo6y8BNfe/pdHxvSyW+Ov5pp4puDAwTe0wF4JvAR5Qn3q7QcgAXAPiKMTYYQBqA4wA+BvA2Y+xFCEligwD8EOe9IjNylDCvHMnQtV4vFC2RwD/+8Q9JrqMWZxV0lbxQSKpqPmHFdysqPY/1RoYBZ+enVMb3oKxhGJQ1jLK8Y9DGbQGPez74nFjtOSddZ8LEHlM9zxFlizdA/wvAvxhjOwC0A5jj7k3vZIwtA1AJwAHgrqRkcANAbq5QhOTAgdBLrfQG4byc3KQ0S0saD1vQeKRJ7mZoltMu7GENIKWCNEBZ3rHa21IZMOiKH3yIOsWVJMY5b+ec/5xzPoJzPpZzvsbruWc458Wc8yGc88/ib2qEGBMqhPXrJ8wv+0+JMyYc79dPOI/WK0ftUFUDXE7aCCGhOFKyNrh/lne6zoR0lpH0dqitsMq3J1bL3QSSANrM9tHrgQsvEoqQbN3aMeTtqcU9Wuhpk5iEq1lNpJGq/87Ben2vHnghaTtkqW0nrmDD3ETdtBmgAaFnnNtLsiIkpEO6yZCywSOZKFveVzSbb6SzDApaRPW0V4ubJFyfklzo9PIMAer0DBmZRlnunWzm3KzwJ6WQST0vjryud4pNXaXrTHI3gSQAfUQnURMTl8Q608nSq68ZxaML0HjYgr2btV+Ny9Ig7JJGNb07eC8LWn98VdAedZvLimFZo1Niu0sd9J5lU0RbKECTmIjroQH4LBFKpGMHLeh2VpeUSZ5qszo6/duKa6f3bakHd3GfgJ1qgXxSz4uxp3UnHNze6bksfTdM6nkx8jIK8cOp9WhxNiNL3w19TANwyFqjqaVc5/e8jDK1NYoCNFGVZPfalYq7hCSmNqsD1VvrcXh3I2ytHYFKPA5oe6nW5LMu6bQsy8AMGNdd2O411DKjvS2VWHO8LCntTJQsfTcKzhpGc9AkaVwujuOHz0Cni/3Hrs3qANOl1vxiOC4n9wnO3se1PtoQaPONyWddGlHQGpQ1TNVzt94fRIg2abYHzTnHsQPN2LLqEA7uOAFHuwuGNB36juiJMRf3QW6/rpLt2XzgwAHceeed+P7775Geno5rr70WL7/8MgwS1flWuoxMY+AA4XJ5/o2ddheOVJ7GqXobTtW1Yc7vJ3rOi3aIXOw9kvBSYbQhnmIcE3tMDdgDH5w5IuKhcAaG/PQi1LUd6vSciWXCyltjalsoWfpuGNd9EvWeNU6TEcTpdGH1vyuxf9txOO0uT1luR7sLNRUNOLjjOPqP7IkLbx4GvT7+QYQ777wTubm5qK+vh8ViwcUXX4y//e1v+O1vfxv3tdVg7EWDsPnLvT5BOiPTiO/fPxzw/JaTbclqWsqjpVqhiQHOe57aO/CFSkQTpbF01LcF/lm38lYMyxqNPa07JKuORptZpA7N/e/lnAvBeetxOOyuAM8LgXr/1uNY/e9KXHzL8Lh70vv378fdd9+NjIwM5OXl4bLLLsPOnTvjuqbajL1oUKdj29c0BAzGWT3SfQ8wQGV1IVSDlmqFF6oHLgbCUEE63HrrQ9YaTD7rUs+HAH96GDGl5yVBnxcxMJRkjaLgnEI0F6CPHWjG/m2Bg7M3h92F/duOo+HAafTqH99+tPfeey+WLl2K888/H6dOncJnn32Gp59+Oq5rasG5M4rx1Vu74GjveC8MaTqcO6PY57xefcy08UaCiJnvWk4US7RJPS8OGaCz9N3Q6jwdtPpYi7M54mH4QLtP6aCnTO0UpbkksS2rDsMZJjiLnHYXtnzZed4oWpMnT8bOnTvRrVs39O7dG6WlpZg5c2bc11W7wePzcMGNQz095qwe6bjgxqEYPD7P57zi0QVyNC9l1Gyvl7sJqmfW9wj63Ljuk1CSFXxXPDGBLZxBWcNwQc8rfGqPp+tMFJxTmOZ60Ad3HI9oK2hAGO4+sP14XPdzuVy47LLLcPvtt+O7775DS0sLfvWrX+HBBx/EH/7wh7iurQWDx+d5AnLjYQv2VtTh+IqTPucke55Up2dgOmHXqFTgtHNPIl5GpjHgdAQJbXbRLXj38OuwODt+dhl0uKDn5Z7escV+slOiWLSZ1rT7FPGmuQDtPZwa0fkR9raDOXnyJA4dOoS7774b6enpSE9Px80334xHH32UArSXUNW/kpFpLFYh85esIitKYWu1Y/OXeylIx2B20S0hn5+ePxt7WyqDJpwREi3NBWhDmi6qIG0wxjfK37NnT/Tv3x+vvPIK/t//+39oaWnBkiVLMHLkyLiuqzVyr8dtPNJEc7FugZbEEWlQD5hISXNz0H1H9Iy4Tj5jQL+ze8Z9zw8//BD/+9//kJOTg4EDB8JoNOKll16K+7paIvd63FQo2kEI0RbN9aBHX1yEgzuOR9SL1ht1GH1Rn/jvOXo01q5dG/d1tEwJW1QGur/eyFJmLpoQoi6a60H36tcN/Uf2DDt0bTDq0H9kT+T265qklqW2PiW5cjchYDLagLPzEcnuhVrTeNgidxMIIWFoLkAzxnDhzcPQf1RPGNJ0nYa7GRPmqfuPEiqJSVXuk4SWU2TGoLHyLafS6VnADwk5RWYMGlOQchW3qrfWU5AmROE0+VtJr9fh4luGo+HAaVSsOiQMedtdMBh16Hd2T4y+uA969YuvOAmJnrhFZeNhC6q31sPlTM7QcritF8XjyWyT3MQ5eUqaI0S5NBmgAaEn3at/N1x2+wi5m0L8eO8lLZJ8uRMDBo0piDgAHapqSJngLJI7J4AQEppmAzRRl6iSyJhQHtTa0obmE9aAp0QTnAHpg5V3MRQlJ6KJH4wMRj36n92LetSEKAgFaKIIfUpysa+iHjxIGbhghUaqt9T51PFmOmDg6OiCMyB9lrnLyQGn8LXTzsEYQ26fbMXWHHfYndhXIZQEpSBNiDJQgCaKIAaF/duPwWF3eo7rjQwDzs4PGjSKRxdIUsu7T0lu0EpnUuCc40Td6YRdXwqcc+zffowCNCEKQQGaKEaguWktcdidilgPHorD7kTjYYum3wdC1EJzy6wIiUUkVcbSTYa4l4opYT14OFRxjRBl0GyA5pzj9Mkz2P3DYWz4pArfrajEhk+qsPvHwzh9yhp0rjMWVVVVmDp1KrKzszFw4EB89NFHkl2bJEckvVpxqVY8a6ZziszodpYp5u9PBiX38AlJJZoM0C4Xx55Ntdj53UGcqD/tWT7jcgrzgDu/PYA9m2rhcsUfpB0OB2bMmIErr7wSJ0+exKuvvoqf//zn2LNnT9zXJskTSdAVh337lORCp4+9wM2I8/qjV19zRwUzBkVVM9MbFdQYQlKY5gI05xx7N9fi1NHTQde1upwcp46ext7NtXH3pHft2oW6ujrcd9990Ov1mDp1KiZOnIj//Oc/cV2XJFefktzQVeW8nsopMqN4VL4nqKebDEKvOExc8/4QUDy6AD+9ahh+OmMYfnrVMAwaU9Dp/owxWYIl096vBUJUSXNJYi2nrCGDs0gM0i0WG7p2l3bIkXOOHTt2SHpNklhi73jflnrwACMrvfqYO50fLJEqUKW0YKVG/e9/qKoBbVaHp/oZkPwKZ95Z9IQQ+Wjuo3Jd9YmIf5m5nBx1+47Hdb8hQ4YgNzcXzz//POx2O7744gusW7cOZ86cieu6JPlyisw4d3pJp+HnYGuwQ13Hv4ddPCr4UjHv7zvnksH46YxhOOeSwZ7z5ahw9t2KSny3ohLVWxK39IwQEprmetCnjrUk9Hx/RqMRy5cvxz333IPnnnsOpaWlmDVrFtLT0+O6LpGPFGurpVgy1njY4ikeIhexsIoUa80JIdHRXA862t6GFL2TkSNHYt26dThx4gQ+//xz1NTUYNy4cXFfl6S2Q1UNkq42iNWxQxa5m0BIStJcgI42uzaebFzRtm3bYLPZcObMGbzwwguor6/HTTfdFPd1SWpTzHIn+T8jEJKSNDfE3b1XVlQlFbv3yor7nv/5z3/w2muvwW63Y9KkSVi1ahUNcZOYNB62dCp3qgTfragMu20nIURamgvQBcVn4dSxloiGrnV6hoKBPeO+5/PPP4/nn38+7uuQ1CbOOSthWDuQNqsDeyuEpDEK0oQknuaGuLO6m9A9r2vYoWudnqF7XldkmTOS1DJCQlPKnHNIHKjZLm/iGiGpQnMBmjGGQWMLQwZpMTgPGlsYujgFIUmkmDnnMJS6tzUhWqO5IW4A0OkYBp9TiBaLDXX7jnuGvHV6hu69slAwsKfkxUkIiZfSd7oihCRXXAGaMTYawN8BZABwALiTc/4DE7qliwFcAeAMgJs455vjbGu0bUPX7iYM+UlRMm9LSMzMuVmedcdKR1tSEpJ48Q5x/wHAk5zz0QAedz8GgMsBDHL/uR3AK3HehxDNszTEVzQnmWhLSkISL94AzQF0c3+dDUCsCzgDwJtcsAGAmTGWH+e9CNE0NQ1vq6mthKhVvHPQ9wL4nDH2AoRg/1P38UIAh73OO+I+RumfhAShpjnoePbEJoREJmwPmjH2JWNsR4A/MwD8BsB9nPMiAPcBeD3aBjDGbmeMlTPGyhsbG6N/BYRoRNgtL/1IUQUvVubc+Av8EEJCC/sxmHN+UbDnGGNvApjrfvgegNfcX9cC8M7O6u0+Fuj6rwJ4FQBKS0tp/QZJWWLSlXclMaYD9Ho9HHZnwEpe362olKGl6povJ0St4h2nqgMwBcBaAFMB7HUf/xjA3YyxpQDGA2jinCd1eJtzjqP79qB85YeoqSiHw94OgzENA8b+BKXTr0Ze8WDJ1kD/5S9/wRtvvIHt27fjhhtuwBtvvOF5bvXq1bjrrrtw6NAhjB8/Hm+88Qb69u0ryX2J9kSzC1bjYUtC2xKKWobiCVGzeAP0bQAWM8YMAGwQMrYB4FMIS6z2QVhmdXOc94mK0+HA//76IvZt2ghne7unOpOjvQ17N36LmoofMfCc8bjsrvuhN8Q/l1ZQUIBHH30Un3/+OaxWq+f48ePHcc011+C1117D9OnT8dhjj2H27NnYsGFD3PckRM5MapqDJiTx4vpfxjn/BsA5AY5zAHfFc+1Ycc6F4Fy+EY72toDPO9rasK98A/731xdxxW/nxd2TvuaaawAA5eXlOHLkiOf4hx9+iOHDh+O6664DACxYsAA9e/bErl27MHTo0LjuSYhcvVidnqFPSa4s9yYklWiu1OfRfXuwb1Pg4OzN0d6OfZs24mj1noS1ZefOnRg1apTncWZmJoqLi7Fz586E3ZOkDjl6sekmA4pH5VOREkKSQHPjVOWffARne3tE5zrb21H+yXJMv/fBhLSlpaUFOTk5Pseys7Nx+nTk22ESEkyfklxUb62PaOe2ePTqa0bx6IKE3oMQ0pnmAnTN5h8j3hGIc46azT8krC1ZWVlobm72Odbc3IyuXbsm7J4kdYi92Jrt9SE3sNDpGdIyDLC12gM+36uvcB3/MqOMMQwcQ71lQuSiuSFuhz2y3rPn/Ah727EYPnw4tm7d6nnc2tqK6upqDB8+PGH3JKklp8iM8VeUYNDYAuiNnXMpxCHpsRcN8gRib2LvuHh0AQaNLfAMm6ebDBScCZGZ5nrQBmNa2Plnn/PT0uK+p8PhgMPhgNPphNPphM1mg8FgwNVXX4158+bhgw8+wLRp0/DUU09h5MiRlCBGJBfJ8iwxEMdzDUJI8miuBz1g7E8izspmjGHA2HFx33PhwoUwmUxYtGgR/vvf/8JkMmHhwoXIycnBBx98gEceeQTdu3fHxo0bsXTp0rjvRwghRPs014MuvfJq1FT8CEdb+F60Pi0NpVfOjPueCxYswIIFCwI+d9FFF2HXrl1x34MQQkhq0VwPOm/gYAw8Z3zYoWtDWhoGnjMeecWDk9QyQgghJHKaC9CMMVx21/0YWDoBhvT0TsPdjDEY0tMxsHQCLrvrfsnKfRJCCCFS0twQNwDoDQZc8dt5OFq9B+UrPxKGvNvbYUhLw4Cx4/CTK69G3kDqORNCCFEuTQZoQOgp5w8cgun3zZe7KYQQQkjUVDPEHWnxETVLhddICCEkMqoI0Eaj0WeXKK2yWq0wGo1yN4MQQogCqCJA5+bmora2FmfOnNFkL5NzjjNnzqC2tha5ubRLECGEEJXMQXfr1g0AUFdXB7s9cD1htTMajejVq5fntRJCCEltqgjQgBCkKXgRQghJFaoY4iaEEEJSDQVoQgghRIEoQBNCCCEKRAGaEEIIUSCmpGVLjLFGAAflbkcUegI4LncjkiwVXzNArzvV0OtOLXK/7r6c8xz/g4oK0GrDGCvnnJfK3Y5kSsXXDNDrlrsdyUavO7Uo9XXTEDchhBCiQBSgCSGEEAWiAB2fV+VugAxS8TUD9LpTDb3u1KLI101z0IQQQogCUQ+aEEIIUSAK0FFijL3LGNvi/nOAMbbFfbwfY8zq9dzfZW6qpBhjCxhjtV6v7wqv5x5ijO1jjO1mjF0qZzulxhh7njG2izG2jTH2EWPM7D6u6fcbABhjl7nf032MsflytydRGGNFjLGvGGOVjLGdjLG57uNBf+a1wv07bLv79ZW7j/VgjK1ijO11/91d7nZKhTE2xOv93MIYa2aM3avU95qGuOPAGPsjgCbO+VOMsX4APuGcj5C5WQnBGFsAoIVz/oLf8WEA3gEwDkABgC8BDOacO5PeyARgjF0CYA3n3MEYew4AOOcPpsD7rQewB8DFAI4A+BHADZzzSlkblgCMsXwA+ZzzzYyxrgA2AZgJYBYC/MxrCWPsAIBSzvlxr2N/AHCSc77I/cGsO+f8QbnamCjun/FaAOMB3AwFvtfUg44RY4xB+A/8jtxtkdkMAEs5522c8/0A9kEI1prAOf+Cc+5wP9wAoLec7UmicQD2cc5rOOftAJZCeK81h3Nezznf7P76NIAqAIXytkpWMwAscX+9BMKHFS26EEA151yxxbEoQMduEoBjnPO9Xsf6M8YqGGPrGGOT5GpYAt3tHur9l9ewVyGAw17nHIF2f7n9CsBnXo+1/H6n0vvq4R4ZGQNgo/tQoJ95LeEAvmCMbWKM3e4+1otzXu/++iiAXvI0LeGuh28HS3HvNQXoABhjXzLGdgT4492DuAG+b249gD6c8zEA7gfwNmNMVRtYh3ndrwAoBjAawmv9o5xtlVIk7zdj7BEADgBvuQ+p/v0mvhhjWQA+AHAv57wZGv6Z93Ie53wsgMsB3MUYm+z9JBfmQDU3D8oYSwNwFYD33IcU+V4b5G6AEnHOLwr1PGPMAOAaAOd4fU8bgDb315sYY9UABgMoT2BTJRXudYsYY/8E8In7YS2AIq+ne7uPqUYE7/dNAK4EcKH7F5Ym3u8wVP++RoMxZoQQnN/inH8IAJzzY17Pe//MawbnvNb9dwNj7CMIUxvHGGP5nPN69/x8g6yNTIzLAWwW32OlvtfUg47NRQB2cc6PiAcYYznupAMwxgYAGASgRqb2Sc79H1V0NYAd7q8/BnA9YyydMdYfwuv+IdntSxTG2GUAHgBwFef8jNdxTb/fEJLCBjHG+rt7G9dDeK81x51P8jqAKs75i17Hg/3MawJjLNOdFAfGWCaASyC8xo8BzHGfNgfACnlamFA+I6BKfa+pBx0b/7kLAJgM4CnGmB2AC8AdnPOTSW9Z4vyBMTYawnDXAQC/BgDO+U7G2DIAlRCGgO/SSga3218ApANYJfwexwbO+R3Q+Pvtzlq/G8DnAPQA/sU53ylzsxJlIoBfANjO3MsmATwM4IZAP/Ma0gvAR+6fawOAtznn/2OM/QhgGWPsFgi7C86SsY2Sc38YuRi+72fA329yo2VWhBBCiALREDchhBCiQBSgCSGEEAWiAE0IIYQoEAVoQgghRIEoQBNCCCEKRAGaEEIIUSAK0IQQQogCUYAmhBBCFOj/A1UgoBIlfNCkAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAegAAAHSCAYAAAAnsVjHAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAB85ElEQVR4nO3deXxU1fk/8M8zSyZDEjIsCSQQVtllNQJWcQG3Finot6LWturX1vZb7dflVxWUKipaLP26tFarXRTrAmgVRdwQBOIClE2WBAJhC0lIwjKBhEkyy/n9cWcmk8msmTtzl3nevnyF3Llz7xkS5plzznOeQ0IIMMYYY0xdDEo3gDHGGGMdcYBmjDHGVIgDNGOMMaZCHKAZY4wxFeIAzRhjjKkQB2jGGGNMhUxKNyBQz549xYABA5RuBmOMMZYyW7ZsOS6EyAs+rqoAPWDAAGzevFnpZjDGGGMpQ0SHQx3nIW7GGGNMhThAM8YYYyrEAZoxxhhTIVkCNBHdS0S7iWgXEb1NRJlENJCINhLRfiJaSkQZctyLMcYYSwcJB2gi6gPgfwEUCyHOBWAEcCOApwE8K4Q4B8ApALcnei/GGGMsXcg1xG0CYCUiE4AuAGoATAXwrvfxxQBmyXQvxhhjTPcSDtBCiCoAfwRwBFJgbgCwBYBdCOHynnYUQJ9QzyeiO4hoMxFtrq+vT7Q5jDHGmC7IMcTdDcBMAAMBFALIAnB1rM8XQrwihCgWQhTn5XVYp80YY4ylJTmGuC8HcFAIUS+EcAJ4D8CFAGzeIW8A6AugSoZ7McYYY2lBjgB9BMBkIupCRARgGoBSAF8C+JH3nFsAfCDDvRhjjLG0IMcc9EZIyWBbAez0XvMVAA8CuI+I9gPoAeAfid6LMcYYSxey1OIWQjwK4NGgwwcATJTj+owxxli64UpijDHGmApxgGaMMcZUiAM0Y4wxpkKq2g+aMcbU5vMta+GqNCEXNtjFKbzneAubnF/5Hx/cdTCWX7vc//2CDQvwTvk78AgPDGTA9UOvx7zJ8xRoOdM6DtCMMRbG51vWIqMyF9lkAQB0ox74SZdfQJwV+I/zawBAxekKjF48GjaLDT0sPVBxusL/fI/wYOnepQDAQZrFjQM0Y4yF4ao0+YOzj4UycW3mTf4A7WNvscPeYg95nWV7l2H90fWoaaqBgQzwCA8Ksgpw94S7MX3Q9GQ1n2kcz0EzxlgYubCFPN7d0COu6wgI1DTVAJB61QBQ01SDOSVzsGDDgoTayPSLe9CMMRZGA+ywoXuH4yc9J2S7R+AQeOD8NYFgIhOcwhnyeTcMu4GHzXWOAzRjaabmscdgX7IUEAIAQFYrCh5/DLkzZoR9TsOKFah98im47XbpOTYbCh5+KOJz9MBU5EJLZTMslOk/1iKa8X7z27LeZ+nepXhn7zvwwOM/JiDCBmffcwCe29YzHuJmTIMaVqzAvqnTUDZiJPZNnYaGFSties6eMWNhf3uJPzgDgHA4UH3/AygbPgJl4yd0uFbNY4+h+v4H/MEZAITdjuq5D8V0Xy278rxL8a+zr+CEux5CeHDCXY9/nX2lw/yzHAKDc6x8QZrpE4mAf6hKKy4uFps3b1a6GYypWsOKFaie+xDgcrU7bj5nMM756KMO59c89pgUlONgu+lGFDz6qHSv+x8Ie56psBBD1qyO69paM3rxaKWbENHOW3Yq3QSWICLaIoQoDj7OQ9yMaUzNk091CM4A4NxfgbKRo2Ds2hXuhgaYCgpg7t8Pjm83xH0P+9tLcHr1Gnjq6iKe56qpifvajLHYcIBmTGNEwFBzBx6PfyjaVV0NV3V1p+8TLTgDgKmgoNPXZ4xFxnPQjLFOy77kYqWboFsEgpnMEc+Z3HtyilrDlMABmjGNoS5dlG6CX8P7y3WfKGY1WhW5b++s3tj6s63YectO7LxlZ4dgPLn3ZPztqr8p0jaWGjzEzZjGqCmxUzQ3o+7Z53S73GrlgZVwiY7z/alwrOlYu+85GKcf7kEzpiENK1YADofSzWhHz4liz299Hk5P+LXIkRhgwA3DboDNYuvU84kIKw+s7NRzmT5wgGZMQ+qefU7pJnQkRMxrsbUmuBcbD4vRgg/3fxi2Pnc0HuHBnJI5GLN4DJcDTVMcoBnTELX2Vl3V1aj53SO6C9K9s3p3+rkOtwMOd+KjHQICS/cu9QfplQdW4sp3r8SYxWNw5btXci9bxzhAM6Yhal7W5JuP1pO7J9ytdBP83il/BysPrMT8b+ajpqnGvwHH/G/mc5DWKa4kxpiGRKvspQZks4Vcq63V+t0T35goS09YDmYyh6zPXZBVgM9/9LkCLWJyCFdJjHvQjDFZhSukIux2VN//AGoeeyy1DUrQo997VOkm+IXbPCORuXKmXhygGdOIhhUrUPPQw0o3I2H2t5doaq56+qDpSjchqkTmypl6cYBmTCNqn3wKwtm5JT9qo7W56oIs9c79A+qaK2fy4QDNmEa4I9Xg1phEaoQr4eK+6i5pOrdkLmd06xAHaMZY6hmNSrcgZisPrMQH+z9QuhkR+TK655TM4TXTOsIBmjGNIJtN6SbIx+1WugUxe37r82h2N8t+3YKsAiycslD26y7duxQT35jIvWkd4ADNmEYUPPwQYNDHP1lTYaHSTYhZsjKk++f0x+83/j4p13a4HZj31TwO0hqnj3/tjKWB3BkzUPj0QoBI6aYkzFVdjbJR56p+ydWCDQsgkJxaERuObUBDa0NSrg0ALuHC81ufT9r1WfJxgGZMQ7RW5CMitxv2t5eoNkgv2LAAS/cuVboZCalpqsHY18fyvLRG8XaTjGkM5eaGLQaiRfZl76DgUfUUA/F5p/wdpZsgC4/wtPug8U75O/AIDwxkwPVDr8e8yfMUbB2LhAM0YxpjAKCdFKsYqDRhzCM8SjchJgSKaRg+eDQgMHBzkFYnHuJmTGPcDcmbt1SESpdcGUgbb4+JzpHrZaRAj7TxG8gYAwBpvlZFG9zIwTb7eqWbENL1Q9XZLrlpZaQgHfEQN2MaUfPYY7C/vUTpZsjKesFkVc4/A23Dvr45W73SykhBOuKfDGMaYV+mv6FIy4ABSjchonmT5+Gpi56C2WBWuilJMzBnoNJNYGFwgGZMK1SaTJUINS+z8nl+6/NwerS5SUkXU5eo51ScruCCJirFAZoxrVBpMlWi1D4yoOW9ls+6zsZ0Hhc0UScO0IxphFqTqRKm8pGBdNhruaapRukmsBA4QDOmEQWPPgrbTTcq25M2mUBmmedjVT4ycPeEu3U9B+3Dw9zqwwGaMQ0pePRRjNi9CyP2lKFw0R9SuukE2WwwZmdDOOWdj1X7yMD0QdPxxIVPwGaxKd2UpOJhbvXhAM2YRuXOmIEha1ajcNEfQJmZSb+faGyEW+YSo7abblTtMqtA0wdNR8mNJbhh2A1KNyVptDzXrleyBGgishHRu0S0h4jKiOgCIupORKuIaJ/3azc57sUYay93xgwUPPF48nvTLpe8O2kZjZoIzoHeK39P6SZEROj8zycd5tq1Rq4e9PMAPhVCDAcwFkAZgDkAVgshhgBY7f2eMaZlMlYxU/vQdrAFGxbAKdS93EpAIDcjN+7nZRozcfeEu5PQIpaIhCuJEVEugIsB3AoAQohWAK1ENBPApd7TFgNYC+DBRO/HGGuvYcUKVM+Zq/ps6GBa6j2vPLBSM1tPxrPHNIHQO6s37p5wN6YPmp7EVrHOkKPU50AA9QBeJaKxALYAuBtALyGEL3f/GIBeoZ5MRHcAuAMA+vXrJ0NzGEsvNY/O11xw1ho9JlDlZuTiq5u+UroZLAI5hrhNACYAeEkIMR5AE4KGs4UQAgi95YoQ4hUhRLEQojgvL0+G5jCWXsTZ2IpRqE3DihVKNyFmekugMpEJcyfNbXds5YGVuOjtizB68WiMXjwaU5ZM4aVXCpMjQB8FcFQIsdH7/buQAnYtERUAgPdrnQz3YozpRPWcuZoJ0npLoPqvof/Vbkh75YGVmPfVvHbD4/YWO+aUzMGCDQuUaCIDQEKGpA8iKgHwcyHEXiKaDyDL+9AJIcRCIpoDoLsQ4oFI1ykuLhabN29OuD1MP8o3HsO3H1Sg8WQLsrtbcMHMwRg6SV9vlokqGz5C6SZ0GnXpguFbtyjdjKhWHliJuSVzE957WS0MMEB4/zOQARaDBQ63I+z5Nwy7wb+7F5MfEW0RQhQHH5dru8nfAHiTiDIAHABwG6Te+TIiuh3AYQCzZboXSxPlG4/hyzf3wNUqbfXXeLIFX765BwAiBul0C+pktUI4wr+5gki1e0hrZXje19t87JvHIgYyrfCgbftMj/BEfU1L9y7F+PzxnEiWYrL0oOXCPWgW6B//bz2am1wdjmd3t+CWpy7scHzdW3uwa311h+OmDAMuu3m4boN0w4oVqL6/4+AUmc0oeOpJAEDNI49GDuIKGrGnTOkmdMrKAyt1E7BjwUllyROuB82VxJgqrXtrT8jgDEg96VDnhwrOAOBq9eDbDypkbZ+a5M6YIVUTs9n8x4w2GwqeehK5M2ZIB1T0QbwdOQufpNj0QdOx6SebsPOWndh5y04UZBUo3aSkamht4PnoFJNriJuxhAUOTUeS3d3S4diuktDB2SfaNbUud8aMtmAcpO7Z5yCam+O7oNEIeDxJD+y2G/VTOvPuCXdj/jfz0eyO8+9aQ3ioO7V4iJulXPAc8YBze2Dvxlo4W2Jfyxs4t1y+8RhWvVoa0/MsWUZcPHuYboe7QykbMVKVPWit1OGORzoMe3cxdcHGmzdGP5HFjIe4mSr4Er98PdrGky3Ytb46ruDse96qV0vxwbNb8cXi2IIzALQ0ubHqtVKUb9TXulafhhUrsG/qNJSNGIl9U6ehYcUKmArUN/RKmZnoMmGC0s2QnW/YW8+bapx1aSOxTw84QLOU+vaDCn9WthyO7rVDxHs5Aaxftle2NqhFw4oVqHnoYbiqqwEh4KquRvX9D4C6WFOy21U8RHMz6p59TulmJM28yfN0PyfNko/noFlKqWUuuKVJ6rGXbzyGkmXl/oQ0LQ+B1z75VMi9mp37K2C9YDKch49IwVsly65cNTXRT9KwuyfcjTklvEcQ6zwO0Cwpwq1Fzu5uUU2QLt94DKtfL4PH3RasWprc/vlsrQXpSHs1Ozb9B4ULf4+aJ5+CkHlP584y5sa/65KWTB80XZcB2gADRi8eDQMZ4BEeFGQV8GYbScJD3Ex2oeaZv3xzD8o3HsOAc3so3Lo2JcvK2wXnQGve1Oba3LDcblTPfUg1wRkA5JvoUC89zkX7ipx4vHNLNU01mP/NfK7bnQQcoJnsQs0zu1o9KFlWHnatshLCrbMGAHer8kPA8QpcBx2SK/zrVYJoiH1bRK2aN3kebhh2AwwkvdUayKDLoN3sbtbljl9K4yFuJrtwQ9iRAiJLXMHDD6H6gQdVMb8cC9L5ELfPvMnzOtSx/uzQZ7C32JVpUJLobccvNeAAzeKy7q092P1VNYQHIAMw6qJCXPLj4e3OsWQZ/UlYahaxnRoscOUrVFLz6Hxt1LhuakLDihVhC6zo2ZyJc3Q3P623Hb/UgIe4Wcx85TR9y5qEB9i1vhrr3pLmlxc/9DX+8qs1mgjOpgwDLp49DIZwH1EF8OKv12DdW3tS2q5E5c6YgcyxY5RuRkyE06nrpVY+Kw+sxJXvXokxi8fgynevxMoDK3WXUJVpzMTdE+5Wuhm6w5XEWMxe/PWa+NccqxAZpA8XBgPB44n++3/uxR1HCdQq3MYZqkWEEWWxF5rRmpUHVuq+/KeBDHjqoqfi+tCxYMMCvFP+DjzCAwMZcP3Q69N6O0uuJMYSpofgDLS9jliCMxC9zreSgiuH1T75VOpuTgTbTTcmtOGFGqucyen5rc/rOjhnGjM7FZyX7l3qzwL3CA+W7l3KG3GEwHPQLCZ6LY0ZE/UMMrXTsGIFan73iH8jDFd16j9I2N9eAkDaPavXww+h7tnnYm4HZWYi/957ktg65ek9cWpc3rh2wXnlgZV4fuvzONZ0DL2zevvXRwf2mMPhjTg64iFuFpVvXbOcJTq15s6/TlW6CR3smzpNkaAcDpnNyCw+D45vN4Q/ybtLlqmgAPn33qP7BLEr370SNU36rpg2ufdkHD5zOOTrzDRmok9WH1Scjm27VxOZsOCiBWkXpHmIm3Wa3PWztUiNyWJqK5UpnE44Nv0n4jmFC3+PEWWlGLJmddTgHGrjD61Jh8SpDcc2hP0Q0uxujjk4A4BLuPD7jb+Xq2maxwGaRaWW0pxK2rW+WnXD/Embv/XOLRcu+kP8z3WHz+C3XjA55h6zb/g+cOOPmt89orkgPX3QdF0WJkmmhlb9F7CJFQdoFlV2d4vSTVCFbz+IvSeQCvn33pNQglZYQuDMJ5/KugSKrFYMePXVmM+ve/Y5/9y6v1ka3QFr3uR5WDhlIWwWm9JN0QzfcrR0x0liLKoLZg5O+zloQH0jCbkzZuDs1q3+RC05ue12QMa63bmzZsZ0XsOKFRETzdQ05x6P6YOm++dV02FeOlG++t4AsK1uW9ouyeIkMRaTwN2p0pkat6OMFtTUwFRYiCFrVod8LN722266EQWPPipn81Jq5YGVuqsiliwZhgy0elo7HL9h2A26CtLhksQ4QLO4/OVXa5RuguLICFz+s5GqCtJAhKxuNez/HKYgSfBSsVivVfiHpzWdAT568Wilm6ALNosNcybO0XzWN2dxMyYT4VbffDQgzUlTZma7Y5SZqXxwRtvGGA0rVmDP5AtQNnwEyoaPQPX9D8QXnAFACE3ORTP52Vvs+N3Xv9PtfDXPQbOoeHi7IzX+Xfh6lHXPPgdXTY1/rbEahr8N8JYhnfuQLNteKv16mHo4PU48v/V5zfeiQ+EAzSLiIiWhqTWzPXfGjJBDv3EPI8vM3dAg9Xrl2pPaaJTnOgopyCrgRDEZ6fXvkoe4WURcpCS0C2YOVroJMcudMQMFTzwOU2GhNB+tRHDzrmWWTYT11lqQDgVMUk2Pw9wcoFlEahzKVdq5FxeqLkEsmtwZMzBkzWqMKCtF4cLfd5ir1hpTYaHSTUjI9EHTMbn3ZKWboSvPb31e6SbIjgM0i0itQ7lKMFuMuOK2kZrZejIcX49ay/Swycbfrvobbhh2AwwkvQ0TCGYyK9wq7appqtHdjlg8B80iumDmYHzxeilEwIgiGdHue10j4Ipb1bekSg5kNkM4nUo3I262m27U9BKrQPMmzwu7npeXYsVv6d6lAKCbNdLcg2ZRESji97om1LmkKlF1zz6nyeBMVqumi5TEoyBL33tlJ8s75e8o3QTZcIBmEX37QQU87vbraIO/17vGky2q2ygjUWrbCStWwuFQugkpc/eEu5FpjJwrUJBVgIVTFqbXh+YoIu05rTU8xJ3m1r21B7u/qobwAGQARl1UiEt+PJzXPgdZ9Wop1rxZhqk3j9DFcLepoIDXEqucb13v81ufb7eMKFQ96uBz0plvTl8POECnocCgHEh4pG0V7bVncezgaV5eFcTdKvDF61K5Sq0H6fx770HNQw9rb5jbalW6BSkVuMlGJHdPuBvzv5mPZrdya93V4vqh1yvdBNlwgNaBwN5udncLLpg5GEMn9Ub5xmNYv2wvWpqkjK7MLBN69s3G0b32iNeL9ng6E25g/Vtlmg/QuTNmoObJp2TdsSoVSOPrn5PFF8TnlsyFQOgpKKvRCodb31MEettEgwO0hgUHYECaL/3yzT2oqbBj99fV7bKtm5tcHHxl0NLiQfmH2zD0h+OVbkpCREOD0k2Im2jtuLMRk/iC9O++/h2cnraREbPBjOuGXIcP9n+gVNNSItOYifH52v43GYwDtIYE9pQzs0xoPutCqA/LrlYPdq3n+cXkIXy7uh5Df6h0OxKj1XnohhUrdLPMSm6B89bHmo6hd1Zv3D3hbjy/9XndD383u5t1V5ObA7RGlG88hlWvlfoDcnOTTDWNWac0tmivFrR/32XvRhrZl1yMhveXK1qjuzPqnn2OA3QEoeat55bMVag1qXWsSV+rLThAq1TwvHJTQ0vI3jJTRrZFW3Ohwfsuu6qrYX97CcznDIaz4oAqtqSMlRZ7/UrrndU7LbK8e2dpOzckmH7y0XWkfOMxfPF6qX+JU+PJlvSp3KUBJoMHF0zLU7oZcal79rmQPWXn/gpNBWcAmt/JSgmxrKnWukxjpu42IeEArUJfvlnGAVl1BACBbIsLl13dQ3MJYlotTBISZ3LHbfqg6Zj/vfkxVSfzFT+JtZJZbkYubBZbgi2MXxdTFxRkFYBAKMgqwPzvzdfV/DPAQ9yKCbc06oNnt8LVqrEeTVog3PnXqUo3otO0mhAWitZ3slJK4Nz0ygMr8VDJQ/CgrdaBAQY8NeWpdku2QiEQdtyyI+RjqaofbjaY8cgFj+guIAeTLUATkRHAZgBVQohriGgggCUAegDYAuCnQgheIwEpOH/55h5/IRDf0qjNnxzEqWP6XqeoZeXvLse3a11odNmQbbLjgktNGPqjWUo3Kyb5996D6vsfULoZCaPMTF3sZKW0cNnegQEv3Ly1UvO8NosNDS0NIduqV3L2oO8GUAagq/f7pwE8K4RYQkR/BXA7gJdkvJ/mlG88hpJl5SEzsF2tHkWCc1rtTJUQgS9XW+AS0q93o6s7vlzdAmC5JoJ07owZOPXee3B8u0HppiQk99pZnMEtk2hVykJVJ1NqnldvBUhiJcscNBH1BTAdwN+93xOAqQDe9Z6yGMAsOe6lVeUbj2H162UJLY/q0lX+vWI5OMfOJSwdvv92rXaWuw149VXYbroRIO1urNC4br3STUgbgfPWcszz3jDshk49b+GUhWkZnAH5etDPAXgAQI73+x4A7EII37vXUQB9ZLqXJoXaFSpeZ09rrG5yGmh02ZRuQvy0lrUdwFVdzYVKUijWWuA+Nwy7wb8nc/DxFRUr4r6/gQxpMZQdTsI9aCK6BkCdEGJLJ59/BxFtJqLN9fX1iTZHtXhXKO0yZRiQaWgK+Vi2yZ7axiTIvkz7e+VW3/8ADt12m9LNYCHMmzwPNwy7wb+jlIEM/uHps66zYZ9nNYbeBEVPG190hhw96AsB/JCIfgAgE9Ic9PMAbERk8vai+wKoCvVkIcQrAF4BgOLiYu1+tI+CDOiwexRTIQL6DrXBXu9ol2GPyg34cnVLu2FuE7Xggks1thBCJ0uUHN9uQNnwEf7vbTfdiIJHH1WwRcxn3uR5cQ9Jb/rJJizYsADvlL8Dj/CE3FIzHSX87iKEmAtgLgAQ0aUAfiuEuJmI3gHwI0iZ3LcA0Hel9gjWvbWHg7PKBS51C2nSLADL8e3aJk1mcfsZjboJ0oHsby8BAA7SGtaZwK53yfz4/yCAJUS0AMA2AP9I4r1UqXzjMaz5VxncLt0ODOgCGShycPYa+qNZGPqjFDUqSWyzr/cHM7UwFRbKskbbvuwdDtAqFml+moUma4AWQqwFsNb75wMAJsp5fS0p33gMq14tVboZLAbCI7D2rb2a3+M5Fr4AppogbTbLV0BFhyMDeuLrHfMwduxIqCijs7i4WGzevFnpZsRswIABOHz4cNTzumf3wuM3v5WCFrFITBkUsUqbliuFdUbNY4+pJ1DLwWjEiN27lG4FY3Ejoi1CiOLg41yLOwGHDx+GECLk/y/8crX//5ONtUo3Ne2REbjs5hHRT0wjBY8+CrLZlG6GbGyz0zvjl+kPB2gZ2Ww22HT0hhfIlKHd4haWLCMu/9nItBjCjpdoaFC6CQkR3v85i5vpkcbWiGgIQVf7N2txAw8yAL9+sf2w9bkXF2LX+o5znudenJ4bMOhhE42ST/8bvxxwv9LNYEx23IOWga/n3NDQgIaGBthsNjzw2kylm5X2Qi1tu+THw3HuxYXw1lEAGaTgfMmPh6e2cSqRf+89oMxO7BNsUsdn+5b8LGQbu0Y/kTENUse/Mh1SU/JdrLr1tqbFblqX/Hh42gbkYL6SmXXPPhdfT9oVoga52Qw4ZSpHS4QRZdIqiH1Tp4VsmwBw5LaJmNhtijz3ZExluActA7vdDrvdjtzcXOTm5sJut2PRrR8q3ay4dOlqTovgzDrKnTEDQ9asTnyfZbmCM9CuXnioXr4AUD9jDEZefxeGZI+U776MqQgHaAajieBo5I040p2q9lk2Gv1/zJ0xAwVPPC59gCCCqbAQfRb9AZcsWsrBmekaD3HLyG63K92EuJGBMPWnI3RZVIX442dccmfMwNmtW2FfslTxHa+Cl0zlzpjBO1ixtMNvYWmMDMDlt4zA0Em9owYzMgBX3DZSU0Fv1EXpmZmdiIJHH0XhH55WrgFGIy+ZYsyLe9AJ6N+/P4iirw/unt0rBa2Jn/DAvzZ41EWhlx/5jLqo0H/ul2/ugas19O4fZosRBhPQ0qR82UVOBOuc3Bkz4k8aSxQRCv/wNPeSGQvAAToBhw4dCvvYB89uxdG99qTdO5btKy1ZxoiBMrt729aJvmC2+6vqdtclgxScfY/7gvS3H1S0244xsAhI+cZjWP16GTzuTgyTyrR+PPC1sfjl33sPan73CERzc2puqMFVD4wlG9fiTqLgIE1GQMjQsfQV4Fj31p6wvd4rbpMqZ5VvPIZVr5V2CHoGI2Haz0YkrbpW+cZjKFlWjuamEMtxfHyDD6Ltg0DBYFu74D/g3B44tOsEGk+2xHV/3+tnndewYoXUk66pgamgwJ9EVj33odDLrBJkKizEkDWrZb8uY2oXrhY3B+gUKt94LOLwcKwCC2use2sPdpVU+wOwKYNw2c0jOvRo1y/b6+9NZ2aZMGX20JQHsPKNxyL2vON5fiTpXHgkVWoeewz2Ze9IO0gZjSCjEaK1NbGLBqx9ZiydcIBWifKNx/DF4tKow9NAW/lJ37Bz8HBzuvrLr9aEfYx7zsooG574RiTcg2bpKlyA5jnoFAuXaEVGwJJpQnOTq0PvMt0DcrBw8+9kAAfnJDt0221wfLvB/731gskY8OqrsV8gTLUxysxU1zpsxlSAA7QCYkm0YuGFyzjnZVXJFRycAcDx7QYcuu02kM0GEakOgNGIwoW/92dph5rf5gxuxtrjIW6mSeve2sND/ykWaRi7cNEfUP3AgyGzsclmQ8HDD3EAZiwMHuJmusIbXqiLL/jWPPmUvydttNnQiwMzY53GAZoxJgsux8mYvDRUuJExpiTrBZPjOs4YSwwHaMZYTAa8+mqHYBx3FjdjLGY8xM0YixkHY8ZSh3vQjDHGmApxgGaMMcZUiAM0Y4wxpkIcoBljjDEV4gDNGGOMqRAHaMYYY0yFOEAzxhhjKsQBmjHGGFMhDtCMMcaYCnGAZowxxlSIAzRjjDGmQhygGWOMMRXiAM0YY4ypEO9mxRhjaaKy3oHdlY1wtHpgzTBgVFE2ivKsKW9Hye4TOH7G5f++Z44JU0b1SHk71I4DNGOM6VRgQM4wEZwuAeF9zNHqweaK09hccdp/vpGA8YO6JjVoBwdnADh+xoWS3Sc4SAfhAM0YYxoXHIiFEHC625/T6hKhnxzALeAP2MkK0sHBOdrxdMYBmjHGNKyy3oFtB0/D7ZG+jyUQR7O7srFDgN5+oAGH6pohABCAAfmZGDcoN+F7sfA4QDPGmMpECoaBvWWzER16ynJwtHo63CuQAHCwrhkAOEgnEQdoxhhTke0HGvzBD2gLhmcc0hBw4FBwMoKzz4ebav298nAO1jXHHaB75phCDmf3zOFwFCzhZVZEVEREXxJRKRHtJqK7vce7E9EqItrn/dot8eYyxpi+HQoIzoGOn3GldJ42WnDurCmjenQIxpzFHZocH1lcAP6fEGIrEeUA2EJEqwDcCmC1EGIhEc0BMAfAgzLcjzHGdCvxGeTYGQ3JC8SBQi3vmjIq9cu7tCbhAC2EqAFQ4/3zGSIqA9AHwEwAl3pPWwxgLThAM8aYKlgzDB3mluNloPbfhwrEALD1wGl4vJ88fMu7Tpxp5fnrKGQd9CeiAQDGA9gIoJc3eAPAMQC95LwXY6r20X3AltcA4QbICJx3K3DNM0q3iqlcZb0jJfcxGoBRRdkhE8Di0T3bhJWb60JmjvsCsYHgD86BOMksOtlKfRJRNoB/A7hHCHE68DEhhECYkRsiuoOINhPR5vr6ermaw5hyProP2PwPKTgD0tfN/wAezwN2LJPnHjuWAc+eC8y3SV/lui5T1NYDp6OfJINuWSYU5Vn9PdzOOn7GFXVZV6jg7HOwrjllH0q0SJYeNBGZIQXnN4UQ73kP1xJRgRCihogKANSFeq4Q4hUArwBAcXFxKqdfGJPXjmXA6seBhsrQj3tageW/lv48Znbn7+P7AODTUAl8cGfi12UpFbyUqkeOKWIwk9PxMy5U1juw5+iZ1NwwglBrrpkk4QBNRATgHwDKhBCBY3gfArgFwELv1w8SvRdjquEPxkcBazfA0QAghjUvHifw/q+kP3cmmO5Y1j44+7hbgU8ejP+aga8jty8w7REO8ikQXO5SIPWVtAJLfCrJ0erB+xtqOySsGQ3A+IHJLTuqdnL0oC8E8FMAO4lou/fYQ5AC8zIiuh3AYQD8r57pw45lwIr/BZzeoTnHyfieL9zS84H4g+Hqx8M/Fm87diwD3vslAO+7YkOl9/tOtIvFrLLewWUtQwjOJnd7gC1JLjuqdnJkcX8FaYQmlGmJXp8xRQX3MIdc2Zb8lQinQ7puvIGw4Whi9w204h74g7OfRzrOATppdhxWflhZKwTSewic94NmLBxfT7mhEoCQvgYmfyWqoTL+BK/cvuEfs3aP7/7OpviOM1nIUSs7nSS6FEzLOEAzFs4nD7YNYydLQ6WUOBZrkJ72CGDMCPGAAfj+09GfH5j9zVJu+4GGiI9bjClqiIYQgPc31OLTrfVpl/HNxU8ZC7ZjGfDRPUBrinqSHmfsCV6+cz55sG3O2dpdCs7Bzw/MKidj7D1/kvlzO68JB9CxxnYoLUmsra1VgftXbzsozUmfONMacjMRve24RdISZXUoLi4WmzdvVroZLJ3tWAYs/xXgUeCdcn7k3lVcghPZ4lF8O9BvsjzZ3cFLwnx6Dgfu2hj/9TRs+YbalJbx1KtwhU+yLYTGlo4PaKHONxFtEUIUBx/nHjRjgT08Jcm55Kmzw/MDL5GC8wd3Sku3AG929y+AIxvi7/lueS308eN7pL/3NOpJc3CWR7i14qGCMyAtX3t/Qy0IwHmDtbVsi3vQLL2F6+GpggG47mXpj+GGtEMF9SMbOv+acoukof1IS7Zyi0J/ePjoPmDzP+EPRRlZsU0TpElv+v0NtUo3QRYEbX/YKFZhkA7Xg+YAzdLbY92V7zlHYsiQ3hF9vVn/cTMw4WfAd2+17ykbMzqem5R2mQFLDuA4JX0w6D4IOLiu89fLLgCMJl0XTNFLgB6Ynxl1Ll3NrBkGXD0hT+lmtBMuQHMWN0tPO5apPzgDUnnQUAHX45SGj4OHsVMRnH33d5yEf/lZIsEZABpr2i9ne+8XwOIfytFSVZAz+zh4L+VU6plj0nTSFaCtZVscoFn6WfxDKQCoPThHo/X2R3NwnTRsrnGV9Q5/9nGiCKkvCepjJPiTrawZ2g0dWmq7dlrKmBw+ui/x3h6L38BLpCVW8QqXZKYhuysbO5Sx7CwlJyTdAli1TdrzqLct1Fp8bUh0B69U4ixull62vKp0C+JjyQWcjcos+5LTwRKg+Lb2SWSxEG6psIqG56TlGFK1Zhjg9gjFq5A1tghNz6UHJohpYc10egfoFR8A1dVt3xMBl00FhgwN/5x95cCmjUBjI5CdDUycFPl8ph47lgFCO/NPAICWBoQvdR9Mzfm1ns5nlmt4O81olcNiMTA/Ez1yMlSz+5SWBQbnwEQ3AWlv6vqGFlwxPl+h1nWUflncwUE5FEsmcOGFHQNvyTqgtDT0czhYq9+z54bfq1nr4qkUplXW7sCDB5VuRVzkKk4SvBUji19g9nakn8tABXrSnMUNxBacAaClGVi/Tuot+0QKzoDUo/5yTfvnMHWRcycotdF7cAakrPGnB8a3uYjC5Or+cHBOXODcc6Sfi5qWkKXHEHfgsHSsXC7pOUOGSs+PFJx9hAC+/iq2XjQPlaeetVv8eyaz1LJ2j/wzcpyUNhcBNDHcreZJh3TSM8fUrjiJVn4u+g/Q+8ql3rCrE0sTfAF9UxxVjlpapK/hetxEQG4uYLe3v8+a1dL/HKzlpZYyniw2Dnv0czzOzu2lrYABGi/qoXUEoEeOCU0tHry/oRbWDANGFWVr5uei/yHuTRs7F5wBwGKRvsbT8waApW+H73EL0T44B/MF69dfi++erCNfGU8OzhoS41iuRqYrxg3KxcD8TKWbkZYMJNXePtno8mfSO1o92HrgNHrkaGOZmP4DdLzBNVBrq9QDz45z3VykABwrh0MK9KzztLakisUut6/SLYjZuEG5uHZyL1w7uVfK7hlr3r+eeQSwueJ0h801PALYcfiMMo2Kk/4DdLzBNZAQUg984iTAoMBfld0OvPJXabicxUeLS6pYbMgImLOA+blt/+uoLGiijAZpWFdrjCl8i1V6PXms9B+g+/VL7PmNjVKQ9ij0Zi+ENFzOQTo+qx9XugUsWYRb2q4y0MF1mgjSqejZuj3KlQNNhJoy1ZdvqMX7G2rx6dZ6Weuox0v/AfrIkcSvEThMbjIBI0e2zU+nSllZau+ndRqZo2Qy0kAJ1wE8H60Jvv61o9WDzRWn/SVOU03/ATqROehQXC4p6N/638Av/0fKyk4FFRWU0QQNzVGy9KGV5CTWXmOLQMnuEym/r/YmKmKRyNKqWPiC/r5yKUCHCp4jRwJTLole4CQeb/6L103Hatoj0o5VjKnI7kqZOwwsZZSYNtBfD3pfuVTRK1nB2efll6TlUOHmpsvLpbZMuUTqaf/yfxK/p++DgW8p1ooPEr+mXmlgjSxLP1rai5gpT38BetNGdQwH+yqRBUokozyU6mrg769wedFwzFlKt4Cl2uN5qi4FqqW9iJny9PfbIveccyIaG6We9ssvAa/9U8ooN8k8q+B2S71pDtIdzXgOevwVZxF4WqWpjY/uU7olIWlpL+J0FCmjqKcCS9f09+4ldy9VLi0t0ly0QOQMcKL2j1tizPpctzaR1unTmNnAdS8DuUUASPp63d+kdbRM3zb/U5U96cB60Ex5RgNg9r4dWDMMOG9wV1w7uVeHYNwzx4Qpo3qkvH36227SNwetotcVt+D56tdelXbYivd5LLT56tqUnSWJOQtwNUvrpskInHcrcM0zSrcKJbtPxJxwlGEizRTV0AslgnH6bDc5ZChw2VT5h5KVdOGFqVvOlQ64B50enE1tddiFW6rLroKh73je/Pt0t6S0wlawgfmZaVdL/PgZlyqKlAB6DNCAFKRv/4V6h7vjpccPHUo671alW6AMa3elW6C8La8p3QIAQPHgrjGdd6iuGd2ylPt33yMnA4c0sOtTMviKlGw/0KBYG/QZoH0mTtJeUBs5MvRx34eOcI+HO846uuYZdWR4W1I81O44BZC+/8lHI4QbFa/+UulmoCjPiuLBXWGIMjAmoGzZzt2VjZrYNzmZDtY1K9aT1ve/1iFDgYsvUboVsfMVN4lkyiXSeb4hb6LYnsfam/EcYFY4YafldGrvl9sXMKV3khIBGHRoiWqC9MxJqd3lKl68bluiVIEZjXUvO2HIUOBYjXzVvJLBZJI+SMRaGWzKJRyQE+UrZPLJg4DjpEKNSHHfZNojwHt3pPaeKkQE9D+8DMDLSjfFz2hIzmYRPXNMne6BGwiwmA0cpKHcBxV996B9gnudahNPcGbyGTMbePAgMDDChx29JJQNvER6velUo7z49rCLOYwq2oq0st6RlOBsIGBAfpeY57uDeQTQ6lTP35OSMkzKxA79LbOKldqWYxEBI0YAvQukCmSdrbldsk7a+UqItmtybzu6j+6TEoiCl+TsWAas+F/AGWYOKiMLcLUCHmcqWxufgZcAt3wo/Tna69ELa3fgwYNwze8GEzoGGRcMMM0/pUDDOvp0a73qe6kGkgJ2uiIA5w3umrR17OGWWaVvgAaSv6mGnHzBFggfgMNtzBFqjpoDeex2LJP2l244KvVApz3Svtb3jmWdGyo3W1MTKHOL2rc5+PU0VCa/DUrILUKtqQ/yj29oN3gmBHBgwI0YfJs6hrjf31CrdBNiQkj5pIyqWDMMuHpCXlKuzQE6nH3lUqlMLfMF4Ff+Gn5EIDAIhwvkNhvQ0MBBu7OeyAfcLaEfs3aXAjgZpV66L2iufjw1AdJgBma9GHoTET0XbjFmoNY2AT1ObIJReOAmAw73n62a4AxoowfNJMlK6OMAHYlvG8d0YDRK9btjxRnisduxDFj+K8AT9PdbfHv4ClapHHL2Dvt28PRABRPlUiAjC3ioWulWhFVZ78C2g6eTMg/N5DUwPxPjBsn/gTZ9Kol1xsRJ6k0gk1s8wRmQhsFZbMbMBmb9tWPt70jlJcfMBmb8yfucJAsXhL//NGDMCP2YQQdJcq1NqqzL7VOUZ8X4gZ1L5GKpdbCuOaWFSzhAA1ISlm9+l7WnohEWTRgzG7h3FzDfLn2NZV9q33OU2shjzGxg5l/aPiT42pBbJH3gKL5d+9ns7/1C9UE6TboImncwhZXV9L8OOhb7yoFy3q4xpHQZWVCDZK/NjlTqc8zs8B8mxsxuGwV49lztJpW99wvpaywfmhQwID8z5Jv/wDDHmXIq6x0p2ZmMe9CAtKwp1kxuo8Z7EvESQtrLmvebTg3f2uz5DdL/cvr+04lfY9oj2u5Nr35c6RaENW5QLgbmZ/p70gSk3UYVWpGqymJJ70ET0dUAngdgBPB3IcTCZN8zbrEmiFks0r7O6aalRVozDnBBlVTLLZKvxypHz3HM7LaeqBY1HFW6BRGNG5TbIQlpuYzLsJJVsSwd9D15BKOO7YbV6YDDbAVyvpf098Ok9qCJyAjgLwC+D2AkgJuISH27OsS669Xgwclth5oJIY00sNSa9og8NcNTkYSmBRqspCZnFkhngjNPcknBefzRbejidIAAdHE64Fm7Nukji8ke4p4IYL8Q4oAQohXAEgAzk3zP+IXa9SrU3Gt5ufZ2x5JTY6O0JI2Hu1OnXZY3SfPI8e7EZbZKgZ5p8u9ByQAplQvNTPsgPerYbphE+xUwBo876Z2WZEebPgACx+eOApiU5HvGzzdM8fXXQIs3GSNU9rLLJQ1za6HyWLI0NkqFXY7V8ProVAmXwLVjGbDiHsDZFP65wVXE5JCRJS1d0hJDBjDrL6pNEIskXPJYsmWYCGP656Aoz4oeORn47tBpON1tj3W1GhXdCjOVrGHqFIjGxqR+eFG8O0hEdwC4AwD69eunbGPcMfyypeMcdCilpVLdcJ6TVk5g4I5WjlRO1zwXuiCLGkUqEqMRvjnpQ3XNSS+1ac0wYFRRdocM5aI8a8is5cp6B3ZXNsLR6oE1w4DetgxdZpw7zFZ0CRGkHWYruiTxvskO0FUAAie/+nqP+QkhXgHwCiBVEktye8KLJ5ObSTZt5ACtFpGWSSXjXkDbBwI1V2g+sV/pFsgiVPJYZb0Dmyvk2VO8uJMbQYQK3OMG5WqmvnisdvcehfFHt7Ub5naREbt7j8L5Sbxvsueg/wNgCBENJKIMADcC+DDJ9+ycdCn1KSf+O0tfgQVZMuKcE0+lg+uAxT9UuhVJUZRn7fRWkqGuJSdrhr5W8B7t3g/b+o7HWbMVAsBZsxXb+o7H0e7JHfVNag9aCOEiorsAfAZpmdU/hRC7k3nPTsvO5oATr1iz35m+qX3I++A6pVuQNEV5Vpw406q6YeVRRdmy9e7V4mj3fkkPyMGSPgcthPgYwMeJXuf06dOoq6uD05mkfXdHj5USxBQarTM7W5F/5DC6ntbQL/VE9eX7MQX4hry1vD5aw8YNyu2QxBWPnjnyhwG1fnDojAwTodUVOjAku5CM4klisTh9+jRqa2vRp08fWK1WULLKTzY3A2dSHyCFEHA4naiyZAL79mojSE+dxvPPrM2Y2cCRDcDmfyjdkrQUPBdcWe/AlorT7fobBCDLQmhsaTvaM8eEKaN6JKVNvg8O2w6chlvFaQrRjOmfE3K3sZ45pqTsbBVIEwG6rq4Offr0QZcuycyXA5CZqUiAJiJ0ychAn4LeqG5pRtddO1PehrgQcXBmHfmypbe8Ju15rRYD0285oC9YB2ZYh8rOTkU7fPcMzPjWCoKyf5eaCNBOpxNWa2p/sZRgNZvhNIfZ9k9NeOcvFs41z0j/P9ZdHUG653DgFnXmpSZbuKVRSom0VKuzw/PJNsA7hK3U36VmUu2SNqytIpp4jSNHcoESFt15t6buXmSUesmBu3VZu0vbd97F5WnVrijPimvO74VrJ/dS1eYgA/Mzkz6EHY0metAplWkFmkNXjWHg4MxiEzzcTUZgwEXAyQPS2mkyyNDDJmmZF9MNX0AMTC4zEuARqcnfNRqA8QM7tyY8GXQboIUQ2F5px99KDuDLPfVodrqRaTZi6vB8/OLiQRjbNzd0jzUnR/oaR5A+eeoUbr/nXny+bi16du+B3z/8EH78X/8l0ytREYtF6RYwLfENd4cy35b49TW48QWLLlRRls4UPjES4kpOCyxtqha6DNBOtwf3LduOL0rr0OJyw+P9ITmcbnyyqwZr9tTh8pH5eGb2OJiNIUb5c3IAs1laFy2iJzTcOWcOMjLMqN21G9t37cL0m2/G2FGjMGr4cJlfmcKcTmmjjOAEsZJ1QFmZVL+cSJqj5p42iyS3b2LbaBozNLnxBesca4YhruQysxG45vxe2H6gIepSL6US6GKhmTnoWAkhcN+y7VhVWguHsy04+3iEFKhXldbivmXbIUJtinHyhJTNHUNwbmpqwr8/Wokn5sxBdnYWLpo8CT+86ir86513ZHpFKuLxdNy9ZcUHUl1u39+jENL3JfotDsFkEO82moaA5Elrd2CmNje+YJ0zqigbwX0poyH0Gm4CMHaAVGFt3KBcFA/u2mFDi545Jlw7WZr3vnpCniqDM6DDHvT2Sju+KK1DszNycG12evBFaR2+O9qAcUW2tgfsdsAd+9xY+YEDMJlMGBqwV/TYUaOw7ttv4my5RgRWW9tXDlRXhz6vtJR70Sy84HregRt8pHLjD6YJkZY6BW/YEdwbVls2ezx0F6D/XnIQLa7YAmyLy42/lxzACz+e0HbQ2RrX/RqbmtA1qORlbtccnGnU2HZ8sQqct4+2F+rfX5E+7GRnS1XHeO00CxRug49UbvzBNCNcoNVyAI5Gd0Pca/bUdRjWDscjgNVldQndLzsrC6eDanifPtOInGwVbyAQaOq0+M4XQuo5A9Frl/tGIhobgbVftj2PMcZYVLoL0M1xrnZvjrG3Hc7QkaPgcrmw78AB/7Hvdu/GqGHDErpuyqzvxFzx+nVSsI1nswyPB/j66/jvxRhjaUp3ATrTbIzvfFPQ+fFU8sq0Iqt3b1x33XV45Omn0dTUhK83bsIHn36Kn15/fVztUExn9sB2uaTh7YmT2g95R9Oi/cL5jDGWKrqbg546PB+f7KqJaZjbQMC0EfntD9psUqJY8Fx0TlepVncIL774Iv77Zz9D/qhR6NGtO176w9P6W2IVrLGxbU55zerYn/fySzwnzRhjMdBdgP75lIFYs6cOjhiGui0mI34+ZVDHB2y2uO7ZvXt3LP/oI+DMmfSpQuYb3h4yNL4ADUjB3Te0zkGaMcZC0t0Q97giGy4fmY9Mc+SXlmk24PKR+RjbV8Zaqzk5QF6+VMZQ7/r1A978l9Qj7gzfMDljjLGQdBdJiAjPzB6HK0b2gtVshCFoitRAgNVsxBUje+GZ2eOSs0FFdjbQYWk8SXW+9aK0NHoWdzSJPp8xxnRMd0PcAGA2GvCnG8fju6MN+Nv6A1izpw7NLjcyTUZMG5GPX0wZhLGBxUnk5purbmoCPG7AYASysqTjLS0xVShLG/vKpZ50YyPPTTPGWABdBmhA6kmPK7LhLzdPiH5yMmRmhk4qy86WyohGYslMn4znwPlrDc5NL99WhUWf7UW13YFCmxX3XzUMs8b3UbpZjDEd0N0Qt+plZoYZ6iYpUzwnB7j1tvjWGOuJhuaml2+rwtz3dqLK7oAAUGV34J6l2zFwzkrMW75T6eYxxjSOA7QScnKkYGwIXIMtpJ71mTPAK38FunZVrHmK08jc9KLP9oZcLSAAvLHhCAdpxlhCdDvErXq+4e8zZ9BhK3IhpE0orFbAkSbLtgKpbPQgcBg712qG0+1BU2v0ZXxvbDgCAFgwa3Sym8gY0yEO0EpqbESH4ByoOU3moYNNnKR0C/x8w9i+nrLd4Yzr+RykGWOdxUPcSoqWzR1qr2q9M5lUlSAWbhg7Hm9tPCJTaxhj6US3AVoIgZNnnNhYbseHm2rx/oZafLipFhvL7TjZ6ISQMfi98MILKC4uhsViwa233irbdQHEV+taDy5W1x7SVfbEpxhi3V2NMcYC6XKI2+MR2FJxGjWnmuEO6KS6PUD1yRbU2ltQ0C0T5w3uCkNwJZNOKCwsxLx58/DZZ5/BEc+cMRmi96JHjJCKguiB0di2BWUoU6epqvcMSOVm5IivA+euhBCAkQg3TSriIW/GWFS6C9BChA7OgdweoOZUM7ZUAMXndE24mth1110HANi8eTOOHj0a+xOjrYnOzgameHuUZWXaH/KOFJyJVBecAXmCM9D2o3MLgTc2HMHB+ka8+YsL4rqGL1mtyu6AkQhuIfxf+/AabMZ0R3cB+lSjK2Jw9vEF6VNNXdA925yaxgXzZXI3NnbsSZtMUrJUyTp9BOdoCgqUbkFKfV1xEsu3VWHW+D4hA29wwA1OVnN7fx98X31rsDcfPsm9cz2r2QZUfA4024FMGzD4SqBgvNKtYkmiuwC9r6YpanD2cXuA/dVNmDjUltQ2ReSrONbcLJUGBdpKXh6r6dTwtkD7SuBCaGAq+3SU6moK6dbFjFNn48vcjtX970gB1ZfpDbQPuHPf24nNh0/iyz31Mc+Fv7HhCP695SgyzUbYzzq5upnWhAvAZcuBqqACPs12oOx96c8cpHVJdwG61t4S1/nH4jw/aXyBuq5OCs6++tSdIbxB2huUVR+cAdUWJ3l0xijcs3R7Uq7t9KBdcA7mcLojPh7+eR44nNKnVF+gB8BBOtX+8zmwcx/gJMAsgNFDgPOvDH/+5r8D9oq275vtQOm/gaot7Y8H8jilgM4BWpd0l8Uda++5s+cnndMJfLkm4YCliaAcbF+50i3oQA9BzeF0Y9Fne5VuRnr5z+fAtn2A0wCApK/b9knHQylbHjoIC3f44OzTbE+wsUytdNeDNhriC7pGGT6iuFwuuFwuuN1uuN1uNDc3w2QywWTqxF9vS0vC882aDM6A9MFEZYliy7dVgUj7KQDVMiwXY3HYUQ4IY/tjwiAd75vXcRi7alPn75VpS6ChTM1014PuZbPEdX7vOM8PZcGCBbBarVi4cCHeeOMNWK1WLFiwoHMX03okSIQQUlKcSizfVoX7lm7XxY+k0Kajvci1wBXmrdVlAHYva+v1Ntul7xNZL9BsB756Wpq/ZrqiuwA9pCAr5l6x0QCcU5iV8D3nz58PIUS7/+fPn5/wddNSaalqgvTc93ZAbTMgnXX/VcOUbkJ6MYVZUhjueKJ8CWMcpHVFd0Pc3bJNKOiWGXWpldEAFHTLRLcslf0VaHZ8WkalpYDdDsyYqWgzfIlWWmezmnUxl656gRnY3bsA9d2lYW0f8gDd7cm7PyeM6Y7KolPiiAjnDe6KLRUIG6R9wfm8wYkXKZGdxQIYDIBHH8Gh06qrpaQxlc1Ja9H8H44CAMxbvhNvb6z0FziJt6JZ4K5evHwrSM02qQfr8S7JyzkrfT1pA1xGqefc3d52PFmCE8ZqtgGl7wPCt1SQgD4TgRGzktsOJgvdBWgAMBgIxed0xammLthX3YRaewvcHikw97ZZMKQwC92UKk4SjdkMXHpZ2zIr35roPWVS0EonmzYqGqANpI862psPnwy53jpwp61owXv5tqp2y818hVEAfWS6d0pgjzlUUdics8kPyMECE8ZqtnnntwMJaT1103Gg+QQXPFE5XQZoQOpJd882Y5KSRUg6a8jQjoFpyFCpR7l+HeByKdOuVFN4bfSPJ/Xr1DpktXljwxGEGyd6e2Ol/xyfwOBd3L+7v8pZKPe/sz09A3Rwj1m2orAJMJilQOuzd0X4c4PXW+9e1jGYm7sAQ6/hwK0g3QZoXfIF7pdfUrolqUGk6DC3rwcZ3LMEIhcYUaNw4cMthD9IB3tzwxH8e0tVxO02dTJNH5toPWaleZyA/XBb5TFXgkvrnGelQikAB2mFcIDWouzs+HuXvsW8yV7UK+f1hZBGDABFg7QvUC/fVoX/t2w73Cp7X06Er/Z3KAJIeC9s3VBjjzkU3/B1tOImsRJuTjxTkO6WWaWFiZOkzTTiccevgF/+j/Q1WZIR/F0uaS5aYcu3VeHepfoKzgCQYSJeOBCLis8DgrPKyRWcfbhSmWK4B61Fvt7k118DLc3xP78zPfBoIuz1XJ+ZhyPZg9BitMDibkG/xgPIa66P/doqqNO96LO9au0zxcxqNqDZ6Wn3OhxODwzU+f7ghYO7y9E09arZBpR/JA33piuuVKaYhHrQRLSIiPYQ0Q4iep+IbAGPzSWi/US0l4iuSrilrL0hQ4FbbwOMMXzGGjmy/fed6YFPndbxOoB0nZEjIwbniq7D0GLKBIjQYspERddhqM/Mi+/+CtNDqcxw67oTyVQ/dMKB5duqOn8BNdv4V2Dn2+kdnMnYPvGMpVSiQ9yrAJwrhBgDoBzAXAAgopEAbgQwCsDVAF4kImPYqySDEMDRzcCynwFP9gbm26Svy24Bjm6RbSi2paUFt99+O/r374+cnByMGzcOn3zyiSzXjok7Ska3zQZMuaT9sSFDgYsvkXrSQPRtrywW6TlTLpECte952dnSdY6ET5g6kj0IHkP7H73HYMSR7EGR260yeimVKfcogG+51c1/+1bmKyts41+B0wcBQ2rftlQnswfPPysooSFuIUTg1iwbAPzI++eZAJYIIVoAHCSi/QAmAkjNv2K3E3j/V8DejwFXMyC8PQenAyj7ENj3OTDsB8C1fwWMia2HdrlcKCoqwrp169CvXz98/PHHmD17Nnbu3IkBAwYk/lqiiTZcbbeHzoQOtZQr1DIukwm48KLIz1uzOuztW4yha52HOx6SCiZJ779qWNK2ndSDrytOYt7ynXEVPlGtmm1AQwVg4BlAOOqkvw8O0oqQM0nsvwH4uo59AASu3TjqPZZ8QniD80ppaEoEDesJj3R8z0rpvAR70llZWZg/fz4GDBgAg8GAa665BgMHDsSWLVsSum7MJk6Kfk6EANpOcM/a10OOlkHtOz8Eizv0ftvhjoc0YkTs5ybJrPF99D/fmqBwy7U0p+JzDs6Byj9SugVpK2qAJqIviGhXiP9nBpzzMAAXgDfjbQAR3UFEm4loc319HIlD4VRtkXrOzihzhi6HdF7V1sTvGaC2thbl5eUYNWqUrNcNK9blR7FuQDFkKHDzT6WM75t/Gtv1w81pFxai38RBMARtOWHwuNGv8YD04SjSByQiaX47eIheIW/+4gJ0MfPCh3DcQmDe8p1KNyNxnLXcnvOstK6apVzUj4lCiMsjPU5EtwK4BsA0IfzvtlUAigJO6+s9Fur6rwB4BQCKi4sTnyL75s/SsHYsXM3Aty8A17+a8G0BwOl04uabb8Ytt9yC4cOHy3LNmMSyvKm0NHmBzhfEg8uTDhkKXyrYke2VaHEbpCzupoPIG5QH5HqAtW8DxvMBow2wGIGLLlN1/W29bKCRLIHlQzUr08ZBOljVRsDWn4e6UyyhcRwiuhrAAwAuEUIEpjp+COAtInoGQCGAIQAS2JE8Dvs+6zisHY7wAOWfynJbj8eDn/70p8jIyMALL7wgyzVjNmKEFICVFGpu2iuvyIa8IlvAkQltfxwzO6nNkluhzRq27CWTvL2xUtsBevCVQUVJGAAuWKKARCdaXgBgAbDKuyvUBiHEr4QQu4loGYBSSEPfdwohUlOSyBnnuuBEy+EBEELg9ttvR21tLT7++GOYzSneiGPKJUBZWXIrhDEAUrLY/e98B6cedtFIknCVyTTDF4R2vwPVVgxLBjJE7tz4RhXKlgNVmyD93fDuWMmUaBb3OREeexLAk4lcv1PMmdHnnwOZEl8+8z//8z8oKyvDF198AatVoeU4l02NnAwWy3ppFpVvY4j5H+6G3SH1sLp1MWP6mIKodavThdGbda/p7SkLxqdfgZKoI48EfP2slNnd9iRp+BvgIJ0E+nvXHnKVtJQqlmFuMgBDr07odocPH8bLL78Mi8WC3r17+4+//PLLuPnmmxO6dlx8w8vr1oYuGnKJOhKt9GDW+D4hA83B+kZ8XXFSgRapy02TirB8WxXmvrfT/4Glyu7A3PekBDLNBOl0Cs4xEUHBOUDVRuDEXt6+Umb6C9Df+420zjmWf1ymTOCCuxK6Xf/+/SHUMqTnmwfeVx4yYYslz7zlOzUZnM0GeXekMhvatqgMHk1wON1Y9NlebQTomm1Q5Y5VauYbAg/cvpKDdUL0F6D7nCcVIdmzMvL8sskqnddnQvhztCpCwhZLDiXWAPexWXHZ8LyEhtal3BH5gpDTg4gFXTRRMrVmm3ebRQ7OCWu2Swl3AAfpTtDfok4iqULY8OnShuMU9BLJIB0fPl06TwVVqpj2pToxqo93TnfljpqE5r1bU7w9l61LihMoO6Pic2mbRSYPj1P6O2Vx018PGpDKd/7X36UiJN/8SRrydjmkXvPQq4Hv3SX1tBmTSaR9lZPBVwNba9QyGxRRuqyB9u1SlYrX22wHvnpa+mqySh0j59n2Q+A126RA3myXOlFCeEdBvaM8aThcrs8ADUi/AH3PA2YvVrolLA3cNKnIX6SDhWd3OHHhwjXqzuhOl0IlqX6NvvsFTj0GzlcHapdDJNqfW/4RMPSatAjU+hviZkwBmi7MkWK+jG7VblM5+Eppm0XdI6mnqjXOs9K8ds02pVuSdBygGZNJH51sSZkKvoxuVSoYD4z8L20Gr7gI7S4lS5N5bf0OcTOWYvdfNazd2l8WmaozugvGtx9C/WKucm1hoaXBNAT3oBmTyazxffD763ioO1aFWhpxkKHiIJOZL8lNx7gHzZiMZo3vg/+37Dvt16NOgfuvGqZ0E2I3bAaw+10AvJuZKhjMUq6Az+a/A/aKtu9tg4Hin6e+XTLTb4AWAjhdCRwuAY7vleYsDGag53Cg/xSga1/Z1kD/5Cc/werVq9HU1ITevXvjgQcewM9/rv1fDtY50TK6zQZK+802huRnqTeLOxTfcLdvGVCmDegxrK0ONUutggltP5Pg4AxI36+eBxQWa7oEqT4DtMctpePXlwEeF/xp+h4nULcLOL4HyBsBjJoNGBLP1pw7dy7+8Y9/wGKxYM+ePbj00ksxfvx4nHcer7VOR76M7rc3VsItBIgAq8mAs04PjMTBGQDOtnqwfFuV9oJ08Js7B2hl1O5o25wjODj7CHf7n48Gq5rpL0ALERCcQ+3nKqTj9WXSeefemHBPetSoUf4/ExGICBUVFRyg09iCWaPbLb0K3jwi3Wly8wymHi5HW+GTePiyvzUSoPWXJHa6MkJwDuAL0qePynLbX//61+jSpQuGDx+OgoIC/OAHP5DlukwfQm0eke5UvdQqVqS/Po5mdDaLW0PZ3/oL0Ie/8g5rx8DjAo6UyHLbF198EWfOnEFJSQmuu+46WCwWWa7L9EHVS4oUVGV3qLdgSSxGXgepFCXTDu38vPQXoI/vQey70Aigfo9stzYajbjoootw9OhRvPTSS7Jdl2mfppYUpdi9S7djwJyVuHDhGu0F64LxwKjrlW4Fi4vQTBUy/QXoaEPbHc6PsbcdB5fLhYqKMIkLLC3df9UwWM3pUD4yfr6P01V2hzaDtUbmM1mA3e9qIkjrL0Ab4tzOzpDYHFJdXR2WLFmCxsZGuN1ufPbZZ3j77bcxbdq0hK7L9MVXxITLgUYWGKxVXa+7A+0MmzIA8AB7VyjdiKj0F6B7Dkfs/1gIyBue0O2ICC+99BL69u2Lbt264be//S2ee+45/PCHP0zoukx/Zo3vg8uG5yndDM3QRBJZzTYpmzjmaTWmGi4HULZc6VZEpL8UxP4XSfPQsQx1G0xAvykJ3S4vLw/r1q1L6Bosfby9sVLpJmhKld2BAXNWwkiEmyYVqWvXsJpt0rraeKfVmHpUbQRs/VU7TaG/HnTXIqkISbShboNZOq9r39S0izFAkRKgz90wLuX3lJtbCLyx4QjmLd+pdFPaVHzOwVkPVDzUrb8ATSRVCPMH6eDhbmoLzqNmy1buk7FYGBX4fZs1vg+sZn38U1fVCISG1tOyCFzqXQKpj3+1wQxGqULYeb8A8s9tC9QGM9DrXOn46JtkKfPJWDxumlSU8nvOW74TDqc+NnlQ1SYkabCbElOW/uagfYiA3CJgzI+VbgljfgtmjcbB+kZ8XXEyZfeMtHGH1igxAhHW4CulcsGqQ5Ataa3PpPSoN16zTZXz0PrsQTOmYm/+4gL0yslQuhmapMQIRFgF46VtDdUmMxe4/PfSFF6Ht/gwH3D6TJL+9z9O0ve2/slrp5qU/luV66L124NmTMVqz7Qq3QTNuXBwd3VlcQNAY3UnnyhjLzeYb2481BaZrpbQc64n9gIXPdi2Q5TPV08np41qI9xA6fuq60VzgGZMg4xE6pqPTbKfTO6nvuAMtAt2+7IzsKmHFY0mA7JdHkw84cCQxjAfxPpMBGq2JicLPHBuPHiLzC/mhn5OuIS3dEqEE05pXXTwhxQF8RA3YxqUTsEZkObRr3hmrdLNCGtfdgbW52eh0WwEiNBoNmJ9fhb2ZYeZyjixFxhxbfREM4r3LdogzY2HE+5+8R7Xq6pNSregHQ7QjClgSH6W0k3QnH11TRjz6KdKN6M9cxcAwKYeVrgM7ed3XQbCph5hSrs226We7UUPRg6CwhOwpWXA9c1dpDli7/0BACYrMOpHkYdpB1/ZsUaEwRw+qIc6X9fU9cFXt0PcQgjsPL4Tr+1+DSVHS9DiboHFaMHFfS/GraNuxbk9zwXJnBG6b98+jB49Gj/60Y/wxhtvyHptpi+r7rsUVzyzFvvqmpRuiqacbnFj3vKd6hnuHnoNsHsZGk2h+zrhjrcLyoOvjFyRTLikZLTin3d8LN7h2FDz0oOvDB/Ug89nKaXLAO30OPFwycP4svJLtLpb4YG0BrTZ3YwvDn+BkqoSXNr3Ujw55UmYZfx0eOedd+L888+X7XpM31bdd6n/z8u3VeH+d76D06OuT/Bq9MaGI+oJ0AXjgd3LkO3ySMPbQbJdodafU/seayxB0C7j7njB89Kxnv/FQ1BbD1N2Khst0N0QtxDCH5yb3c3+4OzjgQcOlwNfVn6Jh0sehpBpLm/JkiWw2Wy8ixXrlFnj+2DR9WNhs6rrDUKtVFXyE4SJJxwwBX24MnkEJp4IkTE96vqOAdI33K1qOg/OICkvQEV0F6B3Ht+JtUfXotndHPG8Zncz1h5di13HdyV8z9OnT+ORRx7BM888k/C1WPqaNb4Ptj96JQ4tnI5DC6erqyhHgEMLp+Mnk/sp2r431VR8pc9EDGlsxcV1Tch2ugEhkO104+K6po5Z3Jk21S3liZ06fx9lkWkL/cFJYboL0It3L0aLqyWmc1tcLVhcujjhe/7ud7/D7bffjr59eeMNJp9wRTm6mA0gKPt2uWDWaFT8/gc4tHC6IvcXAFb/+XWUnPc97B4+AiXnfQ+r//y6Im3BiFlAn0kY0ujEzYcb8MsKO25u6IkhZ4N6nJGSsXzCFT5RQ0GUPhOVbkGSkDR6obLgDOhwDnr90fUdhrXD8cCD9UfXJ3S/7du344svvsC2beqrQsO0zTfP+vbGSriF6LDl4sA5K5VsHgDg5r99q8h9L63cgrwPlsEs3ACAnk2n4HzpD1gNYNpvfpb6Bo2Y1TFhq2Zb7MlYPsU/Bzb/vf2cc7gEsVTzvb6qTdDVcLeKP3joLkC3uGPrPfs0uyIPhUezdu1aHDp0CP369QMANDY2wu12o7S0FFu3bk3o2owtmDU6bEJUoc2KKnvqd+IZMGclupgNeOq6MSmtKR7oVzs/8AdnH7PHjZy//wlQIkCHEm8ylo8agnE4vg8i654CnGeUbk2CSArOKipMEkx3AdpitESdfw6UacpM6H533HEHbrzxRv/3f/zjH3Ho0CG89NJLCV2XsWjuv2oY5r63Ew6nO/rJMjvr9OC+ZdtTfl+frq1nQx7PbuFla0n39bPaDs6ZNg0k5El0F6Av7nsxvjj8RUzD3AYYcHHfixO6X5cuXdClS1uxgOzsbGRmZiIvLy+h6zIWzazxfQAA9yzdrsj9U7Ui7NLKLbi19BPkOeyot9rw2sjvp+bGLDRHndItSEy0PAAV0V2S2C2jboHFZInp3AxjBm4ZeYus958/fz4XKWEpM2t8H9Vme8vh0sotuHv7u+jlsMMAoJfDjru3vwtHmPWq7uyc1DaQaYu5iyqTwcLRXYAe3XM0Lu17KTKNkYeuM42ZuKzoMpzb89wUtYyx5AiX7Z1hTH7gtlnNuHBw96Rd/9bST5Dpbl9hK9PthNNkRmtQnWq3wYh+j/4uaW1hGmcwS5XfNER3AZqI8OSUJ3FZ0WWwmqwwBL1EAwz+4PzklCdlL/fJWKotmDW63bpkIxF+Mrkf8nISy6+IRavLjTd/cQEOLZyO524Yh6yMjtW0EpHnsIc83rXVgcUX/RS1VhsEAGfPfBQ9/Xvkzpgh6/1ZCNZ8pVvQOSOu1VTvGZBpDpqI/h+APwLIE0IcJynqPQ/gBwDOArhVCJGylGazwYynL34au47vkmpxV5Wg2dWMTFNmu1rcLLJdXx3E6YBKSF17WHHuRQMVbBELJ1S2t1zLsMxGgtMdesL5rFPK9Vi+rQr3v/td2PM6q95qQ68QQdpcWIBn/jYHwBxZ78dicOG9UqJYp+eivXthm7sAzmYgxmWxCdNYcAZkCNBEVATgSgCBpX2+D2CI9/9JAF7yfk0ZIsLovNH4v0v/L5W31aT6SjuOlNWhxeGCxWpCvxH5qD18ql1wBoDTJxzY9dVBDtIaEWkZls1qht0R217Ei340Nmoi2qLP9soenAHgtZHfx93b3203zN1sNGPQvffIfi8Whwvvbftz3DW6BXD579u+DbVeHGh/zN0KOENn7sdEDYVeOkGOHvSzAB4A8EHAsZkAXhdSoesNRGQjogIhRI0M92Myqq+0Y9/Wav/3LQ5Xu++DBQftcNcMDvh5RTY5msviEGoZFgG4eXI/LJg1GgNi7GHPGt8Hj63YjVNnOwb0bl2kZK3qJK3HXlt0HgC0y+L+sHgmnuGhbPXoMxGo2hj7+cHba4ZbLx54rGZb5B2/IlFLoZdOSChAE9FMAFVCiO+C5nL7AKgM+P6o9xgHaJXZty18MO6M+ko7Kr6rgcfbm/IF/NMnzmLwuEJZ78Ui8y3DWvTZXlTbHSi0WXH/VcP8x61mAxzOyMOLvnntR2eM6jCEbTYSHp0xCkByi6asLTrPH6gNBDwze1xS7sM6qUOFMW8BEFv/jkE1lnKnoYTbJjPUMQ0OZYcTNUAT0RcAeod46GEAD0Ea3u40IroDwB0A/NW4WArJPCp5cGetPzgHqj1sR9ceXbgnnWKzxvfxB+Rgv79uTNSha1+GeLRgf/9VwyLOQVtMBrS6PCi0WXHZ8Dx/+dJ4+KqXhXs9TEGhSp36yBVAY+lp60zUAC2EuDzUcSIaDWAgAF/vuS+ArUQ0EUAVgMC1H329x0Jd/xUArwBAcXGxjgq8ap+AAAVtyZCZZUbF9mrUHrH7Pyz36mfD4HGFqK+0wxWhqtWBnTUcoFXEF+jmf7i7w3y0gYAfT+rXLvEsUrD3HQ8eCrdZzZj/w1Ednlfcv3vMVdDMRsKiH43lwKxFnS13ygAkMMQthNgJwJ9vT0SHABR7s7g/BHAXES2BlBzWwPPPyqrYXo3aw/a4nhMcnAGgucmJ5qaA6wj4r2uva4x4Pbcz/OevcEGfJVekoJvMa4XrkQPtPzB062LGozM6BnjG0kGySn1+DGmJ1X5Iy6xuS9J9whJCoK61Bjsa/oMjjgNwCRdMZEI/62CMzT0feRm9ZVsDfemll2LDhg0wmaS/zj59+mDv3r2yXFsOwculkiHW4P/NB6UwGAmDxxb4e9MdPjwEBH0O0voVLqBzMGZMIluAFkIMCPizAHCnXNeOl1u48eXxj3H4bAXcwgXhnWh1CRcOni3HEccB9O8yGJf1/AGMJE9hhRdeeAE//7n6MgXrK+1JD87x8riFP1M8r8gWNrjXHrZzgGaMpS3dVRITQuDL4x/j0Nn9cAmnPzj7H4eASzhx6Ox+fHn8Y4g4E1W05kiZegvbH9xZq3QTGGNMtXQXoOtaa/w950jcwoXDZytQ33pMlvvOnTsXPXv2xIUXXoi1a9fKck05tDgi/z0oyeV0Y9PH6pkKYIwxNdFdgN7RsDlqcPZxCxe+a/hPwvd8+umnceDAAVRVVeGOO+7AjBkzUFFRkfB15WCxqntH0UhZ34YUbPbAGGNqpbsAfcRR0WFYOxwBgSOOAwnfc9KkScjJyYHFYsEtt9yCCy+8EB9//HHC15VDvxH52gx0BAweW6B0KxhjTDHq7l51givG3nPb+Z0oHRcFEalmbtuXKR1YepMMhOYm+V93wrw19H3LrHjNNGMsnekuQJvIFFeQNlHojd9jZbfbsXHjRlxyySUwmUxYunQp1q9fj+effz6h68opr6h9sNvyeblyjYlEtH2tPWxH7WF7yFre9ZV27N9eDRFQpZIMwDnjCjmoM8Z0Q3cBup91MA6eLY9pmJtA6GcdlND9nE4n5s2bhz179sBoNGL48OFYvnw5hg4dmtB1k0nNiWPBWhwu7N9W0yEgBxMeYN/WahzcWQuX082bdDDGNE93AXpMbrG3MEn0IVwjGTE29/yE7peXl4f//CfxRLNUslhNmgrSQoiYa4b7ks54kw7GmNbpLkksP6MA/bsMhpEif/Ywkgn9u5yDvIxQ+4Dom6VLYsP6WlJ72I76SrvSzWCMsbjpLkATES7r+QMM6HIOTGTuUE+aQDCRCQO6nIPLev5AtnKfWlGxvVp1lcWSTc3FWhhjLBzdDXED0tD1tJ7XoL71GL7z1+J2wkRm9LMOwtjc85FvSc8lPPFumKEHWhrOZ4wxH10GaEDqSedbCnBF/g+VbgpTmNqLtTDGWCj8zsV0r8XhwjcflMJoJgwaXcCZ3YwxTdDdHDRj4bid0i5anDTGGNMCDtBppmsPq9JNUNz+7dVKN4ExxqLiAJ1mzr1ooNJNUFykgieMMaYWHKDTkCY3z2CMsTSj2wAthIDju+9w9O57sGfceJSNGIk948bj6D33wrFjh+ybWSxZsgQjRoxAVlYWBg8ejJKSElmvL6d4X/qQCfqrxPXNh6Wo4KFuxpiK6TKLWzidqJ4zB2fWfAnR0gJ4pDFN0dyMM59/jsZ165Az9TIULlwIMideVWvVqlV48MEHsXTpUkycOBE1NTUJXzOZhCe+CF17+JTmyoNGJdrWhHMpUMaYGukuQAshpOC8eg1Ec3PHEzweCIcDZ1avQfWcOSj84x8Trib26KOP4pFHHsHkyZMBAH369Enoemqj58pjtYftqD1iR69+tg6BetdXB9u99q49rDyHzxhLGd0NcTfv2CH1nEMF5wCiuRln1nyJ5p07E7qf2+3G5s2bUV9fj3POOQd9+/bFXXfdBYdDv0FNd7y96cAh7+DgDEgfVHZ9dTDVrWOMpSndBegTr74mDWvHQLS04MSrryZ0v9raWjidTrz77rsoKSnB9u3bsW3bNixYsCCh67LUqz1i9/853KiBnkcTGGPqorsA3bh2rX/OOSqPB41r1yV0P6tVWlf8m9/8BgUFBejZsyfuu+8+fPzxxwldl8WG5PwNljdvkDHGEqK/OegYe8/+86MMhUfTrVs39O3bt908ttp3yDKaCW6nPqKR3Guat3xerq9kOMaYZumuB00WS3znZ2YmfM/bbrsNf/7zn1FXV4dTp07h2WefxTXXXJPwdZNl0OgCQN2fIRQTLThzJTbGWKroLkBnX3opYIjxZRkMyL70koTv+bvf/Q7nn38+hg4dihEjRmD8+PF4+OGHE75usuQV2TBkvLaXFik1SnHmlINreTPGUkJ3AbrHbbfG3IsmSwZ63HZbwvc0m8148cUXYbfbcezYMfzpT39Cpgw982TKK7KhV3+b0s3oFIvVBJAyQ/TCA+zbxhtuMMaST3cBOnPMGORMvSzq0DVlZiJn6lRkjh6dopapz+BxhZodslW0nrYAjpTVKdgAxlg60F2AJiIULlyInGlTQVZrx+FugwFkzUTOtKlSJTGVJ3Ql27kXDUy4lCcRSb3xFP1VqiGJSw1tYIzpm+4CNACQ2YzCP/4R/Re/hpwrr5QCNRHIakXOVVei/+uvo8///Z8sZT71IK/Ihsyszv1dmMxGnDO+QPpGH4nhsSHwMDdjLKl0t8zKh4hgHTMGfZ97VummaMKEy4dg6xf70NzkjPk535s5EgBQsb3aX9e6A4I+A7cAKr6Taq7nFdmUbQtjTJd0G6BZ/CZcPqTd9/WVduzbGn7Hp/pKO/KKbO0qcLVDwJDxhThSVicNCessWHvcAkfK6jhAM8aSggM0CyuvyBYxQPuDU7igK6Rr+ALYNx+Uyt5GpfFcNAu0r7EUm06VoNF9GtnGrpjYbQqGZI9UullMozhAs8gi9Hr9wSncOUFJY7rbshLeJV8s7e1rLMXXJ1ajRbRVJmx0n8aXxz/2Hw8O2BzMWTT87sIi6tXPFnZ+2Recwp3Tq58NgHeO+ohdV8PbPv1G5CvdBFULDlwWgxUXdp+qq0C0omYpqluOhHxMQPhfe6P7NNYcX4mvT6zG4KzhKG/aBZdw+R9bf+IzANDV3w1LDAdoFtHgcYVwNLZ02MXJYCR/cPLto+wPwgT//soRE8g0rld/G88/R7CvsRRfHv8YIuCTWYvHgTXHV2LPmZ2YUXCDgq2TR8nxVWGDczgtohmljds7HHcJF74+sdrfq7YYrIAQIXvfLD3oN0ALAdTVATu2A0eOAC4XYDIB/foDY8cCefmATGugs7Oz233vcDjw61//Gn/+859lub7Szr1oIOor7f5kL4vVhH4j8tsFp8HjCv2BOlDYBDIdqD1iR+1he8i/DwZsOlXSLjgHqm45ghU1S3HCWY8Wj/Thz0KZuLDHtE4HocAh40CFln5J+zBQ1vidrNdrEc1ocUs9bt/fC9DW+470wYaHzPVHnwHa7Qa+XAMcPiT9WXjfJFwu4OAB4MhhoP8A4LKpgNGY8O0aGxvb/bl37964/vrrE76umgQme8VFh8Paft7X1uJwYd82KZmOg3Sb4EAZLLjn2SKa8eVxaZvWeAPLvsZSrD/xmX/IOPg+K2qWJiVIh/sAkizVLUfwz0PPw4lW/zGbsTsmdLug3WhF4HB6Ih96mLL0F6CFkILzoUOAO0RCkhBSoD50SDpv2uWy9aQB4N///jfy8/MxZcoU2a6paTpbWhWWAA7srEmbAB1Lby3b2DVqkA4mILDpVEncAWXTqZKQwdkn3mHoWBEo5UE6MDgDgN19EmuOrwx5biIfepjy9Beg6+q8Peco2cJul3RefR2Q30u22y9evBg/+9nP0r6EqE+kJDO90cse29GUHF/Vbg5V6q11DAITu00JGzgiaXSfjvoBIPjxeD8IBEpkaHhE9tiQ88lqIiCw/sTnHKA1SH+lPnd8Jw1rx8LtBr6Tbw7p8OHDWLduHW655RbZrql1g8cVprRON0uufY2lYQKSwLrjn7c7MiR7JEZmj4v7HhbKxPoTn/mDrm+4tuT4Kn8bgh/vrFDXWn/iM+xrDL9mf19jKd6sfBkvH1qEI44DKLT06/T9U8UlYq8QyNRDfz3oI4fb5pyjEUI6Xyb/+te/cNFFF2HgwIGyXVMPghPIAhPOmLZsOlUS9jE3OgaBKT2vQO/MPlh3/FO4Ef2DM4HghjvkcHVp43aUNm7v1LByuCAaamjcJVxYd/wzf48zeMQgUKP7NJo9Z+NqC2OxSjhAE9FvANwJwA1gpRDiAe/xuQBu9x7/XyHEZ4neKyauON/04z0/gtdffx1z5syR7Xp65Us402NlMb2L1lvd11iKY81VKGv8DgICBEKBpQhuxL4/aLTeXrzB2UpZqGmpxMuHFoFAGJE9FlN6XoF9jaVhX48bLn+PPdoQdqS5bzV5+dAimMiMi3tcycPdGpFQgCaiywDMBDBWCNFCRPne4yMB3AhgFIBCAF8Q0VAhRIxjzwkwmeILuiZ5BhG++eYbVFVV6S57O1l4JyhtkXqR0aeDguecBURcCVpyJVz5AtGeMzvb3V9AoLRxO8oad0BE+dAg9xIqNXAJJyeNaUii0el/ACwUQrQAgBDCt4v9TABLvMcPEtF+ABMBfJvg/aLr119aShXLMDeRdL4MFi9ejOuuuw45OTmyXE/vjpTVRT9JY0xmacletDXjWhNpiFetXMIZMUEtWnCWztFn0l9nM+VZ6iUaoIcCmEJETwJoBvBbIcR/APQBsCHgvKPeY8k3Zqw0rxxLL9polIqWyODll1+W5TrpQo/zzwNH9+qwA1iLw+X/XqtBWo89yXSXSGIdS52oAZqIvgDQO8RDD3uf3x3AZADnA1hGRIPiaQAR3QHgDgDo10+GbMj8fKkISbh10D5Gk3ReHtdSVoKeNs4wmgmDRhcAQNjdv/Zvr9ZsgNZrT1IuBENMPXLG4hV1mZUQ4nIhxLkh/v8AUs/4PSHZBMADoCeAKgBFAZfp6z0W6vqvCCGKhRDFeXl5ib8iIqlC2IAB0vxy8HpkIun4gAHSebxeWRH9RuTDYNTH3/2kH4wAED44A4DQ8Ps38Rq5iAQ8MOpwQQxTXqLroJcDuAwAiGgogAwAxwF8COBGIrIQ0UAAQwBsSvBesTMapQphM34IDBzUlghmMknfz5gJXH6FLGU+WefkFdkweGwByKD9N//gYW29GZEtzzSQnrmhrdEg/tClDYl+7PsngH8S0S4ArQBuEUIIALuJaBmAUgAuAHemJIM7EJFUIeyKK1N6WxY733KrXV8d7LBblpZUfFejdBOSakrPKzSXJMYi4w9d2pBQgBZCtAL4SZjHngTwZCLXZ+nh3IvaCrvUV9qxf1sNRKzFZlTA447e1l79bclvSLLUbEO204NGs/4KD8bLRCbNrHsO5CvuErgOnKkfT5wwVfElUu3bVq2rTTZCbcWpGRWfo2s3FxpN5rTP2dBicDbCDDecvAWlBvFHYqY6eUU2DBlf2CGJzGAk/1pjlkLNdlR34eCsVb4SrLHUGWfqwgGaqZIvicxilQZ5LFYTBo8twMDRvXST/a0VJb1sSjeBycQlXBHrqTN14SFuplq+JLJgtYdPaTqpTGvKcvhzvJ5wkRLt0G2AFkKg9tBpbF91BId3nYCr1QNThgH9z+2J8Vf0Q/6AHNn2bD506BB+/etf49tvv4XFYsGPfvQjPPfcczDJVOebtXf6pPaCc8X2as3OQ+soFYABsBisSjeBxUiXH43dbg9W/WM3Pnh2Gw5sq4erVaoS4Wr14MC2Oix/ditW/WM33G55qkf8+te/Rn5+PmpqarB9+3asW7cOL774oizXZiFoMGLUHrajYrs210rzmtnOsVAmLJQZ8jEl95Bu9TTzPLRG6C5ACyGw+tVSHPzuOFytng57ZgghBeqD3x3H6ldLZVnOc/DgQcyePRuZmZno3bs3rr76auzevTvh67IwNBovag/b8c2Hpfjmg1J882GpZgI2r5ntnBbRDLMhAyOzxyHb2BUAkG3siqk9p+O0y65Yu3ybZTD1090YbO2h0zi44zhczsi9Y5fTg4M7jqPu0Bn0Gtg1oXvec889WLJkCS699FKcOnUKn3zyCZ544omErsk68u0SpcUetJ9o+1p72A5A/UuwfGtmfXs8s9g1uk+jvGkXLu5xVbvlTZF22koFnofWBt31oLevqoQ7SnD2cTs92P5F7HvVhnPxxRdj9+7d6Nq1K/r27Yvi4mLMmjUr4euyNvWVdlR8V6ObDTZ8fEFa7ab0vAJ3DPgtfjngfqWbojku4cLXJ9dgX2Mp3qx8GS8fWqT4tIGvR8/UTXcB+vCu4zFtBQ1Iw92Hdh5P6H4ejwdXX301rrvuOjQ1NeH48eM4deoUHnzwwYSuy9o7UlYXU8UuLaqvtCvdhLjwm3v8WjwOrDm+0t9zVXIkwkQmTOw2RbH7s9jpLkD7EsJiPj/G3nY4J0+exJEjR3DXXXfBYrGgR48euO222/Dxxx8ndF3WXiI9Z7my9ZPlSFmd0k2Iy8RuU2AAF4zREt9uW9nGrh2G25l66W4O2pRhiCtImxKsL9yzZ08MHDgQL730En7729+isbERixcvxpgxYxK6Lmsvkf2j1V7XW2vD9r43969PrkGLR3tL3tLRzwfcq3QTWCforgfd/9yeMVckJAIGjO6Z8D3fe+89fPrpp8jLy8M555wDs9mMZ599NuHrsjZ62j86mK9ampYMyR6JW/vdxcPdKUSdfLvmn5F2ae+dIYpxVxTh8K7jMfWijWYDxl2e+HrEcePGYe3atQlfh4Xnqyh2cGctXM7Ydi7t2sOqiYpjtvxspZvQaRO7TcGXxz/m7O4UEPDARGa4hLPDY0YY4Ubofxc836xduutB9xrQFQPH9Iw6dG0yGzBwTE/kD8hJUctYovKKbJj4g2EYMqEQZIjcm/7ezJFoOdvxjUyN7HWNSjeh04Zkj+TgnEJGGGGi9v0qE5lwSc+rMTJ7HAKLBBhhwtSe03m+WcN014MmIky7baRUrGTHcbid7YuVEEk954FjemLabSNVn0DEOvLV6P7mg8jVkLQyt6uVdjLltYhmTO05HZtOlaDRfbrdFpJDskfyPs86o7sADQBGowFX3D4KdYfOYNuqI9KQt9MDk9mAAaN7YtwV/dBrAM/LaF24xLHAHbC0EvzqK+0hNwZhLFC2sas/GDP902WABqSedK+BXXH1Hecq3RSWJP1G5KPiu5p266MNRkK/EfkRH1fjeuqK72oAgIM0i4jnk9OL7uagWfoIt2e0L8iFe3zIBPWV1vS4hebWQ7PU4fnk9KTbHjRLD+H2jI72uBr3lNbKcHywbGNXru2cBCYycVGRNMcBmqUlNWZ4W6wmVGyvRu0Ru7SpBgG9+tlUv5nGxG5TsP7EZ3AJbX7AUIuR2eNwxHGgQ/IXS18coFlaUmNv1dLF3H7zDI3seOULIutPfB5yjS6LDWdgs2A8B83Skhqrd50+GXrIvfaIPbUN6YQh2SNxe/97MDJ7nH+nJgLBZuyucMsY0y71vUvJRAiBxlMOVO8/gVN1jfC4BQxGQrde2Sg8pyeybZmyrYEuKyvDnXfeiS1btiAvLw+LFi3CtddeK8u1WXKEyvAGSUFFidrdEaueqS/pPKwpPa/o0BN8+dAihVrDmLbpsgft8QiUb6nC7m8O40TNGf+bsMctcKL6DHZ/fQjlW6rg8ST+zudyuTBz5kxcc801OHnyJF555RX85Cc/QXl5ecLXZskTKsN7yPhCnDO+QJHedctZJyJtEVyxvTp1jZHRvsbIxWSYpNCSeMlhpj+kpp1+iouLxebNmzscLysrw4gRI2K6hhBScD517EzE9a4GI6Fb7xwMPa9PQj3pXbt2YfLkyThz5oz/OldeeSUmTZqEJ554Iu7rxfNaWfJEq1KWDLGs0bZYTeg3Il/166X3NZbKuttVtrErnJ5WtIhmWa4nFwIlXOq00NIPMwpukKlFTIuIaIsQojj4uO6GuBtPOaIGZ0DqTZ86dgaN9mbkdLPK2gYhBHbt2iXrNVlqKVGFLJYCKi0Ol+qLmuxrLMXa45/CE2bzhniZyOQv0LHm+MpOX8dCmbIH+ESCM69rZtHoboi7uuJEzJWiPG6B6v3HE7rfsGHDkJ+fj0WLFsHpdOLzzz/HunXrcPbs2YSuy5QVbnvLaJt0pILai5psOlUiW3DONnb1rwUekj0SFkPnP0z3yMiXfevFyNeL/LvCwZlFo7se9Kna+HYGivf8YGazGcuXL8dvfvMbPP300yguLsbs2bNhsVgSui5Tlq93eqSsDi0Ol39oed9WdcwFq3GZmI+vaEnemgoMfG0zLPVNaMnLwsFbi1E/dXDU50cq0HFh96mdXnNd3XIk7ucAgMVghcvjhBvt7+nr2R9rrkJp4/YOzxuZPRaljd8hVJYfRQnejAE6DNDx1lmWoy7zmDFjsG7dOv/33/ve93DLLbckfF2mrFBVyHwBWw0qtlercn10trErrKu2YejzX8HYIvWkM+uaMPT5rwAgapCOVD3LdzyRoe54Xdh9KoZkj8S+xtKwu0gBQFnjdxAQIBBGZI/1Z7OHCt4jssemrP1Mu3QXoOPdDCHUMGa8duzYgaFDh8Lj8eDFF19ETU0Nbr311oSvy9RHTb3o2sN2OBpbcO5FA5VuSjsTu01B42t/9wdnH2OLGwNf2xw1QEcb+h2SPTKlAXrTqRJ/IA7XtlDLy3zHgfDBm7FIdBegu/XKxonqM3Gdn6h//etf+Pvf/w6n04kpU6Zg1apVPMStU3lFNhzYWQO3Ux2rH06fcKhuq8oh2SNRVt8U8jFLmOM+I7PHJXx/I8xwQ76KZonWGQ8XvBmLRndJYoWDe8TcKzYYCYXn9Ez4nosWLcKpU6fQ2NiITz75BOecc07C12TqNWh0QYffMYOR0Ku/LVpeUFKoMWHMVFAQ8nhLXlbY54zMHhdzIAu3bthm7I6fD7gnaqDPNnbF1J7TY7qX3IlljMVKdwE6u5sV3XrnRA3SvnXQ2bbMFLWM6UW4bSwHjyvEkPGFskybxEMtc+KB8u+9B5TZ/t+W22LEwVs7LPWEAUZM7Tk9rl7mjIIbOgTpQks/3FB0OwCp1xqpzKhv/jiWZC3eg5kpRXdD3ESEIRP6YN/W8MVKfMF5yITEipSw9BVuG0vfsX3bqlNWolONdcVzZ8wAANQ9+xxcNTUwFRSg8N57YLlsML4+sdq/HtlisPqTsOIVrbjHDUW3o+T4qnaZ1EaYcEnPtiS0EdljQyZx+YzMHsfLoZhi1PcvWwYGA2HoeX3QaG9G9f7jOFXbsRa33MVJGPPxBekOtb6TgaTENTXKnTHDH6j9x5Da9b/R5n/DZVon8sGBMbnoMkADUk86p5sVw84vUropLA2loidtNBMGjS5QVYKYFnESF1Mr3QZoxpSWV2RLypKs783kXh1j6UB3SWKMqYka54cZY9rAAZqxJFLr/DBjTP04QDOWRHlFNnTtIW9Colb3hmaMxYcDNGNJ1nJWvqpWgFTis77SLus1GWPqk1CAJqJxRLSBiLYT0WYimug9TkT0JyLaT0Q7iGiCPM2NnRACNfv2YsUzv8fzP/0v/N+NM/D8T/8LK55diJr9eyGEfKm1L7zwAoqLi2GxWDrU4F69ejWGDx+OLl264LLLLsPhw4dluy/ThmQUElFj9TDGmLwS7UH/AcBjQohxAB7xfg8A3wcwxPv/HQBeSvA+cXG7XPj4T4uw7ImHsG/TN3C1tgBCwNXagn0bv8ayxx/Cx39aBLdLnjfOwsJCzJs3D//93//d7vjx48dx3XXX4YknnsDJkydRXFyMG26IXFyB6U8yEsXUWD2MMSavRAO0AOArVJsLwDc5NhPA60KyAYCNiEIX55WZEAKf/uUZ7N+8Ea6Wlg49ZSEEXC0t2L95Az79yzOy9KSvu+46zJo1Cz169Gh3/L333sOoUaNw/fXXIzMzE/Pnz8d3332HPXv2JHxPph39RuTLXrGOs8MZ079EA/Q9ABYRUSWAPwKY6z3eB0BlwHlHvcc6IKI7vMPjm+vr6xNsDnBsfzn2b9ko9ZojcLW2Yv+WjThWUZ7wPcPZvXs3xo5t2/c1KysLgwcPxu7du5N2T6Y+eUU2nDO+ACazUZbrGYzE2eGMpYGoAZqIviCiXSH+nwngfwDcK4QoAnAvgH/E2wAhxCtCiGIhRHFeXl78ryDI5o/eh7u1NaZz3a2t2PzR8oTvGU5jYyNyc3PbHcvNzcWZM7Fvh8n0Ia/Ihok/GIbvzRwpFRrpbIeagMFjuXoYY+kg6jiZEOLycI8R0esA7vZ++w6Av3v/XAUgsMZmX++xpDuw9T8xD1sLIXBg66aktSU7OxunT7ffS/b06dPIyclJ2j2ZNvTqZ0PtYXuH4117WHH6pCNkeVCDkTg4M5ZGEp3IqgZwCYC1AKYC2Oc9/iGAu4hoCYBJABqEEDUJ3ismLmdsvWf/+TH2tjtj1KhRWLx4sf/7pqYmVFRUYNSoUUm7J9OGweMKAQC1R+xSMCYpaPuOA0B9pR1HyurQ4nDBYjWh34h8Ds6MpZFEA/QvADxPRCYAzZAytgHgYwA/ALAfwFkAtyV4n5iZzBlR55/bnZ+RkfA9XS4XXC4X3G433G43mpubYTKZcO211+L+++/Hv//9b0yfPh2PP/44xowZg+HDhyd8T6Z9g8cVtgvIwcJtackYSw8JJYkJIb4SQpwnhBgrhJgkhNjiPS6EEHcKIQYLIUYLITbL09zoBk04P+aMWSLCoAkTE77nggULYLVasXDhQrzxxhuwWq1YsGAB8vLy8O9//xsPP/wwunXrho0bN2LJkiUJ348xxpj+6W6tRvE11+LAtv/A1RK9F23MyEDxNbMSvuf8+fMxf/78kI9dfvnlvKyKMcZY3HRX6rP3OUNxznmTog5dmzIycM55k9B78NAUtYwxxhiLne4CNBHh6jvvwznFk2GyWDoMdxMRTBYLzimejKvvvE/2AhKMMcaYHHQ3xA0ARpMJP/jf+3GsohybV7wvDXm3tsKUkYFBEybi/GuuRe9zuOfMGGNMvXQZoAGpp1xwzjDMuHeO0k1hjDHG4qaZIW45d59Sq3R4jYwxxmKjiQBtNpvhcDiUbkbSORwOmM1mpZvBGGNMBTQRoPPz81FVVYWzZ8/qspcphMDZs2dRVVWF/HzeBIExxphG5qC7dpV2tKyurobT6VS4NclhNpvRq1cv/2tljDGW3jQRoAEpSHPwYowxli40McTNGGOMpRsO0IwxxpgKcYBmjDHGVIgDNGOMMaZCpKZlS0RUD+Cw0u2QQU8Ax5VuhAL4dacXft3phV938vQXQuQFH1RVgNYLItoshChWuh2pxq87vfDrTi/8ulOPh7gZY4wxFeIAzRhjjKkQB+jkeEXpBiiEX3d64dedXvh1pxjPQTPGGGMqxD1oxhhjTIU4QMuIiJYS0Xbv/4eIaLv3+AAicgQ89leFmyorIppPRFUBr+8HAY/NJaL9RLSXiK5Ssp1yI6JFRLSHiHYQ0ftEZPMe1/XPGwCI6Grvz3Q/Ec1Ruj3JQkRFRPQlEZUS0W4iutt7POzvvF5438N2el/fZu+x7kS0ioj2eb92U7qdciKiYQE/0+1EdJqI7lHq581D3ElCRP8HoEEI8TgRDQDwkRDiXIWblRRENB9AoxDij0HHRwJ4G8BEAIUAvgAwVAjhTnkjk4CIrgSwRgjhIqKnAUAI8WAa/LyNAMoBXAHgKID/ALhJCFGqaMOSgIgKABQIIbYSUQ6ALQBmAZiNEL/zekJEhwAUCyGOBxz7A4CTQoiF3g9m3YQQDyrVxmTy/p5XAZgE4DYo8PPmHnQSEBFB+gf8ttJtUdhMAEuEEC1CiIMA9kMK1roghPhcCOHyfrsBQF8l25NCEwHsF0IcEEK0AlgC6WetO0KIGiHEVu+fzwAoA9BH2VYpaiaAxd4/L4b0YUWvpgGoEEIoVjyLA3RyTAFQK4TYF3BsIBFtI6J1RDRFqYYl0V3eod5/Bgx79QFQGXDOUej3ze2/AXwS8L2ef97p9HP1846MjAew0Xso1O+8nggAnxPRFiK6w3uslxCixvvnYwB6KdO0lLgR7TtZKf95c4COExF9QUS7Qvwf2IO4Ce1/sDUA+gkhxgO4D8BbRKSpza2jvO6XAAwGMA7Sa/0/Jdsqp1h+3kT0MAAXgDe9hzT/82btEVE2gH8DuEcIcRo6/p0PcJEQYgKA7wO4k4guDnxQSPOjupwjJaIMAD8E8I73kCI/b1MqbqInQojLIz1ORCYA1wE4L+A5LQBavH/eQkQVAIYC2JzEpsoq2uv2IaK/AfjI+20VgKKAh/t6j2lGDD/vWwFcA2Ca9w1LFz/vKDT/c40HEZkhBec3hRDvAYAQojbg8cDfed0QQlR5v9YR0fuQpjZqiahACFHjnZ+vU7SRyfN9AFt9P2elft7cg5bf5QD2CCGO+g4QUZ434QBENAjAEAAHFGqf7Lz/UH2uBbDL++cPAdxIRBYiGgjpdW9KdfuShYiuBvAAgB8KIc4GHNf1zxtSUtgQIhro7WncCOlnrTvefJJ/ACgTQjwTcDzc77wuEFGWNykORJQF4EpIr/FDALd4T7sFwAfKtDDp2o2CKvXz5h60/ILnLQDgYgCPE5ETgAfAr4QQJ1PesuT5AxGNgzTcdQjALwFACLGbiJYBKIU0BHynXjK4vV4AYAGwSnofxwYhxK+g85+3N2v9LgCfATAC+KcQYrfCzUqWCwH8FMBO8i6bBPAQgJtC/c7rSC8A73t/r00A3hJCfEpE/wGwjIhuh7Tz4GwF25gU3g8kV6D9zzTke1zS28LLrBhjjDH14SFuxhhjTIU4QDPGGGMqxAGaMcYYUyEO0IwxxpgKcYBmjDHGVIgDNGOMMaZCHKAZY4wxFeIAzRhjjKnQ/weoSznIbyRseQAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 576x576 with 1 Axes>"
       ]
@@ -2171,7 +2319,7 @@
        "TSNE(init='random', learning_rate='auto', random_state=42, verbose=1)"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2215,15 +2363,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 166,
+   "execution_count": 29,
    "id": "c5dc96ad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-08-16T13:51:43.003094Z",
-     "iopub.status.busy": "2022-08-16T13:51:43.002914Z",
-     "iopub.status.idle": "2022-08-16T13:55:03.583794Z",
-     "shell.execute_reply": "2022-08-16T13:55:03.582194Z",
-     "shell.execute_reply.started": "2022-08-16T13:51:43.003076Z"
+     "iopub.execute_input": "2022-08-16T14:56:43.898126Z",
+     "iopub.status.busy": "2022-08-16T14:56:43.897835Z",
+     "iopub.status.idle": "2022-08-16T15:11:23.952640Z",
+     "shell.execute_reply": "2022-08-16T15:11:23.951569Z",
+     "shell.execute_reply.started": "2022-08-16T14:56:43.898094Z"
     },
     "tags": []
    },
@@ -2258,10 +2406,180 @@
     {
      "data": {
       "text/html": [
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: left;\">\n",
+       "      <th>epoch</th>\n",
+       "      <th>train_loss</th>\n",
+       "      <th>valid_loss</th>\n",
+       "      <th>time</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>0</td>\n",
+       "      <td>0.017188</td>\n",
+       "      <td>0.028165</td>\n",
+       "      <td>00:34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1</td>\n",
+       "      <td>0.018652</td>\n",
+       "      <td>0.030425</td>\n",
+       "      <td>00:34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>2</td>\n",
+       "      <td>0.019052</td>\n",
+       "      <td>0.029247</td>\n",
+       "      <td>00:35</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>3</td>\n",
+       "      <td>0.019880</td>\n",
+       "      <td>0.029035</td>\n",
+       "      <td>00:34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>4</td>\n",
+       "      <td>0.016921</td>\n",
+       "      <td>0.029006</td>\n",
+       "      <td>00:34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>5</td>\n",
+       "      <td>0.020704</td>\n",
+       "      <td>0.027825</td>\n",
+       "      <td>00:33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>6</td>\n",
+       "      <td>0.010647</td>\n",
+       "      <td>0.028510</td>\n",
+       "      <td>00:34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>7</td>\n",
+       "      <td>0.019289</td>\n",
+       "      <td>0.029275</td>\n",
+       "      <td>00:33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>8</td>\n",
+       "      <td>0.019621</td>\n",
+       "      <td>0.028783</td>\n",
+       "      <td>00:34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>9</td>\n",
+       "      <td>0.018136</td>\n",
+       "      <td>0.030531</td>\n",
+       "      <td>00:34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>10</td>\n",
+       "      <td>0.013770</td>\n",
+       "      <td>0.029190</td>\n",
+       "      <td>00:33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>11</td>\n",
+       "      <td>0.014662</td>\n",
+       "      <td>0.028587</td>\n",
+       "      <td>00:33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>12</td>\n",
+       "      <td>0.020371</td>\n",
+       "      <td>0.029442</td>\n",
+       "      <td>00:34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>13</td>\n",
+       "      <td>0.015001</td>\n",
+       "      <td>0.028491</td>\n",
+       "      <td>00:34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>14</td>\n",
+       "      <td>0.016344</td>\n",
+       "      <td>0.029733</td>\n",
+       "      <td>00:33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>15</td>\n",
+       "      <td>0.016318</td>\n",
+       "      <td>0.030032</td>\n",
+       "      <td>00:34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>16</td>\n",
+       "      <td>0.023564</td>\n",
+       "      <td>0.029952</td>\n",
+       "      <td>00:33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>17</td>\n",
+       "      <td>0.016856</td>\n",
+       "      <td>0.028677</td>\n",
+       "      <td>00:33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>18</td>\n",
+       "      <td>0.016888</td>\n",
+       "      <td>0.028771</td>\n",
+       "      <td>00:34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>19</td>\n",
+       "      <td>0.014119</td>\n",
+       "      <td>0.028539</td>\n",
+       "      <td>00:34</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<style>\n",
+       "    /* Turns off some styling */\n",
+       "    progress {\n",
+       "        /* gets rid of default border in Firefox and Opera. */\n",
+       "        border: none;\n",
+       "        /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
+       "        background-size: auto;\n",
+       "    }\n",
+       "    progress:not([value]), progress:not([value])::-webkit-progress-bar {\n",
+       "        background: repeating-linear-gradient(45deg, #7e7e7e, #7e7e7e 10px, #5c5c5c 10px, #5c5c5c 20px);\n",
+       "    }\n",
+       "    .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
+       "        background: #F44336;\n",
+       "    }\n",
+       "</style>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
        "\n",
        "    <div>\n",
        "      <progress value='10000' class='' max='10000' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
-       "      100.00% [10000/10000 02:59&lt;00:00]\n",
+       "      100.00% [10000/10000 02:54&lt;00:00]\n",
        "    </div>\n",
        "    "
       ],
@@ -2277,8 +2595,8 @@
      "output_type": "stream",
      "text": [
       "[t-SNE] Computing 91 nearest neighbors...\n",
-      "[t-SNE] Indexed 10003 samples in 0.000s...\n",
-      "[t-SNE] Computed neighbors for 10003 samples in 1.830s...\n",
+      "[t-SNE] Indexed 10003 samples in 0.001s...\n",
+      "[t-SNE] Computed neighbors for 10003 samples in 1.717s...\n",
       "[t-SNE] Computed conditional probabilities for sample 1000 / 10003\n",
       "[t-SNE] Computed conditional probabilities for sample 2000 / 10003\n",
       "[t-SNE] Computed conditional probabilities for sample 3000 / 10003\n",
@@ -2290,14 +2608,14 @@
       "[t-SNE] Computed conditional probabilities for sample 9000 / 10003\n",
       "[t-SNE] Computed conditional probabilities for sample 10000 / 10003\n",
       "[t-SNE] Computed conditional probabilities for sample 10003 / 10003\n",
-      "[t-SNE] Mean sigma: 0.021153\n",
-      "[t-SNE] KL divergence after 250 iterations with early exaggeration: 69.586418\n",
-      "[t-SNE] KL divergence after 1000 iterations: 1.319757\n"
+      "[t-SNE] Mean sigma: 0.020139\n",
+      "[t-SNE] KL divergence after 250 iterations with early exaggeration: 68.921059\n",
+      "[t-SNE] KL divergence after 1000 iterations: 1.298541\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAegAAAHSCAYAAAAnsVjHAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAB330lEQVR4nO3deXxU1fk/8M+ZJcmQQAYkIQthC1sA2UwBi4DiLiLoV0FrW7QutS5F7Q/FHRUrVqvSzdZqK7Yq4gZitIogiAtoIKwJW8KaBBKWSUiYSWY5vz/u3MnMZPa5M3eZ5/168SJz5+beM0zIM+ec5zyHcc5BCCGEEGXRyd0AQgghhHRGAZoQQghRIArQhBBCiAJRgCaEEEIUiAI0IYQQokAUoAkhhBAFMsjdAG89e/bk/fr1k7sZhBBCSNJs2rTpOOc8x/+4ogJ0v379UF5eLnczCCGEkKRhjB0MdJyGuAkhhBAFogBNCCGEKBAFaEIIIUSBKEATQgghCkQBmhBCCFEgCtCEEEKIAlGAJoQQQhSIAjQhhBCiQBSgCSGEEAWiAE0IIYQoEAVoQgghRIEoQBNCCCEKRAGaEEIIUSAK0IQQQogCUYAmhBBCFEhR+0ETQpKnaeVKNLz0Mhz19dBnZ8PZ2grY7Z7nWZcuyH9yAbKnT5exlYSkLkl60Iyx+xhjOxljOxhj7zDGMhhj/RljGxlj+xhj7zLG0qS4FyEkfk0rV6L+scfhqKsDOIfTYvEJzgDAz5xB3fyH0LRypTyNJCTFxR2gGWOFAH4LoJRzPgKAHsD1AJ4D8BLnfCCAUwBuifdehJD4Na1cibr5D4HbbOFPdjrR8NLLCW8TIaQzqYa4DQBMjDE7gC4A6gFMBfAz9/NLACwA8IpE9yOEBNC0ciXqn/k9uMUCANCbzej1yMMAIAxn19VFfU1Hfb2UTSSERCjuAM05r2WMvQDgEAArgC8AbAJg4Zw73KcdAVAY770IIcE1rVyJuoceBhwOzzGnxYK6B+eD6fXgfkPYkTLk50vVREJIFKQY4u4OYAaA/gAKAGQCuCyK77+dMVbOGCtvbGyMtzmEpKyGl172Cc4eLlfMwRkAsqZMjr1RfuqffBJVw0egamgJqoaPQP2TT0p2bUK0RooksYsA7OecN3LO7QA+BDARgJkxJvbQewOoDfTNnPNXOeelnPPSnJwcCZpDSGpK1FB0y7qvgz7XtHIl9k69EFUlw7B36oUhE8rqn3wSlneWAk6ncMDphOWdpdh35ZVSN5kQTZAiQB8CMIEx1oUxxgBcCKASwFcArnWfMwfACgnuRQgJgmVnJ+S6gQJ/08qV2DPhXNTNe8CTCe6oq0PdAw/iwM03BwzalqXvBry+fV819aQJCYBxzuO/CGNPApgNwAGgAsCtEOaclwLo4T72c855W6jrlJaW8vLy8rjbQ0gqqX/ySSH4SfB/ORDWpQu41Rrz9ZnRiPzfP4O6eQ8EP0mvR8nOHTG2kBB1Y4xt4pyXdjouRYCWCgVoQsKrf/JJWJa9JwwVM5awwCwlvdksrLUOoeD5P3gKpxjy85F7371UJIWkBArQhGiAZx5XaxgDMxg6J7O5P4AYCgooYBPNChagqRY3IQoSLunKsuw9mVqWYJwHzjR3dyAcdXWom/cADtx8c5IbRoh8KEATohAHbr65U9JV/WOP+wZpMQNaZZjZLMl1rN9voIQykjIoQBOiAAduvhnW7zd0Os5tNsWX2mRdugC6EL9KDAbku6uZScHyzlIK0iQlUIAmRGZNK1cGDM4ixZbaZAyAkABW8NwimM6d0OkUQ0EBzNddi/pnfi/prSlIk1RAAZoQGTWtXIm6Bx4MeY4hP98zN60Yen2n+WFr+SaAMRgKClDw/B9QsqsKWVMmw/LOUk9tcClZ3lkaUYEUQtSKsrgJkUnTypWof/iR8GU4TSbAak1OoyTCMjKQffXMpGWcs4wM5D/9FGV5E1WiLG5CFKbhpZcjq5GtsuAMCHPnyVwOxm021M17AFVnj6TeNNEMCtCEyESxc8tqZrejbt4DFKSJJlCAJiSBQu3eRNs4Jo7SM98JiQQFaEISJNjuTWKQzr3vXjCjUcYWapejro62tCSqRwGakAQJVvVLPJ49fTryf/8M9BIV8SAB+H0oIkRNKEATEoWmlSuxa8K5Qu9saAn2TDjXZ77Tu1Rn0KpfXsezp0/H4A3fw3zD9QFPNQ4shqGgQNLXkIqCbXVJiJIZ5G4AIWrRtHIl6h56GHA4PMecFgvq5j2AunkPCNsynjkT0bWqhpYAEKpw5T+5QDjotzOV+Ybrkf/EEx33DrVdYzh6PVhamrBtZCpS0HJSQiJFPWhCItC0ciXq5j/kE5z9RRqc/b+nbt4Dwlx1ooKIToeCRc+C22yJuT4hJCEoQBMSRtPKlah/7PGkb1QhzlV77h8rlwv1TyyAPjtbopapkMkkdwsIiRoNcRPi1rRyJeoef6KjMAhjMF8/Gy3rvpan9+l0omnlSqGgSZz352fOwBlJURQtYgwFT1GSGFEfCtCEwKsmtvcwM+dJrYYVSKc2xSMVA7T7QxaVACVqREPchMBd2EKJiURKbJOacA7Le+9TZTGiStSDJgRUdlPTHA7UzXsApz78EPaDh+Cor4chPx9ZUybj+MpPoW9pBgCcTuuCltvm4sJ7filzgwkRUA+aEFDZzVRg/X4DHHV1AOdw1NXh1DtLYWhpBgPAAHRrP4Oef3sOq//8ptxNJQQABWhCAAhlN0lqYQGOpXEX0t74e9LbQkggFKAJASiJiHj0aD0ldxMIAUABmhCSDCxQf1WZTmZ2l7sJhACgAE0ISQaVZKNzAO033SF3MwgBQAGaEEJ8UBY3UQoK0IS4sS5d5G4CkZmOtv4kCkIBmhC3/CcXAHq93M0gMsq+/DK5m0CIBwVoQtyyp09HwaJnwQL1ovT6wMeJprSs+1ruJhDiQQGaEC/Z06dj6IbvUfD8H2AoKAAYg6GgAAWLnsXQDd8Lx9TAaJS7BapEFeWIklCpT0ICyJ4+PeDa6Nz77kX9Y48rf2/lVNwYQwJUUY4oCQVoQqIgBu2Gl14WelsZGR3bUxJ1MxioohxRFBriJiRK2dOnY9Ca1SipqkRJxWaYb7he7iaRaPkVTmFmMwqe/T1VlCOKQj1oQuKU/8QTsu8bTSLHdQzDKivlboZsymrKsHjzYhxtPYq8zDzMHTsX0wZMk7tZJADqQRMiBVqepR4udVQ1S4SymjIs+G4B6lvrwcFR31qP+evn4+wlZ2Pcf8ehrKZM7iYSLxSgCZGAedZ1CbmuPsWWdjGTKeH3aM/tmvB7KNXizYthcwZOcLQ6rXho/UMUpBWEAjQhEsh/4glhLjrYphA6XdS9bJaRAZcEbVMNgwFITw/+fAwbbvj3lZ3pBmTc86uor6MV9a2hl5FxcCz6YVGSWkPCoQBNiETyn3gCJVWVKHj+Dz5FTfRmMwqeW4SCRc961lZHEqy5zQZusSSuwQoiJmnxpqbgJ0W74QZj0D09F225XcEZ0JbbFYZH78LQ61JzM4xIe8aWNgsWbliY4NaQSDCuoF1mSktLeXl5udzNICThqkqGqWaHJ0no9TDPug4t676Go74ehvx85N53b6es6b1TL4Sjrk6SWxoKCjBozWpJrqUFl7x/SdgetLfZQ2bj0QmPJrBFRMQY28Q5L/U/LkkPmjFmZoy9zxjbxRirYoydyxjrwRhbxRjb6/6bNlklxC0RBTGUWuWMdemCgkXPIv+JJzzL0watWR20EAwLVAXNEOWCE8ZoTbOfaIIzALy3570EtYRESqoh7sUA/sc5HwpgFIAqAPMBrOacDwKw2v2YEAIhEEUddEJgGRmJD0jeQ/N6ffiELr0eJbuqMHTzpojXF2dPn4783z/jkxwnDn9HzGRCwR+eozXNEIa1L3n/Epy95Oyov9fFXZ2GxcXrjVwyEpe8fwkllCVY3EPcjLFsAFsADOBeF2OM7QZwPue8njGWD2At53xIqGvREDdJJU0rV6Ju3gNRf5+hoAC5993rqWbmPVx84OabYf1+Q3QXNBph7NsH9n3VIU8z33A98p94wqf9ocqe+p8fr6qhJUGf05vN6PXIwxSUvZTVlOGxbx+D3RV72VcddMgwZOCM40zA5w3MgIXnLaR11HEKNsQtRYAeDeBVAJUQes+bAMwFUMs5N7vPYQBOiY+DoQBNUs2useeAnwn8yy8ggyFsxatogrTp3Ano9+9/h/4+9/xxoGDbtHKl8EHBe944xPnx2DPhXDgDJM2xLl0wdPMmSe+lBZOWToKlzZLw+2SnZeObG75J+H20LJEBuhTABgATOecbGWOLATQDuMc7IDPGTnHOO81DM8ZuB3A7APTp0+ecgwcPxtUeQtQkml40M5uRH2Uvsf7JJ2FZ9h7gdCYscCZL08qVqH/4EXCvjUCY0Yj83z9DPecAYhnWjtX2OduTdi8tSmSAzgOwgXPez/14EoT55oGgIW5Cwqp/8sngpUIZg/n62aoNqlLz9NhDZIITQTIDdBdDFzx+7uM01B2jYAE67iwVzvlRxthhxtgQzvluABdCGO6uBDAHwCL33yvivRchWpT/xBPoMnYs6p/5vWfdM82pBhZsG1DSWXZaNpraQ6wrl9AZxxk8tP4hAKAgLSFJ1kG756FfA5AGoAbAzRAyxJcB6APgIIBZnPOToa5DPWhCCJFGWU0Z5q9P7uIZmo+OTcJ60ADAOd8CoNPFIfSmCSGEpIBk9dhTBZX6JIQQjRF3rSLqRgGaEEI0JtSuVUQ9pCtlRAghJCkWbliI9/a8Bxd3Qcd0uG7wdT51s4+2HpWlXeZ0syz31SoK0IQQoiK3fX4bNhztKCjj4i68u/tdrKxeCavDCpPBBN5po83kmD+OKjpLiQI0IYSoRFlNmU9w9iaW4wxWlpOoD81BE0KISizevFjuJoQ0f/18TFo6iTbRkAgFaEIIUQm55pajYWmz4LFvH6MgLQEK0IQQohJ5mXlyNyEidpdd8b19NaAATQghKjG592S5mxAxNfT2lY6SxDRm3du7sPObOnAXwHTA8PMKMOVnQ33OWfHSZhzZbfE87j3EjBn3jU1ySwkh0SirKcOKferZ0oAxhrKaMqrNHQcK0Bqy7u1d2PF1x7683AXPYzFI+wdnADiy24IVL20OG6T3bDyK71dUo+VkG7J6pOPcGcUYPF4dQ26EqJ3aio+4uMtTzYyCdGwoQGuId3D2Py4GaP/gLDqy24IlD38bNPj6B/+Wk21Y9e9K1FdbfHroFMQJkU5ZTRkWb16Mo61HZVvbHA+b04bFmxdTgI4RBWiV8w6Iofz1jjVgYTIOxGv4B989G4+GDP4APOetfrMKLif3XGf1m1UAQEGakCiJ9bTV1GsOhOaiY0cBWsX2bDyKL9+sBHdGdj53RXf9HV/XIb/YjO9XVIc9DwB2rK+D/4d8l5Nj7du7MXh8XkTz44QQgdqGtINRS+a5ElGAVrGvl+2OODjHKpLeORB8eB0A7G1OvHLXV56eNRB4fpwQ0kErPc+5Y+fK3QTVomVWKtbWmuDoDHjmkuPlHZy97VgfPLATksq00POcPWQ2zT/HgQI0CSuSHnTMuJCARgjxNXfsXGToM+RuRkzyM/OxaNIinx22SPRoiFvFMjINsLU65G5G3MS5bkokI6SD2PN8duOzaGpvkrk10fni2i/kboImUA9axXr2zpK7CZIJl4hGSCqaNmAavrnhG2SnZcvdlKgs3LBQ7iZoAvWgVSbSZVVq03KyDX+9Yw3SM/WYPGsI9aYJcSurKQNjTO5mROW9Pe/R8LYEqAetIns2HsVXb+3SXHD21tbqxKp/V+Kvd6yhuWmS8spqyvDoN4/C0maRuylRcUW7ppMERAFaRb5fUQ1He+r84O/4uo6CNElpz258Fg6uvjwTXbiqSCQi9K+oEns2HtV0zzmYnd/QMiySutSWHCa6bvB1cjdBE2gOWuH2bDyKNf+pgtOhvjq8UqCRMpKqymrK5G5CTIq7FdP8s0SoB61gezYexZdLUjc4i95e8L3cTSAkqcQ63Gq0//R+uZugGRSgFez7FdXgrtQOzgBw6qiV5qJJyli4YSHmr5+v2jrclCAmHQrQCpaKc87BhKr1TYhaLNywEKPeHIWzl5yNUW+O6rReeOGGhXh397sytU4alCAmHZqDVrCsHukUpAlRuLKaMiz6YVGnpVD5mfmYO3aupyKYf/B1cZfnsThn+96e95LT6ASiBDHpMM6VM4RaWlrKy8vL5W6GYohz0DTMLbjr71N9CrVkZBrAwdHW6kRWj3ScO6OYCpyQpCqrKcNj3z4Gu8se8rzstOygGdk6psPWX24FAJy95GzJ25gsOqbDdYOvowSxGDDGNnHOS/2PUw9awcRgs/bt3bC3JX7nKqXz37LSuw55y8k2fPWWME9NQZoky+LNi8MGZyD0cinvOVsd06luDteoM+LpiU/TrlUJQJMFCjd4fB5uXzwFd/19Ki6+eRiYXu4WJQ7TAYa04CUNg21ZKXK0u6imN0kqKfZs9p6zVdvwsDndTME5gagHrTIGgx52pzZ709wFDJ2QH1dCGM3Zk2TKy8xDfWt9XNfwDsrec9Eu7lJkj3rRpEUUkJOE5qBVQqzDrfVSn4Y0HQAOR3vsP5dZPdLRb8RZ2LvpGNpahQ8zGZkGTJo1mIa/iaQinYMWMTAwxjzBN9ScbVlNGRZvXhz3BwCpbZ+zXe4maA7NQatcqtThluI1tpxs69QLt7U6sOqNSgA0R02kI/YkA2VxB8LBse2X28KeJxYqUeJa6Evev8QnO50kDs1BqwQN3UqAA18v2y13K4jGTBswDeuvX4/tc7Zj0aRFMOlNQc/Nz8wPe72ymjI8/M3DigzOAFDfWo8F3y1QbSlSNaEetErQmmhpiEPehCTCtAHTMG3AtIA94Ax9BuaOnYvbPr8NG45u8Bw3MiMc3IG8zDxM7j0ZK/atUNy8sz+b04bFmxdTLzrBqAetEufOKHbPzxJClG7agGlY8NMFyM/MBwNDfmY+Fvx0Af659Z8+wRkA7NwODo761nq8u/tdxfac/UmRwU5Cox60SojzpmKRDhIbY3p069TWvb0LO7+pA3cJy8CGn1eAKT8bGvQ4ISKxNy0qqylDdbN2lgHmZeZ5EtmOth5FXmYezU1LjAK0igwen4fB4/Pw1zvWyN0U1dJF8RO/7u1dPslm3CXUBN+5vg7eix/E4wAoSJOgFm9eLHcTJNW3a1/MXz/f81icmwZAQVoiFKBVZs9GGlaKR1urE3+9Y42nNCgQ/ahEsJWJO76ug+XYGcy4b6wUTSUao6Uh4eJuxZ2G6gGam5aaZJOajDE9Y6yCMfaJ+3F/xthGxtg+xti7jLE0qe6VqvZsPIov36yUuxma0HKyDaveqMSXb1ZKOmVwZLcFK17aLNn1iHbkZWpjed+EvAkhh+rrW+s77dJFYiNl1tFcAFVej58D8BLnfCCAUwBukfBeKenrZbvBKQlZOhwJ+fc8stsi/UUV4sS3/4X1uRLwBWZYnyvBiW//G/9Fty0DXhoBLDADz/UX/iwwC8e2LYv/+goxd+xcZOgz5G5G3AL1nP29u/tdCtISkKSSGGOsN4AlAJ4BcD+A6QAaAeRxzh2MsXMBLOCcXxrqOlRJLDSae1YfLVUwO/Htf5G9+ncwuDqyjDkAru8C3YzFwMhZ0V902zJg5W8Bu7Xzcxmjga6XAgYzkNUVGDceGDQ41uYrQllNGR795lE4uCP8ySrnvUsXCS3RlcReBvAAgK7ux2cBsHDu+Sk8AqBQonulpHVv75K7CSQGtlYHVv27EvXVFvUlkG1bBqy8F7C3AgB6APDfyoQBYM4zwIe3AYc2AFe+GN09Vj8VPDhnXwPo3DNjLS3A1+uEr1UcpCsaKlIiOAPCLl0jl4yk7O44xD3EzRi7EkAD53xTjN9/O2OsnDFW3tjYGG9zNGvnN7FvIEHkt+PrOnUl+G1bBnx4uyc4A52DcyflrwOf3B/dfZqOBD7e9dKO4CxyOIAfNkZ3fYV5b897cjchqcT13VR5LDZSzEFPBHAVY+wAgKUApgJYDMDMGBN76L0B1Ab6Zs75q5zzUs55aU5OjgTN0SaFFxYiEVDVVpifPQhhADtK5a/7zhtvW+aeU84W/jzX3/f57N6Br6M3Bz7e0hJ9mxSirKZM8RXCEkXM7ibRiTtAc84f4pz35pz3A3A9gDWc8xsBfAXgWvdpcwCsiPdeqYxRETHVU1WBGevJ2L/3sweFv7ctA5bf6Xst60lgxV0dQfrCxxGwb+60BL52Vlbs7ZLRbZ/f5rNmOBVpaZlZsiTy1/6DAO5njO2DMCf9egLvpXnDzyuQuwkkTlk90uVuQnJYTwoBePVTQKBtGJ3twnPiOYF66qc/B1ztvsdc7UKimMos3LAwosxnrdPKMrNkkrRQCed8LYC17q9rAIyT8vqpTEww2rG+LqaRRyI/sTCKKph6xNeLXnGXEIiDaTosJJYFY9si/N31UmG422kRgvagubG3SSapNu8czOTek+VugupQJTEVmfKzoZjys6G03EqlVLXU6vLnhOHpQD3gSIQKzpGybekI1CqWqvPO/r4+8rXcTVAdmtnUKNr5SllUl0MwchYw829yt0ITdKp78xOjvrVe7iaoDv3kaFBWj3RccONQ9QUFiRjSwi4ISjpV5hCMnAXoFVahN9plXApw3eDr5G4CUSka4lahjEwDbK1Bih0wYa5THE5d9e/Uqt0tboLx5ZuViiiLqoqtKMVkrabDANML9U+zi4AeA6QZqpbSpn9HXwxFJgs3LMSy3cvAKWmExIgCtApNmjUYq9+sgsvp+x+f6YGLfjnME5wHj8/D2rd3w96mgEiVJC0n2xTxoWTEZIUHZdG2Zb4JXeKnmqbDwh+l4S6hzbGUFU2ihRsW4t3d78rdDEVh4UvdED8UoFVIDMDiNolirzFQEtL5PxsSMJiTxDGkMXUEZ0BYs6y0XnI4H94eW1nRJKLM7c60sFFIslGAVqnB4/Miygr2D+ZaxHTKqbRmSNPhghtVEpyB+JZSyYYD5f8C+kxQbE+aMrc7szlt4U8iPihApwDvYL7ipc2a2g7RkKaDo13aX4b6NAZne/QjDumZekyeNURdy6lUiwvz5goN0KQzKlQSvRTN801dM+4bi95DzD7Heg8xdzqmZMZ0PYCObPX0TL2k17/jTxfg4puHISOz4/OrPkxmeEamAbf+cYr6grOaU/2DbbRBFCdDn4G5Y9VXZEZu1INOQTPuG4s9G49i/bI9sLU6cGS3BemZelx88zBVDIWLSW+JTAgLNIWw7u1d2PF1gF3FmJC4p0pqHooNttGGAuRn5gdd92tkRth5jAVgVIiBYcFPF9B2kzFQ8cdnEqs9G49i1b8rfZZqtbU68eWbleg34iwwaTukqhKqQznlZ0MxYnKBz94OhjSGi28apr6esyi7SO4WxO7Cx+VuQVBzx84NmhSVSsEZELacpOAcG+pBp6DVb1YFPM6dwIEdJzB8YkHgnmIKCNehFMutqp732mcwqLLAu4Lnn8WAtHjzYqqgRWJGPegUFGrJVcvJNhzYcSKJrVEWcX5b07YtA5bf4bXO2evnQc1z0gozbcA0fHHtF3I3g6gY/W8kPrJ6pCt+DjqR7G1OrHhps9zNSIxty4CXRgi7SLkCFK/RpwEGlWyJaeohdwtIhGYPmS13E1SLAjTxce6M4tTZtziII7st2LNRxZvLi4F4gVn4e9sy4c/K34auDuZsB+zWpDUzZjqjsNuWSpjTzXI3ISmy07Jh0ps8jxkYZg+ZjUcnPCpjq9SN5qBTUO8h5oBrobvnmTzJTl+9tUvy9cVq8v2KanUmfvmX7mw6LDxOy1JH8A0nu0hIDlPw/LO/+ePm47FvH4M91q07VaK5vRnb5myTuxmaQj3oFBRsLfTPFpwLQFhilMq7YQFQ7zB/oNKdznaVVgzzk10E3LdDVcFZZGDa7wtRIRLpaf+nhgQ0476xIZ+PpCet0zNwcEXsGiU11Q7zayEQB6IzKnpZVTCpsmmGgRmoEEkCpHAfiYQj9qTFYJWeqfdU18rqkY4Lf1mCzGyVBrIQDGk6nDujWO5mEG/pXVXXcy6rKUuJ4Jydlo2F5y2ktc4JQD1oElK4TTliquTFgBGTCnBgxwnZh5LFrHVxw41QO4Mp3pKr5G5B4lhPAk92D7xQPS0TuPJlxQXwZzc+K3cTOpGqiplRZ8TTE5+moJxgFKBJXKJdluW9ocQUAEse/la2IJ3VIx1zfj9RlntLbslVwP51crcisYJVkWlvFbagBBQTpMtqytDU3iR3M3wwMEmCszndjPnj5lNwTgIK0CQu584ojjjje8Tkgk5VuOQKzpoZxvbP2k5ZXEiQU0iAXrx5sdxN6ITHUC1Ox3RwcRfyM/Mxd+xcCspJRgGaxCXS/aa755kClsgM1wOPdevHUDIyDZg0a7A6h7G9bVvm7jmqsExnIigoQe5oq/rW0TMISZ86psN1g6+j9csKQAGaxM17nnrPxqP48s1Kn8zu3kPMQbPGz51RHHQeW5wPjnqeO0hpaWO6Huf/TEP7NX/2IDQTnHVpgEs7owB5mXmqqsFd3K0Yy69eLncziB8K0ERS4ZLKAp1fX23ptDmHOAQ9eHxeRAFaE0le0VJQjzFueiMADsRTzENB5T8n954sawZ3dlo2GGOwtFkiOp+CszJRgCaym/Kzobjxdxej9ugR3yf+3PncHlm98NSNb3seG9J0uODGoakRkKOmol2q7K1AVj7QEmOvU5+mqPKfXx/5WrZ7Z6dl45sbvsHIJSMjOj8/Mz/BLSKxonXQRBFqjx4B5zzon7VvVeGvv1mNky3HPN+T1SM9tYNz2B6jSoKzKNbgzHTAjL8qJkEMkHcOWswej7SyFxUYUS7GuXL+E5eWlvLy8nK5m0FkwBiD98+i2WwGAFgslpDnpbRty4SdqVLdNf9UVHAGgEvev0TWOejtc7ajrKYMD69/GC4EX2FBm1koA2NsE+e81P849aAJUSuFBSXZKPDfYe7YuTDqjLLdv6ymDNMGTMPvJ/0eabq0Ts/nZ+Zj0aRFFJwVjuagiaKIPeempiafx/49aUIAKCoxzJu4XnjRD4siTtSS0uLNizFtwDTPH6JO1IMmRM2yi+RugbwUlBjmb9qAaVh//XrMHjI76feub61HWU1Z0u9LpEUBmiiKxWKBxWJBdnY2srOzPY9JEBc+DhhNcrdCHqW3KHJ429+jEx6VJUgv+G4BBWmVowBNiJqNnAWM+hnA9HK3RHqltwgJYJ0+gDDhuStflKVZEdm2DHhpBLDADLw0Ao92GYztc7Zj0aRFSWuCzWlTZMlREjmagyaKRL3mCG1bBmx9G5rblNs/AK9+Cmg6AmT3FkYNlNxz3rYMWPlbwG4VHjcdFh4DmDZyFpbvXY4NRzckpSlqLDlKOlCAJkTNVj/VEQi0wtTDNziPnKXsgOwv0HtitwrHR87CzEEzsenYJkl2lgon0rXQRJkoQBNF6Nu3LxhjEZ1HvDQdCX+O2ig48SsiQd6TMsdJPPXWeJxxnElaU6gIibpRgCaKcODAAbmboE6m7hqryZ2urt5yINm9hWFtL2WZXfBYTg/YkxicZw+ZTUusVI6SxAhRq23LAJtF7lZIiAEz/iJ3I+IXILN+cY/usEcwQhSt7LRszB4yG9lp2Z5j5nQzFSHRCOpBE6JWq58StvDSDI2UcBVHALwS244aAgfnnxgn4uqMG9BDdxZOuk7gI9s7+NH+bUS3MelN+OaGbwCAgrFGxd2DZowVMca+YoxVMsZ2Msbmuo/3YIytYoztdf/dPf7mEkI8tDj//OFtwCf3y92K+I2cBdy3A1hgAe7bgbwAO0b9xDgRv+hyO87S54AxHc7S5+AXXW7HT4wTw17eqDPiiZ8+kYCGEyWRYojbAeB3nPNhACYAuIsxNgzAfACrOeeDAKx2PyaESCW7t9wtSIzy14Xhew0JVJv76owbkM4yfI6lswxcnXFDyGvlZ+bj6YlP0/xyCoh7iJtzXg+g3v31acZYFYBCADMAnO8+bQmAtQAejPd+hBC3Cx8Hlt8BuDS2BhoAPntQ/cliXsRg+tD6h8DdQ/k9dGcFPDfQ8fzMfMwdO5eCcoqRNEmMMdYPwBgAGwH0cgdvADgKoJeU9yIk5Y2cBYy9Se5WJIaWMtPdpg2YhmcnPet5fNJ1IuB5/sdnD5mNL679goJzCpIsQDPGsgB8AOBeznmz93Nc2MA3YAYIY+x2xlg5Y6y8sbFRquYQon1iFTGiGtMGTPPU5f7I9g7auM3n+TZuw0e2dwAADIz2a05xkmRxM8aMEILzW5zzD92HjzHG8jnn9YyxfAANgb6Xc/4qgFcBoLS0VCNpnIQkgRariIkUuo2kFB6d8CjG5I7BQ+sfAs6gUxb3Xt1ObJ+zXe5mEgWIO0AzofzT6wCqOOfe1es/BjAHwCL33yvivRchxIsWs7hFaq8mFoY4XP3Yt4/hx9Mdy6qMOiOenvC0XM0iCiPFEPdEAL8AMJUxtsX95woIgflixtheABe5HxNCpKLELO7sImEHqnioZBvJeE0bMA1PT3wa+Zn5YGCUnU06YcL0sDKUlpby8vJyuZtBiLJtWyZkOQdMpNIBkKt4CQOueVUIrgvMiKnwSP8pwJyPpW4YIYrGGNvEOS/1P06lPglRk23LgA9/HSQ46yFfcAZ8AnLpr6L/9p5DKTgT4oUCNCFq8tmDCB6EFbAeevVTwt9XvigMVSOK+tN3b0xIkwhRKwrQhCjdtmXAc/2BBdnKXx/snbh25YtCqctI5qT7T0lYkwhRKwrQhCjZtmXAiruUH5hFgRLXRs4SkseCoXlnQgKiAE2Ikq1+CnC2y92KyF34ePDjflswwmgSetcUnAkJiAI0IUr1yf1A02G5WxE5U4/gy6NGzgKm/8ndk2bC39P/lBLLqQiJFe0HTYgSfXK/sKuTWhhN4YuLjJxFAZmQKFAPmhAl2vSG3C2IDvWGCZEcBWhClIgrYMlUpJiegjMhCUBD3IQoxbZlQlKYXDW2dWmAK4aEtHNukrwphBAK0IQog7icSs6M7ViCc/8pwnpnQojkKECT2O3dA3z7LdDm3tM2PR2YeB4waLC87VKjzx5U13KqtEzgypdpaJuQBKIATWKzdw+wZrXvsbY24Ks1wtcUpKOjhkIkTAdwl7BE6sLHKTgTkmAUoEl4e/cAP2wEWlqArCxg3PjOwVnEudCrpgCtLUzfkbjWdBhY+VvhawrShCQMBehE0cLw7/p1QGWl77GWluDBWdRmE16/ml4rCc0/q9xuFYblKUATkjAUoKXi3ctMTwfa24XepKitzTew+fdIYwlmgXq28QbF9euAqirftsfih40UoCO1bVnH8LGaWE8KbacgTUhCUICWwt49wtyrGNTa2oKfu24twBjgcAiPW1qAr9cJX++qAurqOs4tKACmzwh+T++A792zjTUwBuoxx6qlRZrraNm2ZUIvVA3zz8GsfooCNInZlpom7G+w+Rxj6NhZnAHol5uB0QOyk900RaAAHY9YApozQAEKh8M3wIvq6oCVKwIH6XXrAl//qzWhA3SgXjfgOxwvhaws6a6lRduWCfO4dqvcLYmPXGu2ieoFCs5AR3AWvxbPScUgTQE6VlL2NoHgQ8p1dYGDqtMR/Dr/eEXopXPuO/Tt39MXe93iuVLq00fa62nN6qeiC846I9CjGDi+K3FtikWg7SUJicCBAME5mP0NNpzVNQ1FOaag5xxutGLn4RZY210wpekwvCgr5PlqQAE6VlVVybuX/1C2uJQpFO8gLA6hf/tN4EAsdXAGgD17gLx8mocOJpqepzETmP6yMJSstE00gm0vSYgf7wCqY7495UiUVzejvLoZPbsaMGn4WZ2uXbG/GU53Goe13YXy6macON2u6p4344n45Ryj0tJSXl5eLnczIvOPV+RuQXSyspI/LxyoF08EL42IbitJMYnMe7mTEixokrsFRAX8A2i8/IP0/zY3wtoe/OKmNB3yzGk4amlXZA+bMbaJc17qf5x60LFKxLBwIsmRtBWoF09BWjDokuh6wmKGt5KCc+ktcreAyMh/SDlUANx5uEWy4AwAx0/7TvGFCs7i897z3WIPu7y6GYByk9EoQPuLdOlSSYm0c9Ba53DQ0ivRtmVAxX/kbkUcGFD6K6rBnaION1qx9UAz7F6fFQMFwM01QvAryjGFDaDxMqXp4rqHmIx2oMHmGXo36oFR/brJ2sumAO1t7x6hp+e9BGrNauFPVpaQ+HToUEfwLijwXRZFQqOlV4LVT6mr7rbIaNLWvs/1FcCeTwD7Gd/jGWag+BIgf0zwcwwmYMh04RwN21LT5BO0vJdAhePiwCavXmoi5ZnTAmaER8v7tdmd8Oll95ehh00B2tsPGzuCs7+WFt8ec0sL0NqanHZpBS29EqhlaRLTCYHIfkbI1tZS/e36CqDyg8BTBjYLUPURYDkI1JUHPsdhBXa+L3yt0SAdaBlUtJN6iZoE7Nm1I3QdbrTi0HEJl4gGIcdyLwrQ3qLt4alpDloJxDXXqS67d3QJYnI5azBw90a5W5EY1V+Ens932YHaHxA6xLiE62g0QEezDCqZstKZT4KY1PPboexvsFGAlsXePepL/FKTggKafwaAJVepIzgDyltzLSWbJYKTIvhdENF11EnO34RGvTBE7h94Aw0zJ3p+W04UoIGOuWcKzon11n+krRuuNkuuAvYHqQBHkosZAW6P/zoZ5vivQTqxO4UgrTcwtDt4yGVR8SaIKRkFaCD03DORhncynXexlVQK0hSck6e+QphHdnkFYWYEhl0tzC1LEZwBIZlMg9bvPCF3E2B3AgwcpcWhM6mHF2UlJRFNDqkboKXatYnEhnMhO/6HjanZm1aDnkPlbkFs6iuAne+h0yAttwM7l0l7Lw3NP3uva1YKDmDrgeaQAfrE6eSuiPh44zGMGZCc5VfaDtDBNoZYty54LWuSXFTERJl6DlVvglj1F0jaDGrVcqBkZnLulUBSV/qSkj1ILl+g9djJ4ORAxf6ONd6JpEvo1eUkbscoZmZ7r2mm4KwsYhETres/Re4WhGc0Adf8U73BGUhu4lbtD8m7VwIlMxNaCuIHimQHZ5HTJfybJZp2A7T3BhNE+VpagDf+JXyw0qo5Hys7SGcXaaMQSVITt7QxRaakYW1/aQbW6ZgSPlAk499MmwF65Qq5W0Bi0dYmJI9pPUgrcYOJ7CLgvh3qD85A8hO36iuSe78EMKUpNxR0M+k7HVPCB4pk/Jtpcw6aym+qF+dUszvZjCZtbRuZP0bI1K5N0jB91UeqSBbzLtvpvzlEZrpylyqdON15SlLupVV6nZA9nmjaDNBEMRozcnAoawDa9OlId7ahT0sNcmyNIb+Ht5xGwz//iLphvTFm4uwktTSFaWFY25+5L3Bsm1CSM9FcdsUni/mX7RQ3hwCE0pWBgqBScAAfbTgGQBjuHtm3K4YXZWFzTTNcMswwMABj+lMWd2y0PDyqMo0ZOajuNgQunTBE1WbIQHW3IQAQMkgzMPRydUHOjhM4YHkT/ab9MintTYhP7gc2vSGUlWQ6gBkAl4I2ysgu0l5wDrQGOtFqNwofChTakw5WtvOAu3SlWmbS2x0cm6qbcU5xN+h1gEuGJDGOxGdvi5Q78RCrVMgGVolDWQM8wVnk0ulxKGtARN+vA0PfIypOHvvkfmHPZ7HmM3cpKzjrjNoa2gY61kAnMziLqr9I/j0jFCwAqyUwe+MAth08LVsGdzLn67XXg6YtDRWjTZ8e8XEODobO2ZoMTEgeU+Na6fJ/yd2C4Ew9gMuf007vOdi2kMmk4LrcwbaJZBCWLKmNWP4zkfPQpcXdOq0NT9bcs0h7ATori4K0QqQ729BmyAh43F+g4OxDXCutpgCttP5J6S3AlS/K3QrpyTGkHYiC63L3y80IuF9yZjpTbZnM4UVZCSuu0j83wzOMLVZXC1UPPFESHqAZY5cBWAxAD+A1zvmihN5w3HhaA60QfVpqfOagAUDncqJPS03Q7wmZVEYfvGKn1eAMCEPLcgdnQNF1ucVsbe8s7sx0hpY2hX2IjMKJ0+0JCc5Z6czz71WUY0pqQPaX0ADNGNMD+CuAiwEcAfAjY+xjznllwm46aDAFaIUQA2ukWdxhk8qykje0pCnZRdoNzvUVChlaZopNEBONHpDts1XjcndmtFoFGhEINpQfjZY2ji01TUnd9zmYRPegxwHYxzmvAQDG2FIAMwAkLkATRcmxNYZdViUKlVSW4zjVUUudRE5ra5wBZcw3+zPlyN2CqKm37xycVK9pf4MNZ3VNk7X3DCQ+i7sQgPfu9EfcxwjpJGRS2eQpKpt/BpCWKe/9tVK601t9BVD5gbKCMwBYGzRRUYx0SEat7XBkTxJjjN0O4HYA6NOnT9Dzmpub0dDQALs9grmm0nGAU6Yc/BgZ7e3IPXQQ3ZrVmbAhhaBJZbwdGDRchhbFSZ8OoFWee4ulO7Wm+ouOZWtKs3OZ4oe5SeSUUFkt0QG6FkCR1+Pe7mMenPNXAbwKAKWlpQFHKJqbm3Hs2DEUFhbCZDKBsTAZvwBgsQB2Ba05DYFzDqvdjtr0DGDv7pQN0kGTynp3DtqqYD0lz321OKwtUsR8cwjrfg9MeVjuVkRE7nKZSmfsXAI86RI9xP0jgEGMsf6MsTQA1wP4ONqLNDQ0oLCwEF26dIksOAOA2QyEW7qjEIwxdElLQ2F+Hhr69JW7ObLJsTWiuHk30h02gHOkO2zoaa3HDwfs+Hb5TpS9tw2frd8vdzMjl907efdi7t8mWhzWFlUtl7sF4dlPq2aoO5nredUo4liTQAntQXPOHYyxuwF8DmGZ1b845zujvY7dbofJJO9kfTKYjEbYjWlyN0NW3kllDRk52NNtCLq7e9Td0wxoa2zFZ+v34/JJ/eVsZmQufBz48LbE36f/FGGXLK1Ty97L1V+oYqi7KMek2jXQydDukD+NLuE1yzjnn3LOB3POiznnz8R6ndg+zcj/DxwNJXxiUwzGsCtrIHR+Wd3peh1cR0/L1KgojZwlrD+WUs+hvo9TJTgDUM3/Z6UPw3uRomylTqO/tpSwBafsSWKE+Pj1bzxf6pcHHmzJVsLkUKTE9cflr0tzvbtTuda8FKtck0DBFcX85ZnTAq4njgZXwVsSrWSX9AxG/o8ICcI5R8XRM7hz5T6ULN6E/n/8ESWLN+Gulfuwpb4FXMKfqpOnTuHqOTchs18/9B17Dt7+4APJrp3KLEGq4TfJVSU/Vle+CFzzT7lboX6F4+RuQXg6o6Irivk7aok/kVYL8bm0uJunx2xK0yVtO8lwNNmDtjtduH/ZFnxZeQxtDpdnz1Crw4XP9p7CmpomXDTQjBcv6w+jPv7PKHfNn4+0NCOO7diJLTt2YNqNN2LU8OEYPnRo+G8mHYYN83moy+uKtsZWpHu9R21OF3R5XZPdsviNnAV89iBgPRn7NUw9pGuPGpXMBFqPA5ZquVsSWIZZCM4qmH8WJSOLW+njHmkGJntJz2A014PmnOP+ZVuwqvIYrHZXpw29XVwI1Kv2ncL9/9vv1ZOObSKltbUVH3xShqfnz0dWVibOmzAeV116Kf7z3nvxvZBUM2wYMGmKz6HLJ/WHLScTp9odcHGOU+0O2HIy1ZEgFsjlzwk9rFjo04TvT3WltwLDZc5Q13slchpMQnsuehY470FVBedk7WKl5OAMACP7KvcDv+Z60FsOW/BlZQNs9tCfDG0Oji/3WbD1aCtG53cFunYVNmPg0X2i3FNTA4PBgMHFxZ5jo4YPx7rvv4up/SlFpwPOvyBkhTDVBuNAxKVPq58Cmo4ATBe66AbTCT+P2UVCRrgWl07FwnJQ3vsbuwAXPClvGySw7aBKki0T7MTpdkX2ngENBujX1u9HmyOyOco2pwuvbTqGv9xQAGS4i2GcPo1On/mMaUGLnrS0tqKb3yYO2d264nSLTBWklGzqhcKWkS0twsYX48arr3xnvEbO6gi025YBK+4CnH4/WzojMPNvFJD9VS13L7WSuU+moiztUKReRqRj6DRiqQZKqbsdiOYC9JpdDRH/kLg4sLqmqSM4i3+3tgIuJ6DTA5mZwnGbDTjdec1gVmYmmv22QWw+3YKuWTLXYVYaxoRgnGoBORQxAHvPTZt6CEPZFJx9VS0HahWUwV61XJgTJx4urvz55mAq9gu/25UWpDUXoG1RZvja/HvbGRkdgdr/uN0O2HznbQYPGACHw4G9NTUYNGAAAGDrzp0YPmRIVO3QvJISuVugTN49aiJU4ar+QuilGrsIa3gcyZkrjYr4YUHFQdqoB6ReEKHG4AwAThewqVp5QVpzSWIZUa6RzTBEcX7XrkDXbkLPGgB0emSau+OaaVfg8eeeQ2trK77d+ANW/O9/+MV110XVjpilZwB6CT9nMSasRY61aIre79+TsYAJYIR0Ul8B7Hy/YwjZfkaZwVmklspmQYzq103uJigKB7C5pjlpyXOR0FwPeurQXHy2oz6iYW4dAy4syY3uBgF62H/769/wq1tvRe7w4Tirew+88qc/Yfiw4cIweaIVDwAqJdxeW8xqLykJfF2zWZhDdjh8jzMmfA8FYhKr3SsBqGnzBrX2FwVU6rMzFxeS55TSi9ZcgL51Un+s2dUAawRjN+kGPW6dNCC6G9hsneaoexQUYPmnn3Y+L1DCmZSzNHoDcOiQNNfy9o9X3NfXd2zbSQGYJIo4rK3k3nJA6q9xqdcJw7ukgxJqcIs0F6BHF5lx0bBcrKo8FnKpVYZRh4uG5WJU7+zIL+4fdF1O92N0nrcOlnAGBEw2ixpjwJQpwJrV8V8rGKczoqVQhITlPbfsXdCjvgKo+ghwRbDPe9JE+CFaDZXNQjjcaKXgHMT/NjfC2u6CKU2H4UVZsvWoNTcHzRjDi7NG4+JhvWAy6jsVctcxwGTU4+JhvfDirNHRbVDR2orO/3G5+ziEAH7iBNDYIPwRA3HXbsBZZ3UMj3ftJqxxjcbUC4WlSYDw9wVThaCZleB6sS6XsDSKkFiJQVicW7ZZhMdi0FZUcIYQeCMpKFP7A/DlQ8A3z6lmi0lvOw+3hD8pRYkV1qztLmyqlm9eWnM9aAAw6nX40/VjsPVIE/75dQ3W7GqAzeFEhkGPC0tycdukARhVZI7+wsHmlF3O4EPagXrZ/vPYQZZweWRlBV+iNG58YnvRgDDnTEg0vHvMgbjsoZ+XU8lMwNwX2LkszInu/+viBw5AVZXEklHmUws4gK0HmmXpRWsyQANCT3p0kRl/vXGsdBfV6QMHaZ0+SO9a5O5lB1q+BfgVSfFjMAhBOJD166RNEAsm0b10oi2RDluLw91KCtLiTlTRVisTP3CoKECb0nQUpCNkdwpTAskO0poN0AmRmRmgl8zcx8PMK3sH9gCJZp5edX29EBBDVduKNTB7J31FSqcL/gGBkECiGbZWUnAGOnaiimUJldJeSxjDi7IoizsKchQzoQAdjVCVxsRjwYhrpwMmmjV3BHibLXQJzEiDc7Agv3cP8PW6zsukgqEEMRItlQUqH7tXur+IIZNXRftAA7TMKlpOlzBvTwFayYJVGktL61RlzIeYwd3SgrD/+cU55UCBsaoqombixl8EPi5e89tvgLa20NeYeiEFZxI9pQ1bR8Nhdc8nx7AcUkX7QMeif24G9jfY5G6GrKztLmypacLoAVGs/omD5rK4ZWGzCX9CaW0Ves6R7pYVLHOaR/BLI1xm+qDBwE2/6rT/so+CAgrOJDZnqbzMrcsOsBj6Liqaf45Fqgdn0f4GG7bUNCXlXhSgpRAyQczN5Qzdw/YXLHM6kmVhkda9njRF6CX7lwodNgyYPiOyaxDirb4CqN8sdyvix+1A4XhooRhJKP1zgySupigdA9IM4d/zZH1Y0ewQN+ccp1oc2FvfimOWNjhdQtWcXuZ0DCrIRPdMQ3RroANxJ3v95Z+v4o2l72J7VRVuuPpqvPHnP8X/AoJlTgcrwSmKtu417TBFpBBuWZXaGEzCcquSmcJa50jOVyFxqJZ6x4J0ow6Xjc3xFCqRmyYDtMvFsam6GfWnbD6VcpwuoO5kG45Z2pDfPQPnFHeDzr+SSaROn/b0iAt65eHR++7F51+thTXcUHekgmVOi8HXO0jr9cCU8ynQkuSrrwB2Le+8p7XaOazCa8sfE9mc+pDpyWhVQlCQ7mBtd+GTH49FtMvXqooGXDwmyr0coqS5AM154ODszekC6k/ZsKkaKB3YLfqetM3mM1x9zZXTAADlW7fiSF19rE3vEC45a9IUqolN5FdfAVR+APAkbAojh53L3MVKtD3MDSgjSDMA/XIzcNrqwPHTEa4ySYBIt+BsaeMJXxutuTnoUy2OkMFZJAbpU60x/CAEKigSNyaUAO3alXrCRB2qv9BucPYRQWKmZ3mWeiUrMzkYDuDQcXX14hNdLlVzAXpvfWvEBeCdLmBfXWt0Nwi4Q5UUvGp6E6IGWplvloI4JK5ykSRIJZLTBVl7z9FK9Dy15gL0MUuYtb1+jkZ5flSZ2NFKxv7RhEhFZYU5Ek6sx61iStpqUQ1MaYkNoZoL0NFun6ao7dbEamOEqEHGWXK3IPmMXYI/p7RduaKUrLW9WsEglEtNJM0FaH2Uryja8wNxOByw2WxwOp1wOp2w2WxwRFpK04N1VBsjRA0sNXK3ILn0acCUx+RuRcIcoCzuqJxT3C3hZT81F6B7mdOjOj8vyvOR0fkNWfjiSzD16YtFf/oz/vv++zD16YuFL74U/Bo6vXAdsces0wvJYcF2uyJEkVJsOLRrkfuLYPO06s72TrF3My5GfXI2zdDcMqtB+ZmewiTh6HXAwIIoe61duwp/e81FL3hgHhY8MC/ya5yVgkODRINiqFetZpZq4NuXEPQ1F45LanOkFs27qdcpbHowyUb165aU+2iuB909y4D87hlhh671OiC/ewa6Z8bwGUUM0oSkMpUHpJhYGwIfLxwvVB1TsX5RlP3snmnwJEipe9wgeqVJGNoWaa4HzRjDOcXdsKkaQddDi8H5nOIYipQA4TfGCNlAzX0mIgEsr6jF85/vRp3FigKzCfMuHYKZYwoDHgcQ8FzFM/cFaoNs6pJSmOqDM9CxDvpAgw0coXvUJ047MHNCL2ypaUqpCmTJDM4AwHgkuyMlSWlpKS8vL+90vKqqCiWRbgDhxjnHqVYH9tb51uLOE2txZxlja6TN1rF3cyy6dgs51xzLayWJEyzQ+nt0+Xa8vfEQXFH+d9IxBPyedIMOz/3fSOUG6qrlFJy9XfSs3C1IiI82HAv6XP/cDE8wTxVXT+iVkOsyxjZxzkv9j2uuBy1ijKFHlhHjB5ulvXCwXaYiwigRTCWWV9Riwcc7YbF2LJ2ptVgx7/2tAOATOB9dvh3/3XAopvsEC+htDhfufXcL7n13CwqV1quur6Dg7EO7g7yhetGp1HMGEr/mORDNBuiEsNki3885EJq7VoxQPePlFbV46MPtsAYoymt3cty/TAicyRLsg4Fsqr+QuwXKouG5+H65GSkXiIHOI1t6XeLXPAdCAToasZbi1OmFNc7Ue1aE5RW1mPfeVtjd/wNrLVbcv2wLHvpwG6z28B/Aoh3GloLdyfHkyp3KCNCpWuJz+CzAchCo/QEQZ2kLx2li/jkYJWyiIYexA7ph5+EWWNtdMKXpMLwoK6lzzyIK0NGIthRnhol6zQq04OOdnuAscnFEFJzldOqMQipVRbL9otYUjhe2nswfo+mAHMjoAdkpFaBNaToU5ZhkCcj+KEBHQ6ePPEgb0yg4yyDY0HWsSVwkgOJLhLrTKi9tGZEMs/B688fI3RKSJHIMZQdDAToamZmRZXBTz1kWyytqcf+yLZ4gXGux4t53t+CvX+3F3gb17xRmVMoKPTFYVX8h9KQNJsDl0GbAPu9BuVugCP1TZC46WRXCIqXdAM05ULsJ+O5PwN4vALsNMGYAgy4FfvpboHAsEO0a6IwMIYvbK1Gsra0Ndz74IL78ej1OWiwoLi7Gs88+i8svv1ziF0TCefjDbQF7yGoJziajDt0yDDh2uj3g83YXcOM/v8dbt52b5JYFIA73equv6AjaWlFfQb1npM5cdLIqhEUqrs/kjLHnGWO7GGPbGGMfMcbMXs89xBjbxxjbzRi7NO6WRsNpBz64FVgyHahaCditALjwd9XHwJIrheedMXziz8qC97IKh8OBooJCrPvsMzQ1NWHhwoWYNWsWDhw4INWrIRE6o/A55HCsdheOnW5HlxBd5W+rT+LR5dsxcdEa9J9fhomL1mB5RW0SWxlC/hjt9TgpY91j9IBsWZYaJZOSes9A/D3oVQAe4pw7GGPPAXgIwIOMsWEArgcwHEABgC8ZY4M554nf8Jhz4KM7gN1l7sDs/7wLsJ8BdpUJ5/3fa9H1pMVM7NZWwOVEZtduWPD0057jV155Jfr3749NmzahX79+8b8eEpT/fLNWhPug4b3mWsxABxSwBEvsQWuJlkYDJDC8KAsV+5s1WYe7Z1flDSjH1SLOuff/xg0ArnV/PQPAUs55G4D9jLF9AMYB+D6e+0WkdhOw+9PAwdmbwyqcV7sZ6H1OdPfIyAi6ZOrYsWPYs2cPhg8fHt01SUQeXb4db208BP8CeLWWMO+3hrm4MLwva4CurwB2vg9AY7+5M8xyt0BRxB7m1gPNCFAmQLWy0hkmDVfeJkZSjlf8CsBn7q8LARz2eu6I+1gnjLHbGWPljLHyxsbG+Fvx3Z8BR4TzJA4b8P1f4r+nm91ux4033og5c+Zg6NChkl2XCMSKXVJXpzUZdfj5hD7QqbgglOzD+7tXQnPBGQAylPdLW25FOSZc+ZNeKC3upvohbz0T6mtfPCZX7qYEFPZflzH2JWNsR4A/M7zOeQSAA8Bb0TaAc/4q57yUc16ak5MT7bd3tvfzyKt9cRew53/x3xOAy+XCL37xC6SlpeEvf5Eu6GvR8oramOZQ39l4OPxJUZpY3ANVT1+Or3Y10hKseDg0OoJhqRbqjpNOinJMuGysBL+zZaTXM8XNO3sLO8TNOb8o1POMsZsAXAngQt6x80YtgCKv03q7jyWePcosQwl+sXDOccstt+DYsWP49NNPYTTGuBFHCvAvo1lrseKhD7cDgGe3pydX7vQpytG9ixFPTB8Op8Rd54nFPTwZ0XUqHyKPZVO2uNVXCD1nrQZnUe0PKVecJFKHG+V/7+PZlbzdoexP5XHNQTPGLgPwAIApnPMzXk99DOBtxtiLEJLEBgH4IZ57RcyYEX7+2Zsh/k9Pv/nNb1BVVYUvv/wSJpNyP43J5dHl2/HOxsNBA6zV7sSCj3d2CsyiU2fsnlrUUvq2+iT6zS9DodkEcxejcip1xeDG8X2Se0OtzjkHpOxf4nLaeTiezYOkoeV3J94JhL8A6ApgFWNsC2Ps7wDAOd8JYBmASgD/A3BXUjK4AWGdc6R7LjMdMPiyuG538OBB/OMf/8CWLVuQl5eHrKwsZGVl4a23oh7t1yRx3jhc79ditYcMkHZn4v4b1lqsqg7OP5/QBwtnnp3cm1Z/gdQIzm71FXK3QJGs7er+GTDq5W5BaPFmcQ8M8dwzAJ6J5/ox+ek97sIkZ8Kfa8gAzr07rtv17dsXStpTW2kSMW9MfCU9OAOpt/yo+gsqWBKAKU2n2iDNoLzCJP6Ut/ArXoXnAEOuENY5h5obM5iE8wrHJq9tKcB/bbLU88ZEIVJtw4xUeq1RGF6Uhc01zapMsDynuJuiE8QAaZdZKQNjwNV/B4ZOA4xdOg93M51wfOg04TxZsmu06dHl23Hvu1tQa7GCI7XXJmte8SXQ4q+P4Oj3RCBFOSaMHdANaQZ1/fuIO1YpnfZ60ACgNwoVwmo3d9TidliFXvPgy4Cf3i30tIlkllfU+lS4IhonDvfuXCZvO5JGhV3EJBG3ZjzcaMWm6uaI/6XkGh7X65S1Y1Uo2gzQgNAz7n0OMGuJ3C1JCY98tF3uJqSkQjlLnOaPASwHgdqN8rUhWaiiWFhijzTSIC1HcDal6TC8KEsVvWdAywGaJFVru4bq/qmEUc8w79Ih8jaiZCbQelwo6KFlxZfI3QJVEANfeXUE2/LKQG2FVShAk6CWV9Riwcc7YbEKS5Ay0/Qw6nVostpRYDZ5gsPzn++Ws5kpSSzeIvsGGQBQeiuw7unIVk6oUeF4yuCOQlGOCSdOtytua0o1liWlAE0CEtcvexN6yR0VwO59d0vyG0aQmaaH5Ywd897b0uk9KHR/cEpa4BZ3sNJycKYqYlEbPSAbZ3VNw87DLbC2u8LON189oRcON1oTtlOWjqln3tkbBWjSCSV8KZs4nRBofwz/0qkJVV8BVH0EuNRb5CWshu0UoGMkJo+JPvnxWMAdsMRiITsPtyQkOOsZMGaA8pdUBaK+Pj9JOBqyVjer3Zmc97D6C20HZ0C7IwMyGNWvW6fFat7FQhKVNHbV+F6qDM6AlnvQnAPNh4GD64Hju4VfJDoj0HMo0HcS0K23ZGugf/7zn2P16tVobW1FXl4eHnjgAdx6662SXFsOat84giRpDToV7yBREIOk97C3d0Z1IpZd9c/NkPR6yabNAO1yCuszG6sAlwOeNYwuO9CwAzi+C8gpAYbPAnTxF2N96KGH8PrrryM9PR27du3C+eefjzFjxuCcc9S51lrtG0dEw6gDwFhCa30ny/mHN+Gmys+QY7Wg0WTG6sITuPCeXybuhqlQTUyCzXRIB/9hb2/Di7Ikn4MePSBbuovJQHtD3Jx7BWc7OhcY4MLxxirhPAlKUQ4fPhzp6ekAAMYYGGOorlbnspPlFbVoSpHgDAjzuA6NBOe5W95HL6sFOgC9rBb0+PsLWP3nNxN301RYetRrpNwtSBlFOSaM6d95GDxWSt8IIxLaC9DNh72CcwhikG4+Islt77zzTnTp0gVDhw5Ffn4+rrjiCkmum0zLK2rxu2VbU2mPIgDaqBF1U+VnyHD6/sxnOO1Ie+Pvibtp/hghy1nLTlA+RjIV5ZhwTnE36COMTF2/W4Xi383GkJsuQPHvZqPrd6s8zzENlHHWXoA++I17WDsCLgdwaL0kt/3b3/6G06dPY/369bjmmms8PWq1WF5Ri3nvb6XNLVQqx2oJeLxH66nE3rhkpjBVZOyS2PvIRetD+Aok9qTD6frdKuS/8QKMJ46BgcN44hjy33jBE6TbHer/Xaa9AH18FyLvE3GgcZdkt9br9TjvvPNw5MgRvPLKK5JdNxmeXLlTE/OwqarRZA54/GRm98TfPH8MMOUx4KJnhWCtpbKYWnotKlKUYwo7RJ37wWvQtbf5HNO1tyH3g9cAqLMwiT/1vwJ/0S77iLS3HQWHw6G6OehUSQrTqjeGXQ6b3uhzzKY3ov2mO5LbkPwxwHkPaiOw6YypMc+uUIGWZXkznGgIeVyNhUn8aS9A64zhz/E5P75E9oaGBixduhQtLS1wOp34/PPP8c477+DCCy+M67qERGNt0TlYPPpaHDOZ4QJwzGTGyTv+X2KzuEPRQmAruZpKfMpInI8OFqQdZ+UGPV6qgr2eI6G9ZVY9hwpLqSIa5mZAztC4bscYwyuvvII77rgDLpcLffv2xcsvv4yrrroqrusmm9lk9NTcJuq0tugcrC0SlvYVmk349p6p8jUmf4z6t6Kk4Cw7McgGWn7V8H+3Iv+NF3yGuV1p6ci68x5NBGdAiwG673nCPHQkQ906A9BnUly3y8nJwbp16+K6hhIsuGo41dbWCKNOAbtcqZ1Wk95UKGiBkwk/R00vE1pf+TP0xxvg7JmLzN/cgwE3/p/MLZaO9gJ0tyKhCEm4pVY6o3Bet97Ja5uCzRxTiAfe34p2ShRTNQbg+etGKWOXqwD2HMrD9zsGouVMBrK62HDuiH0Y3Oeo3M3qzKD++UstCVbgZMCN/wdoKCD7094cNGNCJmlOiXs+OkD1VzE4D58lWblPLfjDtaPkbgKJ00uzRysnOJuLfR7uOZSHrzYNQ8sZEwCGljMmfLVpGPYcypOnfaFYG4Dy1+RuBUlx2gvQgFC+c8T1wDm3AbkjOgK1zgj0GiEcP/sGScp8asnMMYUwm6JMsksCPX2IiojJqFNOcAaEfaK9fL9jIBxO3/9zDqce67fEMxyfwJ8Ni7pWYhDt0d4Qt4gxILsIGPkzuVuiKkqci54woDu+rT4pdzMUzahjePYaBZal9KrX3XIm8MYFtnYj9hzKi36oO8MMnDUEqN3Y+bnC8UIVMCo0QlRMmz1oErOZYwoxsbhH0OcH5WYmss8SEAXn0ArNJuXOOxdf4ln6mNXFFuQkhu93DIzuuuIa5ZKZ7nKj4k8lEx6XzPS5t4/C8dovUUo0Qbs9aBKzt247F48u3453Nh6Gk3PoGcMN44uwcObZAISyoM9/vjs5WxqSoExGPZ695mxlBmaRuFSp+gucO2IfVv0wAoGGpYP1rn0xAFzoORdf0nHtkpnCnxD3hs3S+fsAoPYHBF2S6TeHTkiyMa6g2sulpaW8vLy80/GqqiqUlJTI0KLkU9NrnbhojeKCtJ4xODkXf5VrVqHZhHmXDlF2cA7gtblfoq2t88BdVhcr5lzxTehvvujZBLUKQkKY95yzubjTHDohicIY28Q5L/U/Tj1oErN5lw7Bfe9uUUwgFHuUWu/dv6ykTO0oTf7ZCHz130o4vFZAGvROnDtiX+hvTPS+zBSMiQLRHDSJ2cwxhbhxQp+kz0kHIw731mk4OCsuUztKg8fn4YKfD0NWj3QAHFldrLjgnEoM7nPMPaQc6FcSA4ZMT3JLCZGfZnvQnHNsP74db+x8A+uPrEebsw3p+nRM7j0ZNw2/CSN6jpB8v9C9e/fi7LPPxrXXXov//ve/kl5bqRbOPBulfXvgyZU7A264YdQB9jg3mJ5Y3AObDzXBaneGPE8MXAVmk2Z70IrM1I7S4PF5GDw+yNrn+gpg90rA4X7/jF2AwVdS2U2SkjQZoO0uOx5Z/wi+OvwV2p3tcEGIEDanDV8e/BLra9fj/N7n45lJz8AY7eYaIdx11134yU9+Itn11GLmmELMHFPoSR6rs1hR4DVHuryi1ieAm4w6ZBj1OHXGHnau+MCiaQCExLT7lm1BJCkT8y4dgoc+3B42oKtN9y5GVfeeI5I/hoIxIW6aC9Ccc09wtjk7L+twwQWrw4qvDn+FR9Y/gucmPydJT3rp0qUwm8346U9/in37wsynaZQYqCM9DgiB93fLtsIZIPIWmjvmHcXvD7ZG23tpWLhzlSjcZiV6HcMT04cnsUWEELlpbg56+/HtWHtkbcDg7M3mtGHtkbXYcXxH3Pdsbm7G448/jhdffDHua6WamWMK8cdZo2Dy253dZNR32vBh5phCvDx7NIx+P7UTi3vgrdvO7XSuWphNRiy4ajiMusAfFDPT9PijUtc5E0ISRnM96CU7l6DN0Rb+RABtjjYsqVyCF6a8ENc9H3vsMdxyyy3o3Zs23oiFGHgCDY8HOldrgUocin/+ulER/RsQQlKD5gL010e+9sw5h+OCC18f+Tqu+23ZsgVffvklKioq4rpOqtNi4I1Um8OFee9vxfPXjsK382Xcw5kQoiiaC9Btzsh6zyKbI/RQeDhr167FgQMH0KdPHwBAS0sLnE4nKisrsXnz5riuTVKH3cnx/Oe7U/ZDCiGkM83NQafr06M6P8MQSYnB4G6//XZUV1djy5Yt2LJlC+644w5MmzYNn3/+eVzXJfFL1M5cL88enZDrann9NiEkepoL0JN7T4Yuwpelgw6Te0+O635dunRBXl6e509WVhYyMjKQk5MT13VJ/AIlXukYgiZjReLnE/pg5phC/HxCn3ib10mBOcHVsgghqqK5AD1n+BykGyLrRafp0zBn2BxJ779gwYKUKVKidDPHFOL560ah0GwCg7Bs68VZozF7XFFM1/v5hD6eDUMWzjwbL88eDZN/Snkc/LPWCSGpTXNz0Gf3PBvn9z4/6DpoUYY+AxcUXYARPUcksXUk2QIlnz3/+e6or1NoNnmCc6Bre+/w5V98xWwyYnhB15DbZoo9c0IIEUkSoBljvwPwAoAczvlxJlT+WAzgCgBnANzEOU9KxhRjDM9MegaPrH8Ea4+sRZujzSerWwcd0vRpuKDoAjwz6RnJy30S5Ytlrjdc7zaSLPRHl2/Hfzcc6nTcu2dOCCGiuAM0Y6wIwCUAvH/zXA5gkPvPeACvuP9OCqPOiOcmP4cdx3cItbhr18PmsCHDkOFTi5ukpmhrdUvVuxXrltNaZ0JIJKToQb8E4AEAK7yOzQDwJhc2m97AGDMzxvI55/US3C8ijDGcnXM2/nj+H5N1S6IS8y4dgnnvb4XdGb6wt9S921Re700IiU5cGS6MsRkAajnnW/2eKgRw2OvxEfcxQmQ3c0whnr92FLp3Cb0MK03PaOiZECKbsD1oxtiXAALtDfcIgIchDG/HjDF2O4DbAXiKfRCSaP4JXr97byucro4etV7H8IdrR8nVPEIICR+gOecXBTrOGDsbQH8AW92JVr0BbGaMjQNQC8B7LUtv97FA138VwKsAUFpaGsFmgoRIK5pa4IQQkiwxz0FzzrcDyBUfM8YOACh1Z3F/DOBuxthSCMlhTcmcfyYkWjQ3TAhRmkStg/4UwhKrfRCWWd2coPsQQgghmiRZgOac9/P6mgO4S6prx4Jzjob2emxr+hGHrDVwcAcMzIA+pmKMyv4JctLyJFsDff7552PDhg0wGIR/zsLCQuzeHX0xDEIIIUSkuUpiAODkTnx1/FMcPFMNJ3eAu+s6ObgD+8/swSFrDfp2KcYFPa+Anukluedf/vIX3HrrrZJcixBCCNFcLW7OOb46/ikOnNkHB7d7grPneXA4uB0HzuzDV8c/hdDZJ4QQQpRFcwG6ob3e03MOxckdOHimGo3tRyW570MPPYSePXti4sSJWLt2rSTXJIQQkro0F6C3NZWHDc4iJ3dga9OPcd/zueeeQ01NDWpra3H77bdj+vTpqK6ujvu6hBBCUpfmAvQha3WnYe1gODgOWWvivuf48ePRtWtXpKenY86cOZg4cSI+/fTTuK9LCCEkdWkuQDsi7D13nG+XvA2MMZrbJoQQEhfNBWgDiy4x3cBC12MOx2Kx4PPPP4fNZoPD4cBbb72Fr7/+Gpdddllc1yWEEJLaNLfMqo+pGPvP7IlomJuBoY9pQFz3s9vtePTRR7Fr1y7o9XoMHToUy5cvx+DBg+O6LiGEkNSmuQA9MrvUXZgk/NC1nukxKvsncd0vJycHP/4Yf6IZIYRIbf3Bt1HlOgIOgAEo0fXGpL4/k7tZJEKaC9C5afno26UYB87sC5nNrWcG9O0yEDlpgTbqIoQQae1tqcQPp9ajxdmMLH03jOs+CQACHvv2xGq0cRsAIF1nwsQeUzEoa1hU91t/8G1Uuo4A7oqJHBAeH3ybgrRKaC5AM8ZwQc8rAlYSA4RhbT3To2+Xgbig5xWSlfskhJBg9rZU4usTn3uSWFuczVh7/H/gcHl+P7U4m7HmeFmn721zWbHmeBnWHC9DOssAGEObywoGBg7uCez+AbzKKzh7MIZK1xFUH/oL2lxWn6eCXYfIR3MBGhCGri/seSUa249iq6cWtx0GZkQf0wCMyv4JctPz5W4mIURh1h9fhaqWreDgYGAoyRqFST0vjvo6/r1lu6u90woTF5xRX7eN2yD2N7wD+9cnPgcAn+AaKgvHPziL1/nq+KedrkPko8kADQg96dz0fFyce5XcTSGEKJh3MPXGwVHZsgV7WnfCwe0R9zD3tlQKZYS9AmiiObgDP5xaH1lgDTFqyMHx7YnVFKAVQrMBmhBCQtnbUukz1xuMmHAqDkGLw9D+AXtvSyW+PbkmYO80GcQPAuIoQKhAHEq4fw+SPBSgCSEpx39OOBZiwP725BoUdxniGRqX0z8OPC/r/Ym0KEATQlLOD6fWxxWcvbW5rKhs2SLJtZQgXWeSuwnETXOVxAghJJxkzAurlcNlx96WSrmbQUA9aEKIhgRaaxwo4SlL342CdBBOOLDmeBk2n/oes4tukbs5KU2zPWjOOaxbt+LI3Huxa/QYVJUMw67RY3Dk3vtg3bZN8s0sli5dipKSEmRmZqK4uBjr16+X9PqEkMD2tlTircP/wD8OPI81x8s8gVdcfhSoNziu+6So6/anGovzJFbWvyt3M1KaJn9Cud2OuvnzcXrNV+BtbYDLJRy32XD6iy/Qsm4duk69AAWLFoEZ49ssAwBWrVqFBx98EO+++y7GjRuH+vr6uK9JCAnfI/Zf0uTPwR2ezGvv7xevEWh5FelQ13ZI7iakNM0FaM65EJxXrwG3BVgu4HKBW604vXoN6ubPR8ELL8RdTeyJJ57A448/jgkTJgAACgsL47oeISRw9S0x2IpFRKpbd0WcOe1f0MM7UO9tqQxYxYsQOWkuQNu2bRN6zoGCsxdus+H0mq9g274dppEjY76f0+lEeXk5rrrqKgwcOBA2mw0zZ87E888/D5OJsiEJCSVY5a5wPWOxiEi0/At6ePfQ01kGrQEmiqK5OegT/35DGNaOAG9rw4l//zuu+x07dgx2ux3vv/8+1q9fjy1btqCiogILFy6M67qEaN3646tQ2bLFE4TFoPvu4dex5nhZwtYUi0PaYg9dfEzBObB3D78udxNSluYCdMvatZ4557BcLrSsXRfX/cRe8j333IP8/Hz07NkT999/Pz799NO4rkuI1lW1bA143OI8mdD7Zum7AZB2LbSWWZwnKUjLRHMBOtLes+f8MEPh4XTv3h29e/f2mcemHbIICU+uqlvilo6UHBa5RH9oIoFpbg6apadHFXRZRkbc97z55pvx5z//GZdddhmMRiNeeuklXHnllXFfV2vKaspwYqsNxWyocIAB2Wd1wYjz+svbMCILcbvEZBPnn2ktdHTWH18V085eJHaaC9BZ55+P0198Edkwt06HrPOnxH3Pxx57DMePH8fgwYORkZGBWbNm4ZFHHon7umrXeNiCQ1UNaLMKe3KbeT+Yme8IQ9OJM/huhdc6VQb06mNG8egCGVpMEsUnGUtnAjiXrQf91uF/YFz3SRjXfVLc9bhTiZiUR0E6eZjUBTviUVpaysvLyzsdr6qqQklJSUTXsG7dioM33QxuDb+jDDNloO+SJXFlcUstmteqZI2HLdhXUR9XQRiDUY/+Z/dCTpG507X3VtT5bHjb7SwT9cQVSoqNKaRmYAZMPutSAAiZLU58MTDc3u//yd0MzWGMbeKcl/of11wPOmPkSHSdekHwddBuLCMDXadORcbZZyexddrh3TsGA8CBdJMBfUpykVNkxv7tx+Ku1uawO7GvQij60nziDI4dsgTdhb75hBU7vtlPQVphwi2XkouDOxTZLqWjf6/k0lyAZoyhYNGigJXEAAA6HVh6GrpOnSpUEqOErqg1Hragems9XE73f1b3X21WB/ZursPezXWS3YtzHvH1mk9YfT44eH9gIMkn9pyV+ktdqe1SMgb6fZlMmgvQAMCMRhS88AJs27fjxL/+jZZ168BtNrCMDGSdPwVn/epXMFHPOWaHqho6grPCeAfzNqsD1VuFHjgF6eSjZUzaU5I1Su4mpBRNBmhA6EmbRo5E75dfkrspmtNmVc8vXZeTY2+F0KunHnVyUYa0+jh3dgdfVwg0pwHd2sGm1EI//JRPlTeSPJoN0CRx0k0GVQVp/yH4YwdP0Vx1EtAyJnVx7uwO/llfwKEXDjSng3/WF0adCb+6/EZ5G5eiNFeohCQB10m+XWcyNZ+wonqLdPPkJLBuBrPcTSBR4OsKO4KzyKGH9ase8jSIUA+aRGfPxqM4fcqKNJM+/MkKduygBZaGFkomS6D6tsNyN4FEozktuuMk4agHTaLy/YpqGDMU8GMjQTKpOEwvJpM1HrbEf1HiQVnSKtOtPeDhDLO6P4yrmQJ+0xI1aTnZBrvNKXczAA706muW7HIuJ8ehqgbJrkdoSY7asCm1gMH3/7bOCEy6eqhMLSLaHeLmHGhoALZtAQ4dAhwOwGAA+vQFRo0CcnIBidZAZ2Vl+Ty2Wq2488478ec//1mS6yvJoHN7wJihB+fcZw25/+NkOHbQIun1wiW+NR62oGZ7PZx2oWcYrNIZEZRkjYppz2YiD/3wU3ACPlncF/7fGAwenyd301KWNgO00wl8tQY4eED4WkxocjiA/TXAoYNA337ABVMBffzDNy0tLT5f5+Xl4brrrov7ukqz45v9yDIHno/SSsGXHd/sR6++3X2KnZhzs3Ci7jQcdt/ehcPuxN7NdWg+cYZqhwcwqefFqLMeop2QVEQ//BQw/BQAYFjWaAzuScFZTtob4uZcCM4HDggB2T/bmHPh+IEDwnkSZyN/8MEHyM3NxaRJkyS9rhI0nwhf31ztmk9YsXdznc/89LGDlk7B2duxgxaavw5idtEtGJY1moa7VYZBR2ueFSDuHjRj7B4AdwFwAijjnD/gPv4QgFvcx3/LOf883ntFpKHB3XMOs07X6RDOa2wAcntJdvslS5bgl7/8pWZ6lCQyezfX4VBVg082OJUdFUzqebHnl/1bh/9Ba6NVgCOC3QBJwsUVoBljFwCYAWAU57yNMZbrPj4MwPUAhgMoAPAlY2ww5zzx2UXbtgrD2pFwOoGtW4GLL5Hk1gcPHsS6devw+uuvS3I9oi5tVgf2VtRh//ZjnXrcYpGUVB8Opy0eCYlcvEPcvwGwiHPeBgCcczENdgaApZzzNs75fgD7AIyL816ROXQw8mFrzoXzJfKf//wH5513Hvr312iVKhoUCI8j7HB4KhdJGZQ1DJPPuhRZ+m4A4PmbENJZvAF6MIBJjLGNjLF1jLGfuI8XAvCuUnDEfawTxtjtjLFyxlh5Y2NjnM2BML+cyPNDePPNNzFnzhzJrqc0g8akbs9PSqk+Zz0oaxhuLPo1ft1vHm4s+jUFaQUaljVa7iYQRBCgGWNfMsZ2BPgzA8IQeQ8AEwDMA7CMRTn5yjl/lXNeyjkvzcnJielF+DBEOWof7flBfPfdd6itrdVk9rYop8iMQWMLkG7SZvJ/Mu3dXIdNX+xJ6UAtGtd9EnSgYhjxSteZMCxrtOcDT6jEvHSdCb/uNy9gIB6WNZoSxBQi7G9azvlFwZ5jjP0GwIdcKMz8A2PMBaAngFoARV6n9nYfS7w+fYWlVJEMczMmnC+BJUuW4JprrkHXrl0luZ5S5RSZkVNkxg+f7g45lEvCo807BIOyhgEAvj25Bm0u7a8UkFo6y8BNfe/pdHxvSyW+Ov5pp4puDAwTe0wF4JvAR5Qn3q7QcgAXAPiKMTYYQBqA4wA+BvA2Y+xFCEligwD8EOe9IjNylDCvHMnQtV4vFC2RwD/+8Q9JrqMWZxV0lbxQSKpqPmHFdysqPY/1RoYBZ+enVMb3oKxhGJQ1jLK8Y9DGbQGPez74nFjtOSddZ8LEHlM9zxFlizdA/wvAvxhjOwC0A5jj7k3vZIwtA1AJwAHgrqRkcANAbq5QhOTAgdBLrfQG4byc3KQ0S0saD1vQeKRJ7mZoltMu7GENIKWCNEBZ3rHa21IZMOiKH3yIOsWVJMY5b+ec/5xzPoJzPpZzvsbruWc458Wc8yGc88/ib2qEGBMqhPXrJ8wv+0+JMyYc79dPOI/WK0ftUFUDXE7aCCGhOFKyNrh/lne6zoR0lpH0dqitsMq3J1bL3QSSANrM9tHrgQsvEoqQbN3aMeTtqcU9Wuhpk5iEq1lNpJGq/87Ben2vHnghaTtkqW0nrmDD3ETdtBmgAaFnnNtLsiIkpEO6yZCywSOZKFveVzSbb6SzDApaRPW0V4ubJFyfklzo9PIMAer0DBmZRlnunWzm3KzwJ6WQST0vjryud4pNXaXrTHI3gSQAfUQnURMTl8Q608nSq68ZxaML0HjYgr2btV+Ny9Ig7JJGNb07eC8LWn98VdAedZvLimFZo1Niu0sd9J5lU0RbKECTmIjroQH4LBFKpGMHLeh2VpeUSZ5qszo6/duKa6f3bakHd3GfgJ1qgXxSz4uxp3UnHNze6bksfTdM6nkx8jIK8cOp9WhxNiNL3w19TANwyFqjqaVc5/e8jDK1NYoCNFGVZPfalYq7hCSmNqsD1VvrcXh3I2ytHYFKPA5oe6nW5LMu6bQsy8AMGNdd2O411DKjvS2VWHO8LCntTJQsfTcKzhpGc9AkaVwujuOHz0Cni/3Hrs3qANOl1vxiOC4n9wnO3se1PtoQaPONyWddGlHQGpQ1TNVzt94fRIg2abYHzTnHsQPN2LLqEA7uOAFHuwuGNB36juiJMRf3QW6/rpLt2XzgwAHceeed+P7775Geno5rr70WL7/8MgwS1flWuoxMY+AA4XJ5/o2ddheOVJ7GqXobTtW1Yc7vJ3rOi3aIXOw9kvBSYbQhnmIcE3tMDdgDH5w5IuKhcAaG/PQi1LUd6vSciWXCyltjalsoWfpuGNd9EvWeNU6TEcTpdGH1vyuxf9txOO0uT1luR7sLNRUNOLjjOPqP7IkLbx4GvT7+QYQ777wTubm5qK+vh8ViwcUXX4y//e1v+O1vfxv3tdVg7EWDsPnLvT5BOiPTiO/fPxzw/JaTbclqWsqjpVqhiQHOe57aO/CFSkQTpbF01LcF/lm38lYMyxqNPa07JKuORptZpA7N/e/lnAvBeetxOOyuAM8LgXr/1uNY/e9KXHzL8Lh70vv378fdd9+NjIwM5OXl4bLLLsPOnTvjuqbajL1oUKdj29c0BAzGWT3SfQ8wQGV1IVSDlmqFF6oHLgbCUEE63HrrQ9YaTD7rUs+HAH96GDGl5yVBnxcxMJRkjaLgnEI0F6CPHWjG/m2Bg7M3h92F/duOo+HAafTqH99+tPfeey+WLl2K888/H6dOncJnn32Gp59+Oq5rasG5M4rx1Vu74GjveC8MaTqcO6PY57xefcy08UaCiJnvWk4US7RJPS8OGaCz9N3Q6jwdtPpYi7M54mH4QLtP6aCnTO0UpbkksS2rDsMZJjiLnHYXtnzZed4oWpMnT8bOnTvRrVs39O7dG6WlpZg5c2bc11W7wePzcMGNQz095qwe6bjgxqEYPD7P57zi0QVyNC9l1Gyvl7sJqmfW9wj63Ljuk1CSFXxXPDGBLZxBWcNwQc8rfGqPp+tMFJxTmOZ60Ad3HI9oK2hAGO4+sP14XPdzuVy47LLLcPvtt+O7775DS0sLfvWrX+HBBx/EH/7wh7iurQWDx+d5AnLjYQv2VtTh+IqTPucke55Up2dgOmHXqFTgtHNPIl5GpjHgdAQJbXbRLXj38OuwODt+dhl0uKDn5Z7escV+slOiWLSZ1rT7FPGmuQDtPZwa0fkR9raDOXnyJA4dOoS7774b6enpSE9Px80334xHH32UArSXUNW/kpFpLFYh85esIitKYWu1Y/OXeylIx2B20S0hn5+ePxt7WyqDJpwREi3NBWhDmi6qIG0wxjfK37NnT/Tv3x+vvPIK/t//+39oaWnBkiVLMHLkyLiuqzVyr8dtPNJEc7FugZbEEWlQD5hISXNz0H1H9Iy4Tj5jQL+ze8Z9zw8//BD/+9//kJOTg4EDB8JoNOKll16K+7paIvd63FQo2kEI0RbN9aBHX1yEgzuOR9SL1ht1GH1Rn/jvOXo01q5dG/d1tEwJW1QGur/eyFJmLpoQoi6a60H36tcN/Uf2DDt0bTDq0H9kT+T265qklqW2PiW5cjchYDLagLPzEcnuhVrTeNgidxMIIWFoLkAzxnDhzcPQf1RPGNJ0nYa7GRPmqfuPEiqJSVXuk4SWU2TGoLHyLafS6VnADwk5RWYMGlOQchW3qrfWU5AmROE0+VtJr9fh4luGo+HAaVSsOiQMedtdMBh16Hd2T4y+uA969YuvOAmJnrhFZeNhC6q31sPlTM7QcritF8XjyWyT3MQ5eUqaI0S5NBmgAaEn3at/N1x2+wi5m0L8eO8lLZJ8uRMDBo0piDgAHapqSJngLJI7J4AQEppmAzRRl6iSyJhQHtTa0obmE9aAp0QTnAHpg5V3MRQlJ6KJH4wMRj36n92LetSEKAgFaKIIfUpysa+iHjxIGbhghUaqt9T51PFmOmDg6OiCMyB9lrnLyQGn8LXTzsEYQ26fbMXWHHfYndhXIZQEpSBNiDJQgCaKIAaF/duPwWF3eo7rjQwDzs4PGjSKRxdIUsu7T0lu0EpnUuCc40Td6YRdXwqcc+zffowCNCEKQQGaKEaguWktcdidilgPHorD7kTjYYum3wdC1EJzy6wIiUUkVcbSTYa4l4opYT14OFRxjRBl0GyA5pzj9Mkz2P3DYWz4pArfrajEhk+qsPvHwzh9yhp0rjMWVVVVmDp1KrKzszFw4EB89NFHkl2bJEckvVpxqVY8a6ZziszodpYp5u9PBiX38AlJJZoM0C4Xx55Ntdj53UGcqD/tWT7jcgrzgDu/PYA9m2rhcsUfpB0OB2bMmIErr7wSJ0+exKuvvoqf//zn2LNnT9zXJskTSdAVh337lORCp4+9wM2I8/qjV19zRwUzBkVVM9MbFdQYQlKY5gI05xx7N9fi1NHTQde1upwcp46ext7NtXH3pHft2oW6ujrcd9990Ov1mDp1KiZOnIj//Oc/cV2XJFefktzQVeW8nsopMqN4VL4nqKebDEKvOExc8/4QUDy6AD+9ahh+OmMYfnrVMAwaU9Dp/owxWYIl096vBUJUSXNJYi2nrCGDs0gM0i0WG7p2l3bIkXOOHTt2SHpNklhi73jflnrwACMrvfqYO50fLJEqUKW0YKVG/e9/qKoBbVaHp/oZkPwKZ95Z9IQQ+Wjuo3Jd9YmIf5m5nBx1+47Hdb8hQ4YgNzcXzz//POx2O7744gusW7cOZ86cieu6JPlyisw4d3pJp+HnYGuwQ13Hv4ddPCr4UjHv7zvnksH46YxhOOeSwZ7z5ahw9t2KSny3ohLVWxK39IwQEprmetCnjrUk9Hx/RqMRy5cvxz333IPnnnsOpaWlmDVrFtLT0+O6LpGPFGurpVgy1njY4ikeIhexsIoUa80JIdHRXA862t6GFL2TkSNHYt26dThx4gQ+//xz1NTUYNy4cXFfl6S2Q1UNkq42iNWxQxa5m0BIStJcgI42uzaebFzRtm3bYLPZcObMGbzwwguor6/HTTfdFPd1SWpTzHIn+T8jEJKSNDfE3b1XVlQlFbv3yor7nv/5z3/w2muvwW63Y9KkSVi1ahUNcZOYNB62dCp3qgTfragMu20nIURamgvQBcVn4dSxloiGrnV6hoKBPeO+5/PPP4/nn38+7uuQ1CbOOSthWDuQNqsDeyuEpDEK0oQknuaGuLO6m9A9r2vYoWudnqF7XldkmTOS1DJCQlPKnHNIHKjZLm/iGiGpQnMBmjGGQWMLQwZpMTgPGlsYujgFIUmkmDnnMJS6tzUhWqO5IW4A0OkYBp9TiBaLDXX7jnuGvHV6hu69slAwsKfkxUkIiZfSd7oihCRXXAGaMTYawN8BZABwALiTc/4DE7qliwFcAeAMgJs455vjbGu0bUPX7iYM+UlRMm9LSMzMuVmedcdKR1tSEpJ48Q5x/wHAk5zz0QAedz8GgMsBDHL/uR3AK3HehxDNszTEVzQnmWhLSkISL94AzQF0c3+dDUCsCzgDwJtcsAGAmTGWH+e9CNE0NQ1vq6mthKhVvHPQ9wL4nDH2AoRg/1P38UIAh73OO+I+RumfhAShpjnoePbEJoREJmwPmjH2JWNsR4A/MwD8BsB9nPMiAPcBeD3aBjDGbmeMlTPGyhsbG6N/BYRoRNgtL/1IUQUvVubc+Av8EEJCC/sxmHN+UbDnGGNvApjrfvgegNfcX9cC8M7O6u0+Fuj6rwJ4FQBKS0tp/QZJWWLSlXclMaYD9Ho9HHZnwEpe362olKGl6povJ0St4h2nqgMwBcBaAFMB7HUf/xjA3YyxpQDGA2jinCd1eJtzjqP79qB85YeoqSiHw94OgzENA8b+BKXTr0Ze8WDJ1kD/5S9/wRtvvIHt27fjhhtuwBtvvOF5bvXq1bjrrrtw6NAhjB8/Hm+88Qb69u0ryX2J9kSzC1bjYUtC2xKKWobiCVGzeAP0bQAWM8YMAGwQMrYB4FMIS6z2QVhmdXOc94mK0+HA//76IvZt2ghne7unOpOjvQ17N36LmoofMfCc8bjsrvuhN8Q/l1ZQUIBHH30Un3/+OaxWq+f48ePHcc011+C1117D9OnT8dhjj2H27NnYsGFD3PckRM5MapqDJiTx4vpfxjn/BsA5AY5zAHfFc+1Ycc6F4Fy+EY72toDPO9rasK98A/731xdxxW/nxd2TvuaaawAA5eXlOHLkiOf4hx9+iOHDh+O6664DACxYsAA9e/bErl27MHTo0LjuSYhcvVidnqFPSa4s9yYklWiu1OfRfXuwb1Pg4OzN0d6OfZs24mj1noS1ZefOnRg1apTncWZmJoqLi7Fz586E3ZOkDjl6sekmA4pH5VOREkKSQHPjVOWffARne3tE5zrb21H+yXJMv/fBhLSlpaUFOTk5Pseys7Nx+nTk22ESEkyfklxUb62PaOe2ePTqa0bx6IKE3oMQ0pnmAnTN5h8j3hGIc46azT8krC1ZWVlobm72Odbc3IyuXbsm7J4kdYi92Jrt9SE3sNDpGdIyDLC12gM+36uvcB3/MqOMMQwcQ71lQuSiuSFuhz2y3rPn/Ah727EYPnw4tm7d6nnc2tqK6upqDB8+PGH3JKklp8iM8VeUYNDYAuiNnXMpxCHpsRcN8gRib2LvuHh0AQaNLfAMm6ebDBScCZGZ5nrQBmNa2Plnn/PT0uK+p8PhgMPhgNPphNPphM1mg8FgwNVXX4158+bhgw8+wLRp0/DUU09h5MiRlCBGJBfJ8iwxEMdzDUJI8miuBz1g7E8izspmjGHA2HFx33PhwoUwmUxYtGgR/vvf/8JkMmHhwoXIycnBBx98gEceeQTdu3fHxo0bsXTp0rjvRwghRPs014MuvfJq1FT8CEdb+F60Pi0NpVfOjPueCxYswIIFCwI+d9FFF2HXrl1x34MQQkhq0VwPOm/gYAw8Z3zYoWtDWhoGnjMeecWDk9QyQgghJHKaC9CMMVx21/0YWDoBhvT0TsPdjDEY0tMxsHQCLrvrfsnKfRJCCCFS0twQNwDoDQZc8dt5OFq9B+UrPxKGvNvbYUhLw4Cx4/CTK69G3kDqORNCCFEuTQZoQOgp5w8cgun3zZe7KYQQQkjUVDPEHWnxETVLhddICCEkMqoI0Eaj0WeXKK2yWq0wGo1yN4MQQogCqCJA5+bmora2FmfOnNFkL5NzjjNnzqC2tha5ubRLECGEEJXMQXfr1g0AUFdXB7s9cD1htTMajejVq5fntRJCCEltqgjQgBCkKXgRQghJFaoY4iaEEEJSDQVoQgghRIEoQBNCCCEKRAGaEEIIUSCmpGVLjLFGAAflbkcUegI4LncjkiwVXzNArzvV0OtOLXK/7r6c8xz/g4oK0GrDGCvnnJfK3Y5kSsXXDNDrlrsdyUavO7Uo9XXTEDchhBCiQBSgCSGEEAWiAB2fV+VugAxS8TUD9LpTDb3u1KLI101z0IQQQogCUQ+aEEIIUSAK0FFijL3LGNvi/nOAMbbFfbwfY8zq9dzfZW6qpBhjCxhjtV6v7wqv5x5ijO1jjO1mjF0qZzulxhh7njG2izG2jTH2EWPM7D6u6fcbABhjl7nf032MsflytydRGGNFjLGvGGOVjLGdjLG57uNBf+a1wv07bLv79ZW7j/VgjK1ijO11/91d7nZKhTE2xOv93MIYa2aM3avU95qGuOPAGPsjgCbO+VOMsX4APuGcj5C5WQnBGFsAoIVz/oLf8WEA3gEwDkABgC8BDOacO5PeyARgjF0CYA3n3MEYew4AOOcPpsD7rQewB8DFAI4A+BHADZzzSlkblgCMsXwA+ZzzzYyxrgA2AZgJYBYC/MxrCWPsAIBSzvlxr2N/AHCSc77I/cGsO+f8QbnamCjun/FaAOMB3AwFvtfUg44RY4xB+A/8jtxtkdkMAEs5522c8/0A9kEI1prAOf+Cc+5wP9wAoLec7UmicQD2cc5rOOftAJZCeK81h3Nezznf7P76NIAqAIXytkpWMwAscX+9BMKHFS26EEA151yxxbEoQMduEoBjnPO9Xsf6M8YqGGPrGGOT5GpYAt3tHur9l9ewVyGAw17nHIF2f7n9CsBnXo+1/H6n0vvq4R4ZGQNgo/tQoJ95LeEAvmCMbWKM3e4+1otzXu/++iiAXvI0LeGuh28HS3HvNQXoABhjXzLGdgT4492DuAG+b249gD6c8zEA7gfwNmNMVRtYh3ndrwAoBjAawmv9o5xtlVIk7zdj7BEADgBvuQ+p/v0mvhhjWQA+AHAv57wZGv6Z93Ie53wsgMsB3MUYm+z9JBfmQDU3D8oYSwNwFYD33IcU+V4b5G6AEnHOLwr1PGPMAOAaAOd4fU8bgDb315sYY9UABgMoT2BTJRXudYsYY/8E8In7YS2AIq+ne7uPqUYE7/dNAK4EcKH7F5Ym3u8wVP++RoMxZoQQnN/inH8IAJzzY17Pe//MawbnvNb9dwNj7CMIUxvHGGP5nPN69/x8g6yNTIzLAWwW32OlvtfUg47NRQB2cc6PiAcYYznupAMwxgYAGASgRqb2Sc79H1V0NYAd7q8/BnA9YyydMdYfwuv+IdntSxTG2GUAHgBwFef8jNdxTb/fEJLCBjHG+rt7G9dDeK81x51P8jqAKs75i17Hg/3MawJjLNOdFAfGWCaASyC8xo8BzHGfNgfACnlamFA+I6BKfa+pBx0b/7kLAJgM4CnGmB2AC8AdnPOTSW9Z4vyBMTYawnDXAQC/BgDO+U7G2DIAlRCGgO/SSga3218ApANYJfwexwbO+R3Q+Pvtzlq/G8DnAPQA/sU53ylzsxJlIoBfANjO3MsmATwM4IZAP/Ma0gvAR+6fawOAtznn/2OM/QhgGWPsFgi7C86SsY2Sc38YuRi+72fA329yo2VWhBBCiALREDchhBCiQBSgCSGEEAWiAE0IIYQoEAVoQgghRIEoQBNCCCEKRAGaEEIIUSAK0IQQQogCUYAmhBBCFOj/A1UgoBIlfNCkAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAegAAAHSCAYAAAAnsVjHAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAB85ElEQVR4nO3deXxU1fk/8M8zSyZDEjIsCSQQVtllNQJWcQG3Finot6LWturX1vZb7dflVxWUKipaLP26tFarXRTrAmgVRdwQBOIClE2WBAJhC0lIwjKBhEkyy/n9cWcmk8msmTtzl3nevnyF3Llz7xkS5plzznOeQ0IIMMYYY0xdDEo3gDHGGGMdcYBmjDHGVIgDNGOMMaZCHKAZY4wxFeIAzRhjjKkQB2jGGGNMhUxKNyBQz549xYABA5RuBmOMMZYyW7ZsOS6EyAs+rqoAPWDAAGzevFnpZjDGGGMpQ0SHQx3nIW7GGGNMhThAM8YYYyrEAZoxxhhTIVkCNBHdS0S7iWgXEb1NRJlENJCINhLRfiJaSkQZctyLMcYYSwcJB2gi6gPgfwEUCyHOBWAEcCOApwE8K4Q4B8ApALcnei/GGGMsXcg1xG0CYCUiE4AuAGoATAXwrvfxxQBmyXQvxhhjTPcSDtBCiCoAfwRwBFJgbgCwBYBdCOHynnYUQJ9QzyeiO4hoMxFtrq+vT7Q5jDHGmC7IMcTdDcBMAAMBFALIAnB1rM8XQrwihCgWQhTn5XVYp80YY4ylJTmGuC8HcFAIUS+EcAJ4D8CFAGzeIW8A6AugSoZ7McYYY2lBjgB9BMBkIupCRARgGoBSAF8C+JH3nFsAfCDDvRhjjLG0IMcc9EZIyWBbAez0XvMVAA8CuI+I9gPoAeAfid6LMcYYSxey1OIWQjwK4NGgwwcATJTj+owxxli64UpijDHGmApxgGaMMcZUiAM0Y4wxpkKq2g+aMcbU5vMta+GqNCEXNtjFKbzneAubnF/5Hx/cdTCWX7vc//2CDQvwTvk78AgPDGTA9UOvx7zJ8xRoOdM6DtCMMRbG51vWIqMyF9lkAQB0ox74SZdfQJwV+I/zawBAxekKjF48GjaLDT0sPVBxusL/fI/wYOnepQDAQZrFjQM0Y4yF4ao0+YOzj4UycW3mTf4A7WNvscPeYg95nWV7l2H90fWoaaqBgQzwCA8Ksgpw94S7MX3Q9GQ1n2kcz0EzxlgYubCFPN7d0COu6wgI1DTVAJB61QBQ01SDOSVzsGDDgoTayPSLe9CMMRZGA+ywoXuH4yc9J2S7R+AQeOD8NYFgIhOcwhnyeTcMu4GHzXWOAzRjaabmscdgX7IUEAIAQFYrCh5/DLkzZoR9TsOKFah98im47XbpOTYbCh5+KOJz9MBU5EJLZTMslOk/1iKa8X7z27LeZ+nepXhn7zvwwOM/JiDCBmffcwCe29YzHuJmTIMaVqzAvqnTUDZiJPZNnYaGFSties6eMWNhf3uJPzgDgHA4UH3/AygbPgJl4yd0uFbNY4+h+v4H/MEZAITdjuq5D8V0Xy278rxL8a+zr+CEux5CeHDCXY9/nX2lw/yzHAKDc6x8QZrpE4mAf6hKKy4uFps3b1a6GYypWsOKFaie+xDgcrU7bj5nMM756KMO59c89pgUlONgu+lGFDz6qHSv+x8Ie56psBBD1qyO69paM3rxaKWbENHOW3Yq3QSWICLaIoQoDj7OQ9yMaUzNk091CM4A4NxfgbKRo2Ds2hXuhgaYCgpg7t8Pjm83xH0P+9tLcHr1Gnjq6iKe56qpifvajLHYcIBmTGNEwFBzBx6PfyjaVV0NV3V1p+8TLTgDgKmgoNPXZ4xFxnPQjLFOy77kYqWboFsEgpnMEc+Z3HtyilrDlMABmjGNoS5dlG6CX8P7y3WfKGY1WhW5b++s3tj6s63YectO7LxlZ4dgPLn3ZPztqr8p0jaWGjzEzZjGqCmxUzQ3o+7Z53S73GrlgZVwiY7z/alwrOlYu+85GKcf7kEzpiENK1YADofSzWhHz4liz299Hk5P+LXIkRhgwA3DboDNYuvU84kIKw+s7NRzmT5wgGZMQ+qefU7pJnQkRMxrsbUmuBcbD4vRgg/3fxi2Pnc0HuHBnJI5GLN4DJcDTVMcoBnTELX2Vl3V1aj53SO6C9K9s3p3+rkOtwMOd+KjHQICS/cu9QfplQdW4sp3r8SYxWNw5btXci9bxzhAM6Yhal7W5JuP1pO7J9ytdBP83il/BysPrMT8b+ajpqnGvwHH/G/mc5DWKa4kxpiGRKvspQZks4Vcq63V+t0T35goS09YDmYyh6zPXZBVgM9/9LkCLWJyCFdJjHvQjDFZhSukIux2VN//AGoeeyy1DUrQo997VOkm+IXbPCORuXKmXhygGdOIhhUrUPPQw0o3I2H2t5doaq56+qDpSjchqkTmypl6cYBmTCNqn3wKwtm5JT9qo7W56oIs9c79A+qaK2fy4QDNmEa4I9Xg1phEaoQr4eK+6i5pOrdkLmd06xAHaMZY6hmNSrcgZisPrMQH+z9QuhkR+TK655TM4TXTOsIBmjGNIJtN6SbIx+1WugUxe37r82h2N8t+3YKsAiycslD26y7duxQT35jIvWkd4ADNmEYUPPwQYNDHP1lTYaHSTYhZsjKk++f0x+83/j4p13a4HZj31TwO0hqnj3/tjKWB3BkzUPj0QoBI6aYkzFVdjbJR56p+ydWCDQsgkJxaERuObUBDa0NSrg0ALuHC81ufT9r1WfJxgGZMQ7RW5CMitxv2t5eoNkgv2LAAS/cuVboZCalpqsHY18fyvLRG8XaTjGkM5eaGLQaiRfZl76DgUfUUA/F5p/wdpZsgC4/wtPug8U75O/AIDwxkwPVDr8e8yfMUbB2LhAM0YxpjAKCdFKsYqDRhzCM8SjchJgSKaRg+eDQgMHBzkFYnHuJmTGPcDcmbt1SESpdcGUgbb4+JzpHrZaRAj7TxG8gYAwBpvlZFG9zIwTb7eqWbENL1Q9XZLrlpZaQgHfEQN2MaUfPYY7C/vUTpZsjKesFkVc4/A23Dvr45W73SykhBOuKfDGMaYV+mv6FIy4ABSjchonmT5+Gpi56C2WBWuilJMzBnoNJNYGFwgGZMK1SaTJUINS+z8nl+6/NwerS5SUkXU5eo51ScruCCJirFAZoxrVBpMlWi1D4yoOW9ls+6zsZ0Hhc0UScO0IxphFqTqRKm8pGBdNhruaapRukmsBA4QDOmEQWPPgrbTTcq25M2mUBmmedjVT4ycPeEu3U9B+3Dw9zqwwGaMQ0pePRRjNi9CyP2lKFw0R9SuukE2WwwZmdDOOWdj1X7yMD0QdPxxIVPwGaxKd2UpOJhbvXhAM2YRuXOmIEha1ajcNEfQJmZSb+faGyEW+YSo7abblTtMqtA0wdNR8mNJbhh2A1KNyVptDzXrleyBGgishHRu0S0h4jKiOgCIupORKuIaJ/3azc57sUYay93xgwUPPF48nvTLpe8O2kZjZoIzoHeK39P6SZEROj8zycd5tq1Rq4e9PMAPhVCDAcwFkAZgDkAVgshhgBY7f2eMaZlMlYxU/vQdrAFGxbAKdS93EpAIDcjN+7nZRozcfeEu5PQIpaIhCuJEVEugIsB3AoAQohWAK1ENBPApd7TFgNYC+DBRO/HGGuvYcUKVM+Zq/ps6GBa6j2vPLBSM1tPxrPHNIHQO6s37p5wN6YPmp7EVrHOkKPU50AA9QBeJaKxALYAuBtALyGEL3f/GIBeoZ5MRHcAuAMA+vXrJ0NzGEsvNY/O11xw1ho9JlDlZuTiq5u+UroZLAI5hrhNACYAeEkIMR5AE4KGs4UQAgi95YoQ4hUhRLEQojgvL0+G5jCWXsTZ2IpRqE3DihVKNyFmekugMpEJcyfNbXds5YGVuOjtizB68WiMXjwaU5ZM4aVXCpMjQB8FcFQIsdH7/buQAnYtERUAgPdrnQz3YozpRPWcuZoJ0npLoPqvof/Vbkh75YGVmPfVvHbD4/YWO+aUzMGCDQuUaCIDQEKGpA8iKgHwcyHEXiKaDyDL+9AJIcRCIpoDoLsQ4oFI1ykuLhabN29OuD1MP8o3HsO3H1Sg8WQLsrtbcMHMwRg6SV9vlokqGz5C6SZ0GnXpguFbtyjdjKhWHliJuSVzE957WS0MMEB4/zOQARaDBQ63I+z5Nwy7wb+7F5MfEW0RQhQHH5dru8nfAHiTiDIAHABwG6Te+TIiuh3AYQCzZboXSxPlG4/hyzf3wNUqbfXXeLIFX765BwAiBul0C+pktUI4wr+5gki1e0hrZXje19t87JvHIgYyrfCgbftMj/BEfU1L9y7F+PzxnEiWYrL0oOXCPWgW6B//bz2am1wdjmd3t+CWpy7scHzdW3uwa311h+OmDAMuu3m4boN0w4oVqL6/4+AUmc0oeOpJAEDNI49GDuIKGrGnTOkmdMrKAyt1E7BjwUllyROuB82VxJgqrXtrT8jgDEg96VDnhwrOAOBq9eDbDypkbZ+a5M6YIVUTs9n8x4w2GwqeehK5M2ZIB1T0QbwdOQufpNj0QdOx6SebsPOWndh5y04UZBUo3aSkamht4PnoFJNriJuxhAUOTUeS3d3S4diuktDB2SfaNbUud8aMtmAcpO7Z5yCam+O7oNEIeDxJD+y2G/VTOvPuCXdj/jfz0eyO8+9aQ3ioO7V4iJulXPAc8YBze2Dvxlo4W2Jfyxs4t1y+8RhWvVoa0/MsWUZcPHuYboe7QykbMVKVPWit1OGORzoMe3cxdcHGmzdGP5HFjIe4mSr4Er98PdrGky3Ytb46ruDse96qV0vxwbNb8cXi2IIzALQ0ubHqtVKUb9TXulafhhUrsG/qNJSNGIl9U6ehYcUKmArUN/RKmZnoMmGC0s2QnW/YW8+bapx1aSOxTw84QLOU+vaDCn9WthyO7rVDxHs5Aaxftle2NqhFw4oVqHnoYbiqqwEh4KquRvX9D4C6WFOy21U8RHMz6p59TulmJM28yfN0PyfNko/noFlKqWUuuKVJ6rGXbzyGkmXl/oQ0LQ+B1z75VMi9mp37K2C9YDKch49IwVsly65cNTXRT9KwuyfcjTklvEcQ6zwO0Cwpwq1Fzu5uUU2QLt94DKtfL4PH3RasWprc/vlsrQXpSHs1Ozb9B4ULf4+aJ5+CkHlP584y5sa/65KWTB80XZcB2gADRi8eDQMZ4BEeFGQV8GYbScJD3Ex2oeaZv3xzD8o3HsOAc3so3Lo2JcvK2wXnQGve1Oba3LDcblTPfUg1wRkA5JvoUC89zkX7ipx4vHNLNU01mP/NfK7bnQQcoJnsQs0zu1o9KFlWHnatshLCrbMGAHer8kPA8QpcBx2SK/zrVYJoiH1bRK2aN3kebhh2AwwkvdUayKDLoN3sbtbljl9K4yFuJrtwQ9iRAiJLXMHDD6H6gQdVMb8cC9L5ELfPvMnzOtSx/uzQZ7C32JVpUJLobccvNeAAzeKy7q092P1VNYQHIAMw6qJCXPLj4e3OsWQZ/UlYahaxnRoscOUrVFLz6Hxt1LhuakLDihVhC6zo2ZyJc3Q3P623Hb/UgIe4Wcx85TR9y5qEB9i1vhrr3pLmlxc/9DX+8qs1mgjOpgwDLp49DIZwH1EF8OKv12DdW3tS2q5E5c6YgcyxY5RuRkyE06nrpVY+Kw+sxJXvXokxi8fgynevxMoDK3WXUJVpzMTdE+5Wuhm6w5XEWMxe/PWa+NccqxAZpA8XBgPB44n++3/uxR1HCdQq3MYZqkWEEWWxF5rRmpUHVuq+/KeBDHjqoqfi+tCxYMMCvFP+DjzCAwMZcP3Q69N6O0uuJMYSpofgDLS9jliCMxC9zreSgiuH1T75VOpuTgTbTTcmtOGFGqucyen5rc/rOjhnGjM7FZyX7l3qzwL3CA+W7l3KG3GEwHPQLCZ6LY0ZE/UMMrXTsGIFan73iH8jDFd16j9I2N9eAkDaPavXww+h7tnnYm4HZWYi/957ktg65ek9cWpc3rh2wXnlgZV4fuvzONZ0DL2zevvXRwf2mMPhjTg64iFuFpVvXbOcJTq15s6/TlW6CR3smzpNkaAcDpnNyCw+D45vN4Q/ybtLlqmgAPn33qP7BLEr370SNU36rpg2ufdkHD5zOOTrzDRmok9WH1Scjm27VxOZsOCiBWkXpHmIm3Wa3PWztUiNyWJqK5UpnE44Nv0n4jmFC3+PEWWlGLJmddTgHGrjD61Jh8SpDcc2hP0Q0uxujjk4A4BLuPD7jb+Xq2maxwGaRaWW0pxK2rW+WnXD/Embv/XOLRcu+kP8z3WHz+C3XjA55h6zb/g+cOOPmt89orkgPX3QdF0WJkmmhlb9F7CJFQdoFlV2d4vSTVCFbz+IvSeQCvn33pNQglZYQuDMJ5/KugSKrFYMePXVmM+ve/Y5/9y6v1ka3QFr3uR5WDhlIWwWm9JN0QzfcrR0x0liLKoLZg5O+zloQH0jCbkzZuDs1q3+RC05ue12QMa63bmzZsZ0XsOKFRETzdQ05x6P6YOm++dV02FeOlG++t4AsK1uW9ouyeIkMRaTwN2p0pkat6OMFtTUwFRYiCFrVod8LN722266EQWPPipn81Jq5YGVuqsiliwZhgy0elo7HL9h2A26CtLhksQ4QLO4/OVXa5RuguLICFz+s5GqCtJAhKxuNez/HKYgSfBSsVivVfiHpzWdAT568Wilm6ALNosNcybO0XzWN2dxMyYT4VbffDQgzUlTZma7Y5SZqXxwRtvGGA0rVmDP5AtQNnwEyoaPQPX9D8QXnAFACE3ORTP52Vvs+N3Xv9PtfDXPQbOoeHi7IzX+Xfh6lHXPPgdXTY1/rbEahr8N8JYhnfuQLNteKv16mHo4PU48v/V5zfeiQ+EAzSLiIiWhqTWzPXfGjJBDv3EPI8vM3dAg9Xrl2pPaaJTnOgopyCrgRDEZ6fXvkoe4WURcpCS0C2YOVroJMcudMQMFTzwOU2GhNB+tRHDzrmWWTYT11lqQDgVMUk2Pw9wcoFlEahzKVdq5FxeqLkEsmtwZMzBkzWqMKCtF4cLfd5ir1hpTYaHSTUjI9EHTMbn3ZKWboSvPb31e6SbIjgM0i0itQ7lKMFuMuOK2kZrZejIcX49ay/Swycbfrvobbhh2AwwkvQ0TCGYyK9wq7appqtHdjlg8B80iumDmYHzxeilEwIgiGdHue10j4Ipb1bekSg5kNkM4nUo3I262m27U9BKrQPMmzwu7npeXYsVv6d6lAKCbNdLcg2ZRESji97om1LmkKlF1zz6nyeBMVqumi5TEoyBL33tlJ8s75e8o3QTZcIBmEX37QQU87vbraIO/17vGky2q2ygjUWrbCStWwuFQugkpc/eEu5FpjJwrUJBVgIVTFqbXh+YoIu05rTU8xJ3m1r21B7u/qobwAGQARl1UiEt+PJzXPgdZ9Wop1rxZhqk3j9DFcLepoIDXEqucb13v81ufb7eMKFQ96uBz0plvTl8POECnocCgHEh4pG0V7bVncezgaV5eFcTdKvDF61K5Sq0H6fx770HNQw9rb5jbalW6BSkVuMlGJHdPuBvzv5mPZrdya93V4vqh1yvdBNlwgNaBwN5udncLLpg5GEMn9Ub5xmNYv2wvWpqkjK7MLBN69s3G0b32iNeL9ng6E25g/Vtlmg/QuTNmoObJp2TdsSoVSOPrn5PFF8TnlsyFQOgpKKvRCodb31MEettEgwO0hgUHYECaL/3yzT2oqbBj99fV7bKtm5tcHHxl0NLiQfmH2zD0h+OVbkpCREOD0k2Im2jtuLMRk/iC9O++/h2cnraREbPBjOuGXIcP9n+gVNNSItOYifH52v43GYwDtIYE9pQzs0xoPutCqA/LrlYPdq3n+cXkIXy7uh5Df6h0OxKj1XnohhUrdLPMSm6B89bHmo6hd1Zv3D3hbjy/9XndD383u5t1V5ObA7RGlG88hlWvlfoDcnOTTDWNWac0tmivFrR/32XvRhrZl1yMhveXK1qjuzPqnn2OA3QEoeat55bMVag1qXWsSV+rLThAq1TwvHJTQ0vI3jJTRrZFW3Ohwfsuu6qrYX97CcznDIaz4oAqtqSMlRZ7/UrrndU7LbK8e2dpOzckmH7y0XWkfOMxfPF6qX+JU+PJlvSp3KUBJoMHF0zLU7oZcal79rmQPWXn/gpNBWcAmt/JSgmxrKnWukxjpu42IeEArUJfvlnGAVl1BACBbIsLl13dQ3MJYlotTBISZ3LHbfqg6Zj/vfkxVSfzFT+JtZJZbkYubBZbgi2MXxdTFxRkFYBAKMgqwPzvzdfV/DPAQ9yKCbc06oNnt8LVqrEeTVog3PnXqUo3otO0mhAWitZ3slJK4Nz0ygMr8VDJQ/CgrdaBAQY8NeWpdku2QiEQdtyyI+RjqaofbjaY8cgFj+guIAeTLUATkRHAZgBVQohriGgggCUAegDYAuCnQgheIwEpOH/55h5/IRDf0qjNnxzEqWP6XqeoZeXvLse3a11odNmQbbLjgktNGPqjWUo3Kyb5996D6vsfULoZCaPMTF3sZKW0cNnegQEv3Ly1UvO8NosNDS0NIduqV3L2oO8GUAagq/f7pwE8K4RYQkR/BXA7gJdkvJ/mlG88hpJl5SEzsF2tHkWCc1rtTJUQgS9XW+AS0q93o6s7vlzdAmC5JoJ07owZOPXee3B8u0HppiQk99pZnMEtk2hVykJVJ1NqnldvBUhiJcscNBH1BTAdwN+93xOAqQDe9Z6yGMAsOe6lVeUbj2H162UJLY/q0lX+vWI5OMfOJSwdvv92rXaWuw149VXYbroRIO1urNC4br3STUgbgfPWcszz3jDshk49b+GUhWkZnAH5etDPAXgAQI73+x4A7EII37vXUQB9ZLqXJoXaFSpeZ09rrG5yGmh02ZRuQvy0lrUdwFVdzYVKUijWWuA+Nwy7wb8nc/DxFRUr4r6/gQxpMZQdTsI9aCK6BkCdEGJLJ59/BxFtJqLN9fX1iTZHtXhXKO0yZRiQaWgK+Vi2yZ7axiTIvkz7e+VW3/8ADt12m9LNYCHMmzwPNwy7wb+jlIEM/uHps66zYZ9nNYbeBEVPG190hhw96AsB/JCIfgAgE9Ic9PMAbERk8vai+wKoCvVkIcQrAF4BgOLiYu1+tI+CDOiwexRTIQL6DrXBXu9ol2GPyg34cnVLu2FuE7Xggks1thBCJ0uUHN9uQNnwEf7vbTfdiIJHH1WwRcxn3uR5cQ9Jb/rJJizYsADvlL8Dj/CE3FIzHSX87iKEmAtgLgAQ0aUAfiuEuJmI3gHwI0iZ3LcA0Hel9gjWvbWHg7PKBS51C2nSLADL8e3aJk1mcfsZjboJ0oHsby8BAA7SGtaZwK53yfz4/yCAJUS0AMA2AP9I4r1UqXzjMaz5VxncLt0ODOgCGShycPYa+qNZGPqjFDUqSWyzr/cHM7UwFRbKskbbvuwdDtAqFml+moUma4AWQqwFsNb75wMAJsp5fS0p33gMq14tVboZLAbCI7D2rb2a3+M5Fr4AppogbTbLV0BFhyMDeuLrHfMwduxIqCijs7i4WGzevFnpZsRswIABOHz4cNTzumf3wuM3v5WCFrFITBkUsUqbliuFdUbNY4+pJ1DLwWjEiN27lG4FY3Ejoi1CiOLg41yLOwGHDx+GECLk/y/8crX//5ONtUo3Ne2REbjs5hHRT0wjBY8+CrLZlG6GbGyz0zvjl+kPB2gZ2Ww22HT0hhfIlKHd4haWLCMu/9nItBjCjpdoaFC6CQkR3v85i5vpkcbWiGgIQVf7N2txAw8yAL9+sf2w9bkXF2LX+o5znudenJ4bMOhhE42ST/8bvxxwv9LNYEx23IOWga/n3NDQgIaGBthsNjzw2kylm5X2Qi1tu+THw3HuxYXw1lEAGaTgfMmPh6e2cSqRf+89oMxO7BNsUsdn+5b8LGQbu0Y/kTENUse/Mh1SU/JdrLr1tqbFblqX/Hh42gbkYL6SmXXPPhdfT9oVoga52Qw4ZSpHS4QRZdIqiH1Tp4VsmwBw5LaJmNhtijz3ZExluActA7vdDrvdjtzcXOTm5sJut2PRrR8q3ay4dOlqTovgzDrKnTEDQ9asTnyfZbmCM9CuXnioXr4AUD9jDEZefxeGZI+U776MqQgHaAajieBo5I040p2q9lk2Gv1/zJ0xAwVPPC59gCCCqbAQfRb9AZcsWsrBmekaD3HLyG63K92EuJGBMPWnI3RZVIX442dccmfMwNmtW2FfslTxHa+Cl0zlzpjBO1ixtMNvYWmMDMDlt4zA0Em9owYzMgBX3DZSU0Fv1EXpmZmdiIJHH0XhH55WrgFGIy+ZYsyLe9AJ6N+/P4iirw/unt0rBa2Jn/DAvzZ41EWhlx/5jLqo0H/ul2/ugas19O4fZosRBhPQ0qR82UVOBOuc3Bkz4k8aSxQRCv/wNPeSGQvAAToBhw4dCvvYB89uxdG99qTdO5btKy1ZxoiBMrt729aJvmC2+6vqdtclgxScfY/7gvS3H1S0244xsAhI+cZjWP16GTzuTgyTyrR+PPC1sfjl33sPan73CERzc2puqMFVD4wlG9fiTqLgIE1GQMjQsfQV4Fj31p6wvd4rbpMqZ5VvPIZVr5V2CHoGI2Haz0YkrbpW+cZjKFlWjuamEMtxfHyDD6Ltg0DBYFu74D/g3B44tOsEGk+2xHV/3+tnndewYoXUk66pgamgwJ9EVj33odDLrBJkKizEkDWrZb8uY2oXrhY3B+gUKt94LOLwcKwCC2use2sPdpVU+wOwKYNw2c0jOvRo1y/b6+9NZ2aZMGX20JQHsPKNxyL2vON5fiTpXHgkVWoeewz2Ze9IO0gZjSCjEaK1NbGLBqx9ZiydcIBWifKNx/DF4tKow9NAW/lJ37Bz8HBzuvrLr9aEfYx7zsooG574RiTcg2bpKlyA5jnoFAuXaEVGwJJpQnOTq0PvMt0DcrBw8+9kAAfnJDt0221wfLvB/731gskY8OqrsV8gTLUxysxU1zpsxlSAA7QCYkm0YuGFyzjnZVXJFRycAcDx7QYcuu02kM0GEakOgNGIwoW/92dph5rf5gxuxtrjIW6mSeve2sND/ykWaRi7cNEfUP3AgyGzsclmQ8HDD3EAZiwMHuJmusIbXqiLL/jWPPmUvydttNnQiwMzY53GAZoxJgsux8mYvDRUuJExpiTrBZPjOs4YSwwHaMZYTAa8+mqHYBx3FjdjLGY8xM0YixkHY8ZSh3vQjDHGmApxgGaMMcZUiAM0Y4wxpkIcoBljjDEV4gDNGGOMqRAHaMYYY0yFOEAzxhhjKsQBmjHGGFMhDtCMMcaYCnGAZowxxlSIAzRjjDGmQhygGWOMMRXiAM0YY4ypEO9mxRhjaaKy3oHdlY1wtHpgzTBgVFE2ivKsKW9Hye4TOH7G5f++Z44JU0b1SHk71I4DNGOM6VRgQM4wEZwuAeF9zNHqweaK09hccdp/vpGA8YO6JjVoBwdnADh+xoWS3Sc4SAfhAM0YYxoXHIiFEHC625/T6hKhnxzALeAP2MkK0sHBOdrxdMYBmjHGNKyy3oFtB0/D7ZG+jyUQR7O7srFDgN5+oAGH6pohABCAAfmZGDcoN+F7sfA4QDPGmMpECoaBvWWzER16ynJwtHo63CuQAHCwrhkAOEgnEQdoxhhTke0HGvzBD2gLhmcc0hBw4FBwMoKzz4ebav298nAO1jXHHaB75phCDmf3zOFwFCzhZVZEVEREXxJRKRHtJqK7vce7E9EqItrn/dot8eYyxpi+HQoIzoGOn3GldJ42WnDurCmjenQIxpzFHZocH1lcAP6fEGIrEeUA2EJEqwDcCmC1EGIhEc0BMAfAgzLcjzHGdCvxGeTYGQ3JC8SBQi3vmjIq9cu7tCbhAC2EqAFQ4/3zGSIqA9AHwEwAl3pPWwxgLThAM8aYKlgzDB3mluNloPbfhwrEALD1wGl4vJ88fMu7Tpxp5fnrKGQd9CeiAQDGA9gIoJc3eAPAMQC95LwXY6r20X3AltcA4QbICJx3K3DNM0q3iqlcZb0jJfcxGoBRRdkhE8Di0T3bhJWb60JmjvsCsYHgD86BOMksOtlKfRJRNoB/A7hHCHE68DEhhECYkRsiuoOINhPR5vr6ermaw5hyProP2PwPKTgD0tfN/wAezwN2LJPnHjuWAc+eC8y3SV/lui5T1NYDp6OfJINuWSYU5Vn9PdzOOn7GFXVZV6jg7HOwrjllH0q0SJYeNBGZIQXnN4UQ73kP1xJRgRCihogKANSFeq4Q4hUArwBAcXFxKqdfGJPXjmXA6seBhsrQj3tageW/lv48Znbn7+P7AODTUAl8cGfi12UpFbyUqkeOKWIwk9PxMy5U1juw5+iZ1NwwglBrrpkk4QBNRATgHwDKhBCBY3gfArgFwELv1w8SvRdjquEPxkcBazfA0QAghjUvHifw/q+kP3cmmO5Y1j44+7hbgU8ejP+aga8jty8w7REO8ikQXO5SIPWVtAJLfCrJ0erB+xtqOySsGQ3A+IHJLTuqdnL0oC8E8FMAO4lou/fYQ5AC8zIiuh3AYQD8r57pw45lwIr/BZzeoTnHyfieL9zS84H4g+Hqx8M/Fm87diwD3vslAO+7YkOl9/tOtIvFrLLewWUtQwjOJnd7gC1JLjuqdnJkcX8FaYQmlGmJXp8xRQX3MIdc2Zb8lQinQ7puvIGw4Whi9w204h74g7OfRzrOATppdhxWflhZKwTSewic94NmLBxfT7mhEoCQvgYmfyWqoTL+BK/cvuEfs3aP7/7OpviOM1nIUSs7nSS6FEzLOEAzFs4nD7YNYydLQ6WUOBZrkJ72CGDMCPGAAfj+09GfH5j9zVJu+4GGiI9bjClqiIYQgPc31OLTrfVpl/HNxU8ZC7ZjGfDRPUBrinqSHmfsCV6+cz55sG3O2dpdCs7Bzw/MKidj7D1/kvlzO68JB9CxxnYoLUmsra1VgftXbzsozUmfONMacjMRve24RdISZXUoLi4WmzdvVroZLJ3tWAYs/xXgUeCdcn7k3lVcghPZ4lF8O9BvsjzZ3cFLwnx6Dgfu2hj/9TRs+YbalJbx1KtwhU+yLYTGlo4PaKHONxFtEUIUBx/nHjRjgT08Jcm55Kmzw/MDL5GC8wd3Sku3AG929y+AIxvi7/lueS308eN7pL/3NOpJc3CWR7i14qGCMyAtX3t/Qy0IwHmDtbVsi3vQLL2F6+GpggG47mXpj+GGtEMF9SMbOv+acoukof1IS7Zyi0J/ePjoPmDzP+EPRRlZsU0TpElv+v0NtUo3QRYEbX/YKFZhkA7Xg+YAzdLbY92V7zlHYsiQ3hF9vVn/cTMw4WfAd2+17ykbMzqem5R2mQFLDuA4JX0w6D4IOLiu89fLLgCMJl0XTNFLgB6Ynxl1Ll3NrBkGXD0hT+lmtBMuQHMWN0tPO5apPzgDUnnQUAHX45SGj4OHsVMRnH33d5yEf/lZIsEZABpr2i9ne+8XwOIfytFSVZAz+zh4L+VU6plj0nTSFaCtZVscoFn6WfxDKQCoPThHo/X2R3NwnTRsrnGV9Q5/9nGiCKkvCepjJPiTrawZ2g0dWmq7dlrKmBw+ui/x3h6L38BLpCVW8QqXZKYhuysbO5Sx7CwlJyTdAli1TdrzqLct1Fp8bUh0B69U4ixull62vKp0C+JjyQWcjcos+5LTwRKg+Lb2SWSxEG6psIqG56TlGFK1Zhjg9gjFq5A1tghNz6UHJohpYc10egfoFR8A1dVt3xMBl00FhgwN/5x95cCmjUBjI5CdDUycFPl8ph47lgFCO/NPAICWBoQvdR9Mzfm1ns5nlmt4O81olcNiMTA/Ez1yMlSz+5SWBQbnwEQ3AWlv6vqGFlwxPl+h1nWUflncwUE5FEsmcOGFHQNvyTqgtDT0czhYq9+z54bfq1nr4qkUplXW7sCDB5VuRVzkKk4SvBUji19g9nakn8tABXrSnMUNxBacAaClGVi/Tuot+0QKzoDUo/5yTfvnMHWRcycotdF7cAakrPGnB8a3uYjC5Or+cHBOXODcc6Sfi5qWkKXHEHfgsHSsXC7pOUOGSs+PFJx9hAC+/iq2XjQPlaeetVv8eyaz1LJ2j/wzcpyUNhcBNDHcreZJh3TSM8fUrjiJVn4u+g/Q+8ql3rCrE0sTfAF9UxxVjlpapK/hetxEQG4uYLe3v8+a1dL/HKzlpZYyniw2Dnv0czzOzu2lrYABGi/qoXUEoEeOCU0tHry/oRbWDANGFWVr5uei/yHuTRs7F5wBwGKRvsbT8waApW+H73EL0T44B/MF69dfi++erCNfGU8OzhoS41iuRqYrxg3KxcD8TKWbkZYMJNXePtno8mfSO1o92HrgNHrkaGOZmP4DdLzBNVBrq9QDz45z3VykABwrh0MK9KzztLakisUut6/SLYjZuEG5uHZyL1w7uVfK7hlr3r+eeQSwueJ0h801PALYcfiMMo2Kk/4DdLzBNZAQUg984iTAoMBfld0OvPJXabicxUeLS6pYbMgImLOA+blt/+uoLGiijAZpWFdrjCl8i1V6PXms9B+g+/VL7PmNjVKQ9ij0Zi+ENFzOQTo+qx9XugUsWYRb2q4y0MF1mgjSqejZuj3KlQNNhJoy1ZdvqMX7G2rx6dZ6Weuox0v/AfrIkcSvEThMbjIBI0e2zU+nSllZau+ndRqZo2Qy0kAJ1wE8H60Jvv61o9WDzRWn/SVOU03/ATqROehQXC4p6N/638Av/0fKyk4FFRWU0QQNzVGy9KGV5CTWXmOLQMnuEym/r/YmKmKRyNKqWPiC/r5yKUCHCp4jRwJTLole4CQeb/6L103Hatoj0o5VjKnI7kqZOwwsZZSYNtBfD3pfuVTRK1nB2efll6TlUOHmpsvLpbZMuUTqaf/yfxK/p++DgW8p1ooPEr+mXmlgjSxLP1rai5gpT38BetNGdQwH+yqRBUokozyU6mrg769wedFwzFlKt4Cl2uN5qi4FqqW9iJny9PfbIveccyIaG6We9ssvAa/9U8ooN8k8q+B2S71pDtIdzXgOevwVZxF4WqWpjY/uU7olIWlpL+J0FCmjqKcCS9f09+4ldy9VLi0t0ly0QOQMcKL2j1tizPpctzaR1unTmNnAdS8DuUUASPp63d+kdbRM3zb/U5U96cB60Ex5RgNg9r4dWDMMOG9wV1w7uVeHYNwzx4Qpo3qkvH36227SNwetotcVt+D56tdelXbYivd5LLT56tqUnSWJOQtwNUvrpskInHcrcM0zSrcKJbtPxJxwlGEizRTV0AslgnH6bDc5ZChw2VT5h5KVdOGFqVvOlQ64B50enE1tddiFW6rLroKh73je/Pt0t6S0wlawgfmZaVdL/PgZlyqKlAB6DNCAFKRv/4V6h7vjpccPHUo671alW6AMa3elW6C8La8p3QIAQPHgrjGdd6iuGd2ylPt33yMnA4c0sOtTMviKlGw/0KBYG/QZoH0mTtJeUBs5MvRx34eOcI+HO846uuYZdWR4W1I81O44BZC+/8lHI4QbFa/+UulmoCjPiuLBXWGIMjAmoGzZzt2VjZrYNzmZDtY1K9aT1ve/1iFDgYsvUboVsfMVN4lkyiXSeb4hb6LYnsfam/EcYFY4YafldGrvl9sXMKV3khIBGHRoiWqC9MxJqd3lKl68bluiVIEZjXUvO2HIUOBYjXzVvJLBZJI+SMRaGWzKJRyQE+UrZPLJg4DjpEKNSHHfZNojwHt3pPaeKkQE9D+8DMDLSjfFz2hIzmYRPXNMne6BGwiwmA0cpKHcBxV996B9gnudahNPcGbyGTMbePAgMDDChx29JJQNvER6velUo7z49rCLOYwq2oq0st6RlOBsIGBAfpeY57uDeQTQ6lTP35OSMkzKxA79LbOKldqWYxEBI0YAvQukCmSdrbldsk7a+UqItmtybzu6j+6TEoiCl+TsWAas+F/AGWYOKiMLcLUCHmcqWxufgZcAt3wo/Tna69ELa3fgwYNwze8GEzoGGRcMMM0/pUDDOvp0a73qe6kGkgJ2uiIA5w3umrR17OGWWaVvgAaSv6mGnHzBFggfgMNtzBFqjpoDeex2LJP2l244KvVApz3Svtb3jmWdGyo3W1MTKHOL2rc5+PU0VCa/DUrILUKtqQ/yj29oN3gmBHBgwI0YfJs6hrjf31CrdBNiQkj5pIyqWDMMuHpCXlKuzQE6nH3lUqlMLfMF4Ff+Gn5EIDAIhwvkNhvQ0MBBu7OeyAfcLaEfs3aXAjgZpV66L2iufjw1AdJgBma9GHoTET0XbjFmoNY2AT1ObIJReOAmAw73n62a4AxoowfNJMlK6OMAHYlvG8d0YDRK9btjxRnisduxDFj+K8AT9PdbfHv4ClapHHL2Dvt28PRABRPlUiAjC3ioWulWhFVZ78C2g6eTMg/N5DUwPxPjBsn/gTZ9Kol1xsRJ6k0gk1s8wRmQhsFZbMbMBmb9tWPt70jlJcfMBmb8yfucJAsXhL//NGDMCP2YQQdJcq1NqqzL7VOUZ8X4gZ1L5GKpdbCuOaWFSzhAA1ISlm9+l7WnohEWTRgzG7h3FzDfLn2NZV9q33OU2shjzGxg5l/aPiT42pBbJH3gKL5d+9ns7/1C9UE6TboImncwhZXV9L8OOhb7yoFy3q4xpHQZWVCDZK/NjlTqc8zs8B8mxsxuGwV49lztJpW99wvpaywfmhQwID8z5Jv/wDDHmXIq6x0p2ZmMe9CAtKwp1kxuo8Z7EvESQtrLmvebTg3f2uz5DdL/cvr+04lfY9oj2u5Nr35c6RaENW5QLgbmZ/p70gSk3UYVWpGqymJJ70ET0dUAngdgBPB3IcTCZN8zbrEmiFks0r7O6aalRVozDnBBlVTLLZKvxypHz3HM7LaeqBY1HFW6BRGNG5TbIQlpuYzLsJJVsSwd9D15BKOO7YbV6YDDbAVyvpf098Ok9qCJyAjgLwC+D2AkgJuISH27OsS669Xgwclth5oJIY00sNSa9og8NcNTkYSmBRqspCZnFkhngjNPcknBefzRbejidIAAdHE64Fm7Nukji8ke4p4IYL8Q4oAQohXAEgAzk3zP+IXa9SrU3Gt5ufZ2x5JTY6O0JI2Hu1OnXZY3SfPI8e7EZbZKgZ5p8u9ByQAplQvNTPsgPerYbphE+xUwBo876Z2WZEebPgACx+eOApiU5HvGzzdM8fXXQIs3GSNU9rLLJQ1za6HyWLI0NkqFXY7V8ProVAmXwLVjGbDiHsDZFP65wVXE5JCRJS1d0hJDBjDrL6pNEIskXPJYsmWYCGP656Aoz4oeORn47tBpON1tj3W1GhXdCjOVrGHqFIjGxqR+eFG8O0hEdwC4AwD69eunbGPcMfyypeMcdCilpVLdcJ6TVk5g4I5WjlRO1zwXuiCLGkUqEqMRvjnpQ3XNSS+1ac0wYFRRdocM5aI8a8is5cp6B3ZXNsLR6oE1w4DetgxdZpw7zFZ0CRGkHWYruiTxvskO0FUAAie/+nqP+QkhXgHwCiBVEktye8KLJ5ObSTZt5ACtFpGWSSXjXkDbBwI1V2g+sV/pFsgiVPJYZb0Dmyvk2VO8uJMbQYQK3OMG5WqmvnisdvcehfFHt7Ub5naREbt7j8L5Sbxvsueg/wNgCBENJKIMADcC+DDJ9+ycdCn1KSf+O0tfgQVZMuKcE0+lg+uAxT9UuhVJUZRn7fRWkqGuJSdrhr5W8B7t3g/b+o7HWbMVAsBZsxXb+o7H0e7JHfVNag9aCOEiorsAfAZpmdU/hRC7k3nPTsvO5oATr1iz35m+qX3I++A6pVuQNEV5Vpw406q6YeVRRdmy9e7V4mj3fkkPyMGSPgcthPgYwMeJXuf06dOoq6uD05mkfXdHj5USxBQarTM7W5F/5DC6ntbQL/VE9eX7MQX4hry1vD5aw8YNyu2QxBWPnjnyhwG1fnDojAwTodUVOjAku5CM4klisTh9+jRqa2vRp08fWK1WULLKTzY3A2dSHyCFEHA4naiyZAL79mojSE+dxvPPrM2Y2cCRDcDmfyjdkrQUPBdcWe/AlorT7fobBCDLQmhsaTvaM8eEKaN6JKVNvg8O2w6chlvFaQrRjOmfE3K3sZ45pqTsbBVIEwG6rq4Offr0QZcuycyXA5CZqUiAJiJ0ychAn4LeqG5pRtddO1PehrgQcXBmHfmypbe8Ju15rRYD0285oC9YB2ZYh8rOTkU7fPcMzPjWCoKyf5eaCNBOpxNWa2p/sZRgNZvhNIfZ9k9NeOcvFs41z0j/P9ZdHUG653DgFnXmpSZbuKVRSom0VKuzw/PJNsA7hK3U36VmUu2SNqytIpp4jSNHcoESFt15t6buXmSUesmBu3VZu0vbd97F5WnVrijPimvO74VrJ/dS1eYgA/Mzkz6EHY0metAplWkFmkNXjWHg4MxiEzzcTUZgwEXAyQPS2mkyyNDDJmmZF9MNX0AMTC4zEuARqcnfNRqA8QM7tyY8GXQboIUQ2F5px99KDuDLPfVodrqRaTZi6vB8/OLiQRjbNzd0jzUnR/oaR5A+eeoUbr/nXny+bi16du+B3z/8EH78X/8l0ytREYtF6RYwLfENd4cy35b49TW48QWLLlRRls4UPjES4kpOCyxtqha6DNBOtwf3LduOL0rr0OJyw+P9ITmcbnyyqwZr9tTh8pH5eGb2OJiNIUb5c3IAs1laFy2iJzTcOWcOMjLMqN21G9t37cL0m2/G2FGjMGr4cJlfmcKcTmmjjOAEsZJ1QFmZVL+cSJqj5p42iyS3b2LbaBozNLnxBesca4YhruQysxG45vxe2H6gIepSL6US6GKhmTnoWAkhcN+y7VhVWguHsy04+3iEFKhXldbivmXbIUJtinHyhJTNHUNwbmpqwr8/Wokn5sxBdnYWLpo8CT+86ir86513ZHpFKuLxdNy9ZcUHUl1u39+jENL3JfotDsFkEO82moaA5Elrd2CmNje+YJ0zqigbwX0poyH0Gm4CMHaAVGFt3KBcFA/u2mFDi545Jlw7WZr3vnpCniqDM6DDHvT2Sju+KK1DszNycG12evBFaR2+O9qAcUW2tgfsdsAd+9xY+YEDMJlMGBqwV/TYUaOw7ttv4my5RgRWW9tXDlRXhz6vtJR70Sy84HregRt8pHLjD6YJkZY6BW/YEdwbVls2ezx0F6D/XnIQLa7YAmyLy42/lxzACz+e0HbQ2RrX/RqbmtA1qORlbtccnGnU2HZ8sQqct4+2F+rfX5E+7GRnS1XHeO00CxRug49UbvzBNCNcoNVyAI5Gd0Pca/bUdRjWDscjgNVldQndLzsrC6eDanifPtOInGwVbyAQaOq0+M4XQuo5A9Frl/tGIhobgbVftj2PMcZYVLoL0M1xrnZvjrG3Hc7QkaPgcrmw78AB/7Hvdu/GqGHDErpuyqzvxFzx+nVSsI1nswyPB/j66/jvxRhjaUp3ATrTbIzvfFPQ+fFU8sq0Iqt3b1x33XV45Omn0dTUhK83bsIHn36Kn15/fVztUExn9sB2uaTh7YmT2g95R9Oi/cL5jDGWKrqbg546PB+f7KqJaZjbQMC0EfntD9psUqJY8Fx0TlepVncIL774Iv77Zz9D/qhR6NGtO176w9P6W2IVrLGxbU55zerYn/fySzwnzRhjMdBdgP75lIFYs6cOjhiGui0mI34+ZVDHB2y2uO7ZvXt3LP/oI+DMmfSpQuYb3h4yNL4ADUjB3Te0zkGaMcZC0t0Q97giGy4fmY9Mc+SXlmk24PKR+RjbV8Zaqzk5QF6+VMZQ7/r1A978l9Qj7gzfMDljjLGQdBdJiAjPzB6HK0b2gtVshCFoitRAgNVsxBUje+GZ2eOSs0FFdjbQYWk8SXW+9aK0NHoWdzSJPp8xxnRMd0PcAGA2GvCnG8fju6MN+Nv6A1izpw7NLjcyTUZMG5GPX0wZhLGBxUnk5purbmoCPG7AYASysqTjLS0xVShLG/vKpZ50YyPPTTPGWABdBmhA6kmPK7LhLzdPiH5yMmRmhk4qy86WyohGYslMn4znwPlrDc5NL99WhUWf7UW13YFCmxX3XzUMs8b3UbpZjDEd0N0Qt+plZoYZ6iYpUzwnB7j1tvjWGOuJhuaml2+rwtz3dqLK7oAAUGV34J6l2zFwzkrMW75T6eYxxjSOA7QScnKkYGwIXIMtpJ71mTPAK38FunZVrHmK08jc9KLP9oZcLSAAvLHhCAdpxlhCdDvErXq+4e8zZ9BhK3IhpE0orFbAkSbLtgKpbPQgcBg712qG0+1BU2v0ZXxvbDgCAFgwa3Sym8gY0yEO0EpqbESH4ByoOU3moYNNnKR0C/x8w9i+nrLd4Yzr+RykGWOdxUPcSoqWzR1qr2q9M5lUlSAWbhg7Hm9tPCJTaxhj6US3AVoIgZNnnNhYbseHm2rx/oZafLipFhvL7TjZ6ISQMfi98MILKC4uhsViwa233irbdQHEV+taDy5W1x7SVfbEpxhi3V2NMcYC6XKI2+MR2FJxGjWnmuEO6KS6PUD1yRbU2ltQ0C0T5w3uCkNwJZNOKCwsxLx58/DZZ5/BEc+cMRmi96JHjJCKguiB0di2BWUoU6epqvcMSOVm5IivA+euhBCAkQg3TSriIW/GWFS6C9BChA7OgdweoOZUM7ZUAMXndE24mth1110HANi8eTOOHj0a+xOjrYnOzgameHuUZWXaH/KOFJyJVBecAXmCM9D2o3MLgTc2HMHB+ka8+YsL4rqGL1mtyu6AkQhuIfxf+/AabMZ0R3cB+lSjK2Jw9vEF6VNNXdA925yaxgXzZXI3NnbsSZtMUrJUyTp9BOdoCgqUbkFKfV1xEsu3VWHW+D4hA29wwA1OVnN7fx98X31rsDcfPsm9cz2r2QZUfA4024FMGzD4SqBgvNKtYkmiuwC9r6YpanD2cXuA/dVNmDjUltQ2ReSrONbcLJUGBdpKXh6r6dTwtkD7SuBCaGAq+3SU6moK6dbFjFNn48vcjtX970gB1ZfpDbQPuHPf24nNh0/iyz31Mc+Fv7HhCP695SgyzUbYzzq5upnWhAvAZcuBqqACPs12oOx96c8cpHVJdwG61t4S1/nH4jw/aXyBuq5OCs6++tSdIbxB2huUVR+cAdUWJ3l0xijcs3R7Uq7t9KBdcA7mcLojPh7+eR44nNKnVF+gB8BBOtX+8zmwcx/gJMAsgNFDgPOvDH/+5r8D9oq275vtQOm/gaot7Y8H8jilgM4BWpd0l8Uda++5s+cnndMJfLkm4YCliaAcbF+50i3oQA9BzeF0Y9Fne5VuRnr5z+fAtn2A0wCApK/b9knHQylbHjoIC3f44OzTbE+wsUytdNeDNhriC7pGGT6iuFwuuFwuuN1uuN1uNDc3w2QywWTqxF9vS0vC882aDM6A9MFEZYliy7dVgUj7KQDVMiwXY3HYUQ4IY/tjwiAd75vXcRi7alPn75VpS6ChTM1014PuZbPEdX7vOM8PZcGCBbBarVi4cCHeeOMNWK1WLFiwoHMX03okSIQQUlKcSizfVoX7lm7XxY+k0Kajvci1wBXmrdVlAHYva+v1Ntul7xNZL9BsB756Wpq/ZrqiuwA9pCAr5l6x0QCcU5iV8D3nz58PIUS7/+fPn5/wddNSaalqgvTc93ZAbTMgnXX/VcOUbkJ6MYVZUhjueKJ8CWMcpHVFd0Pc3bJNKOiWGXWpldEAFHTLRLcslf0VaHZ8WkalpYDdDsyYqWgzfIlWWmezmnUxl656gRnY3bsA9d2lYW0f8gDd7cm7PyeM6Y7KolPiiAjnDe6KLRUIG6R9wfm8wYkXKZGdxQIYDIBHH8Gh06qrpaQxlc1Ja9H8H44CAMxbvhNvb6z0FziJt6JZ4K5evHwrSM02qQfr8S7JyzkrfT1pA1xGqefc3d52PFmCE8ZqtgGl7wPCt1SQgD4TgRGzktsOJgvdBWgAMBgIxed0xammLthX3YRaewvcHikw97ZZMKQwC92UKk4SjdkMXHpZ2zIr35roPWVS0EonmzYqGqANpI862psPnwy53jpwp61owXv5tqp2y818hVEAfWS6d0pgjzlUUdics8kPyMECE8ZqtnnntwMJaT1103Gg+QQXPFE5XQZoQOpJd882Y5KSRUg6a8jQjoFpyFCpR7l+HeByKdOuVFN4bfSPJ/Xr1DpktXljwxGEGyd6e2Ol/xyfwOBd3L+7v8pZKPe/sz09A3Rwj1m2orAJMJilQOuzd0X4c4PXW+9e1jGYm7sAQ6/hwK0g3QZoXfIF7pdfUrolqUGk6DC3rwcZ3LMEIhcYUaNw4cMthD9IB3tzwxH8e0tVxO02dTJNH5toPWaleZyA/XBb5TFXgkvrnGelQikAB2mFcIDWouzs+HuXvsW8yV7UK+f1hZBGDABFg7QvUC/fVoX/t2w73Cp7X06Er/Z3KAJIeC9s3VBjjzkU3/B1tOImsRJuTjxTkO6WWaWFiZOkzTTiccevgF/+j/Q1WZIR/F0uaS5aYcu3VeHepfoKzgCQYSJeOBCLis8DgrPKyRWcfbhSmWK4B61Fvt7k118DLc3xP78zPfBoIuz1XJ+ZhyPZg9BitMDibkG/xgPIa66P/doqqNO96LO9au0zxcxqNqDZ6Wn3OhxODwzU+f7ghYO7y9E09arZBpR/JA33piuuVKaYhHrQRLSIiPYQ0Q4iep+IbAGPzSWi/US0l4iuSrilrL0hQ4FbbwOMMXzGGjmy/fed6YFPndbxOoB0nZEjIwbniq7D0GLKBIjQYspERddhqM/Mi+/+CtNDqcxw67oTyVQ/dMKB5duqOn8BNdv4V2Dn2+kdnMnYPvGMpVSiQ9yrAJwrhBgDoBzAXAAgopEAbgQwCsDVAF4kImPYqySDEMDRzcCynwFP9gbm26Svy24Bjm6RbSi2paUFt99+O/r374+cnByMGzcOn3zyiSzXjok7Ska3zQZMuaT9sSFDgYsvkXrSQPRtrywW6TlTLpECte952dnSdY6ET5g6kj0IHkP7H73HYMSR7EGR260yeimVKfcogG+51c1/+1bmKyts41+B0wcBQ2rftlQnswfPPysooSFuIUTg1iwbAPzI++eZAJYIIVoAHCSi/QAmAkjNv2K3E3j/V8DejwFXMyC8PQenAyj7ENj3OTDsB8C1fwWMia2HdrlcKCoqwrp169CvXz98/PHHmD17Nnbu3IkBAwYk/lqiiTZcbbeHzoQOtZQr1DIukwm48KLIz1uzOuztW4yha52HOx6SCiZJ779qWNK2ndSDrytOYt7ynXEVPlGtmm1AQwVg4BlAOOqkvw8O0oqQM0nsvwH4uo59AASu3TjqPZZ8QniD80ppaEoEDesJj3R8z0rpvAR70llZWZg/fz4GDBgAg8GAa665BgMHDsSWLVsSum7MJk6Kfk6EANpOcM/a10OOlkHtOz8Eizv0ftvhjoc0YkTs5ybJrPF99D/fmqBwy7U0p+JzDs6Byj9SugVpK2qAJqIviGhXiP9nBpzzMAAXgDfjbQAR3UFEm4loc319HIlD4VRtkXrOzihzhi6HdF7V1sTvGaC2thbl5eUYNWqUrNcNK9blR7FuQDFkKHDzT6WM75t/Gtv1w81pFxai38RBMARtOWHwuNGv8YD04SjSByQiaX47eIheIW/+4gJ0MfPCh3DcQmDe8p1KNyNxnLXcnvOstK6apVzUj4lCiMsjPU5EtwK4BsA0IfzvtlUAigJO6+s9Fur6rwB4BQCKi4sTnyL75s/SsHYsXM3Aty8A17+a8G0BwOl04uabb8Ytt9yC4cOHy3LNmMSyvKm0NHmBzhfEg8uTDhkKXyrYke2VaHEbpCzupoPIG5QH5HqAtW8DxvMBow2wGIGLLlN1/W29bKCRLIHlQzUr08ZBOljVRsDWn4e6UyyhcRwiuhrAAwAuEUIEpjp+COAtInoGQCGAIQAS2JE8Dvs+6zisHY7wAOWfynJbj8eDn/70p8jIyMALL7wgyzVjNmKEFICVFGpu2iuvyIa8IlvAkQltfxwzO6nNkluhzRq27CWTvL2xUtsBevCVQUVJGAAuWKKARCdaXgBgAbDKuyvUBiHEr4QQu4loGYBSSEPfdwohUlOSyBnnuuBEy+EBEELg9ttvR21tLT7++GOYzSneiGPKJUBZWXIrhDEAUrLY/e98B6cedtFIknCVyTTDF4R2vwPVVgxLBjJE7tz4RhXKlgNVmyD93fDuWMmUaBb3OREeexLAk4lcv1PMmdHnnwOZEl8+8z//8z8oKyvDF198AatVoeU4l02NnAwWy3ppFpVvY4j5H+6G3SH1sLp1MWP6mIKodavThdGbda/p7SkLxqdfgZKoI48EfP2slNnd9iRp+BvgIJ0E+nvXHnKVtJQqlmFuMgBDr07odocPH8bLL78Mi8WC3r17+4+//PLLuPnmmxO6dlx8w8vr1oYuGnKJOhKt9GDW+D4hA83B+kZ8XXFSgRapy02TirB8WxXmvrfT/4Glyu7A3PekBDLNBOl0Cs4xEUHBOUDVRuDEXt6+Umb6C9Df+420zjmWf1ymTOCCuxK6Xf/+/SHUMqTnmwfeVx4yYYslz7zlOzUZnM0GeXekMhvatqgMHk1wON1Y9NlebQTomm1Q5Y5VauYbAg/cvpKDdUL0F6D7nCcVIdmzMvL8sskqnddnQvhztCpCwhZLDiXWAPexWXHZ8LyEhtal3BH5gpDTg4gFXTRRMrVmm3ebRQ7OCWu2Swl3AAfpTtDfok4iqULY8OnShuMU9BLJIB0fPl06TwVVqpj2pToxqo93TnfljpqE5r1bU7w9l61LihMoO6Pic2mbRSYPj1P6O2Vx018PGpDKd/7X36UiJN/8SRrydjmkXvPQq4Hv3SX1tBmTSaR9lZPBVwNba9QyGxRRuqyB9u1SlYrX22wHvnpa+mqySh0j59n2Q+A126RA3myXOlFCeEdBvaM8aThcrs8ADUi/AH3PA2YvVrolLA3cNKnIX6SDhWd3OHHhwjXqzuhOl0IlqX6NvvsFTj0GzlcHapdDJNqfW/4RMPSatAjU+hviZkwBmi7MkWK+jG7VblM5+Eppm0XdI6mnqjXOs9K8ds02pVuSdBygGZNJH51sSZkKvoxuVSoYD4z8L20Gr7gI7S4lS5N5bf0OcTOWYvdfNazd2l8WmaozugvGtx9C/WKucm1hoaXBNAT3oBmTyazxffD763ioO1aFWhpxkKHiIJOZL8lNx7gHzZiMZo3vg/+37Dvt16NOgfuvGqZ0E2I3bAaw+10AvJuZKhjMUq6Az+a/A/aKtu9tg4Hin6e+XTLTb4AWAjhdCRwuAY7vleYsDGag53Cg/xSga1/Z1kD/5Cc/werVq9HU1ITevXvjgQcewM9/rv1fDtY50TK6zQZK+802huRnqTeLOxTfcLdvGVCmDegxrK0ONUutggltP5Pg4AxI36+eBxQWa7oEqT4DtMctpePXlwEeF/xp+h4nULcLOL4HyBsBjJoNGBLP1pw7dy7+8Y9/wGKxYM+ePbj00ksxfvx4nHcer7VOR76M7rc3VsItBIgAq8mAs04PjMTBGQDOtnqwfFuV9oJ08Js7B2hl1O5o25wjODj7CHf7n48Gq5rpL0ALERCcQ+3nKqTj9WXSeefemHBPetSoUf4/ExGICBUVFRyg09iCWaPbLb0K3jwi3Wly8wymHi5HW+GTePiyvzUSoPWXJHa6MkJwDuAL0qePynLbX//61+jSpQuGDx+OgoIC/OAHP5DlukwfQm0eke5UvdQqVqS/Po5mdDaLW0PZ3/oL0Ie/8g5rx8DjAo6UyHLbF198EWfOnEFJSQmuu+46WCwWWa7L9EHVS4oUVGV3qLdgSSxGXgepFCXTDu38vPQXoI/vQey70Aigfo9stzYajbjoootw9OhRvPTSS7Jdl2mfppYUpdi9S7djwJyVuHDhGu0F64LxwKjrlW4Fi4vQTBUy/QXoaEPbHc6PsbcdB5fLhYqKMIkLLC3df9UwWM3pUD4yfr6P01V2hzaDtUbmM1mA3e9qIkjrL0Ab4tzOzpDYHFJdXR2WLFmCxsZGuN1ufPbZZ3j77bcxbdq0hK7L9MVXxITLgUYWGKxVXa+7A+0MmzIA8AB7VyjdiKj0F6B7Dkfs/1gIyBue0O2ICC+99BL69u2Lbt264be//S2ee+45/PCHP0zoukx/Zo3vg8uG5yndDM3QRBJZzTYpmzjmaTWmGi4HULZc6VZEpL8UxP4XSfPQsQx1G0xAvykJ3S4vLw/r1q1L6Bosfby9sVLpJmhKld2BAXNWwkiEmyYVqWvXsJpt0rraeKfVmHpUbQRs/VU7TaG/HnTXIqkISbShboNZOq9r39S0izFAkRKgz90wLuX3lJtbCLyx4QjmLd+pdFPaVHzOwVkPVDzUrb8ATSRVCPMH6eDhbmoLzqNmy1buk7FYGBX4fZs1vg+sZn38U1fVCISG1tOyCFzqXQKpj3+1wQxGqULYeb8A8s9tC9QGM9DrXOn46JtkKfPJWDxumlSU8nvOW74TDqc+NnlQ1SYkabCbElOW/uagfYiA3CJgzI+VbgljfgtmjcbB+kZ8XXEyZfeMtHGH1igxAhHW4CulcsGqQ5Ataa3PpPSoN16zTZXz0PrsQTOmYm/+4gL0yslQuhmapMQIRFgF46VtDdUmMxe4/PfSFF6Ht/gwH3D6TJL+9z9O0ve2/slrp5qU/luV66L124NmTMVqz7Qq3QTNuXBwd3VlcQNAY3UnnyhjLzeYb2481BaZrpbQc64n9gIXPdi2Q5TPV08np41qI9xA6fuq60VzgGZMg4xE6pqPTbKfTO6nvuAMtAt2+7IzsKmHFY0mA7JdHkw84cCQxjAfxPpMBGq2JicLPHBuPHiLzC/mhn5OuIS3dEqEE05pXXTwhxQF8RA3YxqUTsEZkObRr3hmrdLNCGtfdgbW52eh0WwEiNBoNmJ9fhb2ZYeZyjixFxhxbfREM4r3LdogzY2HE+5+8R7Xq6pNSregHQ7QjClgSH6W0k3QnH11TRjz6KdKN6M9cxcAwKYeVrgM7ed3XQbCph5hSrs226We7UUPRg6CwhOwpWXA9c1dpDli7/0BACYrMOpHkYdpB1/ZsUaEwRw+qIc6X9fU9cFXt0PcQgjsPL4Tr+1+DSVHS9DiboHFaMHFfS/GraNuxbk9zwXJnBG6b98+jB49Gj/60Y/wxhtvyHptpi+r7rsUVzyzFvvqmpRuiqacbnFj3vKd6hnuHnoNsHsZGk2h+zrhjrcLyoOvjFyRTLikZLTin3d8LN7h2FDz0oOvDB/Ug89nKaXLAO30OPFwycP4svJLtLpb4YG0BrTZ3YwvDn+BkqoSXNr3Ujw55UmYZfx0eOedd+L888+X7XpM31bdd6n/z8u3VeH+d76D06OuT/Bq9MaGI+oJ0AXjgd3LkO3ySMPbQbJdodafU/seayxB0C7j7njB89Kxnv/FQ1BbD1N2Khst0N0QtxDCH5yb3c3+4OzjgQcOlwNfVn6Jh0sehpBpLm/JkiWw2Wy8ixXrlFnj+2DR9WNhs6rrDUKtVFXyE4SJJxwwBX24MnkEJp4IkTE96vqOAdI33K1qOg/OICkvQEV0F6B3Ht+JtUfXotndHPG8Zncz1h5di13HdyV8z9OnT+ORRx7BM888k/C1WPqaNb4Ptj96JQ4tnI5DC6erqyhHgEMLp+Mnk/sp2r431VR8pc9EDGlsxcV1Tch2ugEhkO104+K6po5Z3Jk21S3liZ06fx9lkWkL/cFJYboL0It3L0aLqyWmc1tcLVhcujjhe/7ud7/D7bffjr59eeMNJp9wRTm6mA0gKPt2uWDWaFT8/gc4tHC6IvcXAFb/+XWUnPc97B4+AiXnfQ+r//y6Im3BiFlAn0kY0ujEzYcb8MsKO25u6IkhZ4N6nJGSsXzCFT5RQ0GUPhOVbkGSkDR6obLgDOhwDnr90fUdhrXD8cCD9UfXJ3S/7du344svvsC2beqrQsO0zTfP+vbGSriF6LDl4sA5K5VsHgDg5r99q8h9L63cgrwPlsEs3ACAnk2n4HzpD1gNYNpvfpb6Bo2Y1TFhq2Zb7MlYPsU/Bzb/vf2cc7gEsVTzvb6qTdDVcLeKP3joLkC3uGPrPfs0uyIPhUezdu1aHDp0CP369QMANDY2wu12o7S0FFu3bk3o2owtmDU6bEJUoc2KKnvqd+IZMGclupgNeOq6MSmtKR7oVzs/8AdnH7PHjZy//wlQIkCHEm8ylo8agnE4vg8i654CnGeUbk2CSArOKipMEkx3AdpitESdfw6UacpM6H533HEHbrzxRv/3f/zjH3Ho0CG89NJLCV2XsWjuv2oY5r63Ew6nO/rJMjvr9OC+ZdtTfl+frq1nQx7PbuFla0n39bPaDs6ZNg0k5El0F6Av7nsxvjj8RUzD3AYYcHHfixO6X5cuXdClS1uxgOzsbGRmZiIvLy+h6zIWzazxfQAA9yzdrsj9U7Ui7NLKLbi19BPkOeyot9rw2sjvp+bGLDRHndItSEy0PAAV0V2S2C2jboHFZInp3AxjBm4ZeYus958/fz4XKWEpM2t8H9Vme8vh0sotuHv7u+jlsMMAoJfDjru3vwtHmPWq7uyc1DaQaYu5iyqTwcLRXYAe3XM0Lu17KTKNkYeuM42ZuKzoMpzb89wUtYyx5AiX7Z1hTH7gtlnNuHBw96Rd/9bST5Dpbl9hK9PthNNkRmtQnWq3wYh+j/4uaW1hGmcwS5XfNER3AZqI8OSUJ3FZ0WWwmqwwBL1EAwz+4PzklCdlL/fJWKotmDW63bpkIxF+Mrkf8nISy6+IRavLjTd/cQEOLZyO524Yh6yMjtW0EpHnsIc83rXVgcUX/RS1VhsEAGfPfBQ9/Xvkzpgh6/1ZCNZ8pVvQOSOu1VTvGZBpDpqI/h+APwLIE0IcJynqPQ/gBwDOArhVCJGylGazwYynL34au47vkmpxV5Wg2dWMTFNmu1rcLLJdXx3E6YBKSF17WHHuRQMVbBELJ1S2t1zLsMxGgtMdesL5rFPK9Vi+rQr3v/td2PM6q95qQ68QQdpcWIBn/jYHwBxZ78dicOG9UqJYp+eivXthm7sAzmYgxmWxCdNYcAZkCNBEVATgSgCBpX2+D2CI9/9JAF7yfk0ZIsLovNH4v0v/L5W31aT6SjuOlNWhxeGCxWpCvxH5qD18ql1wBoDTJxzY9dVBDtIaEWkZls1qht0R217Ei340Nmoi2qLP9soenAHgtZHfx93b3203zN1sNGPQvffIfi8Whwvvbftz3DW6BXD579u+DbVeHGh/zN0KOENn7sdEDYVeOkGOHvSzAB4A8EHAsZkAXhdSoesNRGQjogIhRI0M92Myqq+0Y9/Wav/3LQ5Xu++DBQftcNcMDvh5RTY5msviEGoZFgG4eXI/LJg1GgNi7GHPGt8Hj63YjVNnOwb0bl2kZK3qJK3HXlt0HgC0y+L+sHgmnuGhbPXoMxGo2hj7+cHba4ZbLx54rGZb5B2/IlFLoZdOSChAE9FMAFVCiO+C5nL7AKgM+P6o9xgHaJXZty18MO6M+ko7Kr6rgcfbm/IF/NMnzmLwuEJZ78Ui8y3DWvTZXlTbHSi0WXH/VcP8x61mAxzOyMOLvnntR2eM6jCEbTYSHp0xCkByi6asLTrPH6gNBDwze1xS7sM6qUOFMW8BEFv/jkE1lnKnoYTbJjPUMQ0OZYcTNUAT0RcAeod46GEAD0Ea3u40IroDwB0A/NW4WArJPCp5cGetPzgHqj1sR9ceXbgnnWKzxvfxB+Rgv79uTNSha1+GeLRgf/9VwyLOQVtMBrS6PCi0WXHZ8Dx/+dJ4+KqXhXs9TEGhSp36yBVAY+lp60zUAC2EuDzUcSIaDWAgAF/vuS+ArUQ0EUAVgMC1H329x0Jd/xUArwBAcXGxjgq8ap+AAAVtyZCZZUbF9mrUHrH7Pyz36mfD4HGFqK+0wxWhqtWBnTUcoFXEF+jmf7i7w3y0gYAfT+rXLvEsUrD3HQ8eCrdZzZj/w1Ednlfcv3vMVdDMRsKiH43lwKxFnS13ygAkMMQthNgJwJ9vT0SHABR7s7g/BHAXES2BlBzWwPPPyqrYXo3aw/a4nhMcnAGgucmJ5qaA6wj4r2uva4x4Pbcz/OevcEGfJVekoJvMa4XrkQPtPzB062LGozM6BnjG0kGySn1+DGmJ1X5Iy6xuS9J9whJCoK61Bjsa/oMjjgNwCRdMZEI/62CMzT0feRm9ZVsDfemll2LDhg0wmaS/zj59+mDv3r2yXFsOwculkiHW4P/NB6UwGAmDxxb4e9MdPjwEBH0O0voVLqBzMGZMIluAFkIMCPizAHCnXNeOl1u48eXxj3H4bAXcwgXhnWh1CRcOni3HEccB9O8yGJf1/AGMJE9hhRdeeAE//7n6MgXrK+1JD87x8riFP1M8r8gWNrjXHrZzgGaMpS3dVRITQuDL4x/j0Nn9cAmnPzj7H4eASzhx6Ox+fHn8Y4g4E1W05kiZegvbH9xZq3QTGGNMtXQXoOtaa/w950jcwoXDZytQ33pMlvvOnTsXPXv2xIUXXoi1a9fKck05tDgi/z0oyeV0Y9PH6pkKYIwxNdFdgN7RsDlqcPZxCxe+a/hPwvd8+umnceDAAVRVVeGOO+7AjBkzUFFRkfB15WCxqntH0UhZ34YUbPbAGGNqpbsAfcRR0WFYOxwBgSOOAwnfc9KkScjJyYHFYsEtt9yCCy+8EB9//HHC15VDvxH52gx0BAweW6B0KxhjTDHq7l51givG3nPb+Z0oHRcFEalmbtuXKR1YepMMhOYm+V93wrw19H3LrHjNNGMsnekuQJvIFFeQNlHojd9jZbfbsXHjRlxyySUwmUxYunQp1q9fj+effz6h68opr6h9sNvyeblyjYlEtH2tPWxH7WF7yFre9ZV27N9eDRFQpZIMwDnjCjmoM8Z0Q3cBup91MA6eLY9pmJtA6GcdlND9nE4n5s2bhz179sBoNGL48OFYvnw5hg4dmtB1k0nNiWPBWhwu7N9W0yEgBxMeYN/WahzcWQuX082bdDDGNE93AXpMbrG3MEn0IVwjGTE29/yE7peXl4f//CfxRLNUslhNmgrSQoiYa4b7ks54kw7GmNbpLkksP6MA/bsMhpEif/Ywkgn9u5yDvIxQ+4Dom6VLYsP6WlJ72I76SrvSzWCMsbjpLkATES7r+QMM6HIOTGTuUE+aQDCRCQO6nIPLev5AtnKfWlGxvVp1lcWSTc3FWhhjLBzdDXED0tD1tJ7XoL71GL7z1+J2wkRm9LMOwtjc85FvSc8lPPFumKEHWhrOZ4wxH10GaEDqSedbCnBF/g+VbgpTmNqLtTDGWCj8zsV0r8XhwjcflMJoJgwaXcCZ3YwxTdDdHDRj4bid0i5anDTGGNMCDtBppmsPq9JNUNz+7dVKN4ExxqLiAJ1mzr1ooNJNUFykgieMMaYWHKDTkCY3z2CMsTSj2wAthIDju+9w9O57sGfceJSNGIk948bj6D33wrFjh+ybWSxZsgQjRoxAVlYWBg8ejJKSElmvL6d4X/qQCfqrxPXNh6Wo4KFuxpiK6TKLWzidqJ4zB2fWfAnR0gJ4pDFN0dyMM59/jsZ165Az9TIULlwIMideVWvVqlV48MEHsXTpUkycOBE1NTUJXzOZhCe+CF17+JTmyoNGJdrWhHMpUMaYGukuQAshpOC8eg1Ec3PHEzweCIcDZ1avQfWcOSj84x8Trib26KOP4pFHHsHkyZMBAH369Enoemqj58pjtYftqD1iR69+tg6BetdXB9u99q49rDyHzxhLGd0NcTfv2CH1nEMF5wCiuRln1nyJ5p07E7qf2+3G5s2bUV9fj3POOQd9+/bFXXfdBYdDv0FNd7y96cAh7+DgDEgfVHZ9dTDVrWOMpSndBegTr74mDWvHQLS04MSrryZ0v9raWjidTrz77rsoKSnB9u3bsW3bNixYsCCh67LUqz1i9/853KiBnkcTGGPqorsA3bh2rX/OOSqPB41r1yV0P6tVWlf8m9/8BgUFBejZsyfuu+8+fPzxxwldl8WG5PwNljdvkDHGEqK/OegYe8/+86MMhUfTrVs39O3bt908ttp3yDKaCW6nPqKR3Guat3xerq9kOMaYZumuB00WS3znZ2YmfM/bbrsNf/7zn1FXV4dTp07h2WefxTXXXJPwdZNl0OgCQN2fIRQTLThzJTbGWKroLkBnX3opYIjxZRkMyL70koTv+bvf/Q7nn38+hg4dihEjRmD8+PF4+OGHE75usuQV2TBkvLaXFik1SnHmlINreTPGUkJ3AbrHbbfG3IsmSwZ63HZbwvc0m8148cUXYbfbcezYMfzpT39Cpgw982TKK7KhV3+b0s3oFIvVBJAyQ/TCA+zbxhtuMMaST3cBOnPMGORMvSzq0DVlZiJn6lRkjh6dopapz+BxhZodslW0nrYAjpTVKdgAxlg60F2AJiIULlyInGlTQVZrx+FugwFkzUTOtKlSJTGVJ3Ql27kXDUy4lCcRSb3xFP1VqiGJSw1tYIzpm+4CNACQ2YzCP/4R/Re/hpwrr5QCNRHIakXOVVei/+uvo8///Z8sZT71IK/Ihsyszv1dmMxGnDO+QPpGH4nhsSHwMDdjLKl0t8zKh4hgHTMGfZ97VummaMKEy4dg6xf70NzkjPk535s5EgBQsb3aX9e6A4I+A7cAKr6Taq7nFdmUbQtjTJd0G6BZ/CZcPqTd9/WVduzbGn7Hp/pKO/KKbO0qcLVDwJDxhThSVicNCessWHvcAkfK6jhAM8aSggM0CyuvyBYxQPuDU7igK6Rr+ALYNx+Uyt5GpfFcNAu0r7EUm06VoNF9GtnGrpjYbQqGZI9UullMozhAs8gi9Hr9wSncOUFJY7rbshLeJV8s7e1rLMXXJ1ajRbRVJmx0n8aXxz/2Hw8O2BzMWTT87sIi6tXPFnZ+2Recwp3Tq58NgHeO+ohdV8PbPv1G5CvdBFULDlwWgxUXdp+qq0C0omYpqluOhHxMQPhfe6P7NNYcX4mvT6zG4KzhKG/aBZdw+R9bf+IzANDV3w1LDAdoFtHgcYVwNLZ02MXJYCR/cPLto+wPwgT//soRE8g0rld/G88/R7CvsRRfHv8YIuCTWYvHgTXHV2LPmZ2YUXCDgq2TR8nxVWGDczgtohmljds7HHcJF74+sdrfq7YYrIAQIXvfLD3oN0ALAdTVATu2A0eOAC4XYDIB/foDY8cCefmATGugs7Oz233vcDjw61//Gn/+859lub7Szr1oIOor7f5kL4vVhH4j8tsFp8HjCv2BOlDYBDIdqD1iR+1he8i/DwZsOlXSLjgHqm45ghU1S3HCWY8Wj/Thz0KZuLDHtE4HocAh40CFln5J+zBQ1vidrNdrEc1ocUs9bt/fC9DW+470wYaHzPVHnwHa7Qa+XAMcPiT9WXjfJFwu4OAB4MhhoP8A4LKpgNGY8O0aGxvb/bl37964/vrrE76umgQme8VFh8Paft7X1uJwYd82KZmOg3Sb4EAZLLjn2SKa8eVxaZvWeAPLvsZSrD/xmX/IOPg+K2qWJiVIh/sAkizVLUfwz0PPw4lW/zGbsTsmdLug3WhF4HB6Ih96mLL0F6CFkILzoUOAO0RCkhBSoD50SDpv2uWy9aQB4N///jfy8/MxZcoU2a6paTpbWhWWAA7srEmbAB1Lby3b2DVqkA4mILDpVEncAWXTqZKQwdkn3mHoWBEo5UE6MDgDgN19EmuOrwx5biIfepjy9Beg6+q8Peco2cJul3RefR2Q30u22y9evBg/+9nP0r6EqE+kJDO90cse29GUHF/Vbg5V6q11DAITu00JGzgiaXSfjvoBIPjxeD8IBEpkaHhE9tiQ88lqIiCw/sTnHKA1SH+lPnd8Jw1rx8LtBr6Tbw7p8OHDWLduHW655RbZrql1g8cVprRON0uufY2lYQKSwLrjn7c7MiR7JEZmj4v7HhbKxPoTn/mDrm+4tuT4Kn8bgh/vrFDXWn/iM+xrDL9mf19jKd6sfBkvH1qEI44DKLT06/T9U8UlYq8QyNRDfz3oI4fb5pyjEUI6Xyb/+te/cNFFF2HgwIGyXVMPghPIAhPOmLZsOlUS9jE3OgaBKT2vQO/MPlh3/FO4Ef2DM4HghjvkcHVp43aUNm7v1LByuCAaamjcJVxYd/wzf48zeMQgUKP7NJo9Z+NqC2OxSjhAE9FvANwJwA1gpRDiAe/xuQBu9x7/XyHEZ4neKyauON/04z0/gtdffx1z5syR7Xp65Us402NlMb2L1lvd11iKY81VKGv8DgICBEKBpQhuxL4/aLTeXrzB2UpZqGmpxMuHFoFAGJE9FlN6XoF9jaVhX48bLn+PPdoQdqS5bzV5+dAimMiMi3tcycPdGpFQgCaiywDMBDBWCNFCRPne4yMB3AhgFIBCAF8Q0VAhRIxjzwkwmeILuiZ5BhG++eYbVFVV6S57O1l4JyhtkXqR0aeDguecBURcCVpyJVz5AtGeMzvb3V9AoLRxO8oad0BE+dAg9xIqNXAJJyeNaUii0el/ACwUQrQAgBDCt4v9TABLvMcPEtF+ABMBfJvg/aLr119aShXLMDeRdL4MFi9ejOuuuw45OTmyXE/vjpTVRT9JY0xmacletDXjWhNpiFetXMIZMUEtWnCWztFn0l9nM+VZ6iUaoIcCmEJETwJoBvBbIcR/APQBsCHgvKPeY8k3Zqw0rxxLL9polIqWyODll1+W5TrpQo/zzwNH9+qwA1iLw+X/XqtBWo89yXSXSGIdS52oAZqIvgDQO8RDD3uf3x3AZADnA1hGRIPiaQAR3QHgDgDo10+GbMj8fKkISbh10D5Gk3ReHtdSVoKeNs4wmgmDRhcAQNjdv/Zvr9ZsgNZrT1IuBENMPXLG4hV1mZUQ4nIhxLkh/v8AUs/4PSHZBMADoCeAKgBFAZfp6z0W6vqvCCGKhRDFeXl5ib8iIqlC2IAB0vxy8HpkIun4gAHSebxeWRH9RuTDYNTH3/2kH4wAED44A4DQ8Ps38Rq5iAQ8MOpwQQxTXqLroJcDuAwAiGgogAwAxwF8COBGIrIQ0UAAQwBsSvBesTMapQphM34IDBzUlghmMknfz5gJXH6FLGU+WefkFdkweGwByKD9N//gYW29GZEtzzSQnrmhrdEg/tClDYl+7PsngH8S0S4ArQBuEUIIALuJaBmAUgAuAHemJIM7EJFUIeyKK1N6WxY733KrXV8d7LBblpZUfFejdBOSakrPKzSXJMYi4w9d2pBQgBZCtAL4SZjHngTwZCLXZ+nh3IvaCrvUV9qxf1sNRKzFZlTA447e1l79bclvSLLUbEO204NGs/4KD8bLRCbNrHsO5CvuErgOnKkfT5wwVfElUu3bVq2rTTZCbcWpGRWfo2s3FxpN5rTP2dBicDbCDDecvAWlBvFHYqY6eUU2DBlf2CGJzGAk/1pjlkLNdlR34eCsVb4SrLHUGWfqwgGaqZIvicxilQZ5LFYTBo8twMDRvXST/a0VJb1sSjeBycQlXBHrqTN14SFuplq+JLJgtYdPaTqpTGvKcvhzvJ5wkRLt0G2AFkKg9tBpbF91BId3nYCr1QNThgH9z+2J8Vf0Q/6AHNn2bD506BB+/etf49tvv4XFYsGPfvQjPPfcczDJVOebtXf6pPaCc8X2as3OQ+soFYABsBisSjeBxUiXH43dbg9W/WM3Pnh2Gw5sq4erVaoS4Wr14MC2Oix/ditW/WM33G55qkf8+te/Rn5+PmpqarB9+3asW7cOL774oizXZiFoMGLUHrajYrs210rzmtnOsVAmLJQZ8jEl95Bu9TTzPLRG6C5ACyGw+tVSHPzuOFytng57ZgghBeqD3x3H6ldLZVnOc/DgQcyePRuZmZno3bs3rr76auzevTvh67IwNBovag/b8c2Hpfjmg1J882GpZgI2r5ntnBbRDLMhAyOzxyHb2BUAkG3siqk9p+O0y65Yu3ybZTD1090YbO2h0zi44zhczsi9Y5fTg4M7jqPu0Bn0Gtg1oXvec889WLJkCS699FKcOnUKn3zyCZ544omErsk68u0SpcUetJ9o+1p72A5A/UuwfGtmfXs8s9g1uk+jvGkXLu5xVbvlTZF22koFnofWBt31oLevqoQ7SnD2cTs92P5F7HvVhnPxxRdj9+7d6Nq1K/r27Yvi4mLMmjUr4euyNvWVdlR8V6ObDTZ8fEFa7ab0vAJ3DPgtfjngfqWbojku4cLXJ9dgX2Mp3qx8GS8fWqT4tIGvR8/UTXcB+vCu4zFtBQ1Iw92Hdh5P6H4ejwdXX301rrvuOjQ1NeH48eM4deoUHnzwwYSuy9o7UlYXU8UuLaqvtCvdhLjwm3v8WjwOrDm+0t9zVXIkwkQmTOw2RbH7s9jpLkD7EsJiPj/G3nY4J0+exJEjR3DXXXfBYrGgR48euO222/Dxxx8ndF3WXiI9Z7my9ZPlSFmd0k2Iy8RuU2AAF4zREt9uW9nGrh2G25l66W4O2pRhiCtImxKsL9yzZ08MHDgQL730En7729+isbERixcvxpgxYxK6Lmsvkf2j1V7XW2vD9r43969PrkGLR3tL3tLRzwfcq3QTWCforgfd/9yeMVckJAIGjO6Z8D3fe+89fPrpp8jLy8M555wDs9mMZ599NuHrsjZ62j86mK9ampYMyR6JW/vdxcPdKUSdfLvmn5F2ae+dIYpxVxTh8K7jMfWijWYDxl2e+HrEcePGYe3atQlfh4Xnqyh2cGctXM7Ydi7t2sOqiYpjtvxspZvQaRO7TcGXxz/m7O4UEPDARGa4hLPDY0YY4Ubofxc836xduutB9xrQFQPH9Iw6dG0yGzBwTE/kD8hJUctYovKKbJj4g2EYMqEQZIjcm/7ezJFoOdvxjUyN7HWNSjeh04Zkj+TgnEJGGGGi9v0qE5lwSc+rMTJ7HAKLBBhhwtSe03m+WcN014MmIky7baRUrGTHcbid7YuVEEk954FjemLabSNVn0DEOvLV6P7mg8jVkLQyt6uVdjLltYhmTO05HZtOlaDRfbrdFpJDskfyPs86o7sADQBGowFX3D4KdYfOYNuqI9KQt9MDk9mAAaN7YtwV/dBrAM/LaF24xLHAHbC0EvzqK+0hNwZhLFC2sas/GDP902WABqSedK+BXXH1Hecq3RSWJP1G5KPiu5p266MNRkK/EfkRH1fjeuqK72oAgIM0i4jnk9OL7uagWfoIt2e0L8iFe3zIBPWV1vS4hebWQ7PU4fnk9KTbHjRLD+H2jI72uBr3lNbKcHywbGNXru2cBCYycVGRNMcBmqUlNWZ4W6wmVGyvRu0Ru7SpBgG9+tlUv5nGxG5TsP7EZ3AJbX7AUIuR2eNwxHGgQ/IXS18coFlaUmNv1dLF3H7zDI3seOULIutPfB5yjS6LDWdgs2A8B83Skhqrd50+GXrIvfaIPbUN6YQh2SNxe/97MDJ7nH+nJgLBZuyucMsY0y71vUvJRAiBxlMOVO8/gVN1jfC4BQxGQrde2Sg8pyeybZmyrYEuKyvDnXfeiS1btiAvLw+LFi3CtddeK8u1WXKEyvAGSUFFidrdEaueqS/pPKwpPa/o0BN8+dAihVrDmLbpsgft8QiUb6nC7m8O40TNGf+bsMctcKL6DHZ/fQjlW6rg8ST+zudyuTBz5kxcc801OHnyJF555RX85Cc/QXl5ecLXZskTKsN7yPhCnDO+QJHedctZJyJtEVyxvTp1jZHRvsbIxWSYpNCSeMlhpj+kpp1+iouLxebNmzscLysrw4gRI2K6hhBScD517EzE9a4GI6Fb7xwMPa9PQj3pXbt2YfLkyThz5oz/OldeeSUmTZqEJ554Iu7rxfNaWfJEq1KWDLGs0bZYTeg3Il/166X3NZbKuttVtrErnJ5WtIhmWa4nFwIlXOq00NIPMwpukKlFTIuIaIsQojj4uO6GuBtPOaIGZ0DqTZ86dgaN9mbkdLPK2gYhBHbt2iXrNVlqKVGFLJYCKi0Ol+qLmuxrLMXa45/CE2bzhniZyOQv0LHm+MpOX8dCmbIH+ESCM69rZtHoboi7uuJEzJWiPG6B6v3HE7rfsGHDkJ+fj0WLFsHpdOLzzz/HunXrcPbs2YSuy5QVbnvLaJt0pILai5psOlUiW3DONnb1rwUekj0SFkPnP0z3yMiXfevFyNeL/LvCwZlFo7se9Kna+HYGivf8YGazGcuXL8dvfvMbPP300yguLsbs2bNhsVgSui5Tlq93eqSsDi0Ol39oed9WdcwFq3GZmI+vaEnemgoMfG0zLPVNaMnLwsFbi1E/dXDU50cq0HFh96mdXnNd3XIk7ucAgMVghcvjhBvt7+nr2R9rrkJp4/YOzxuZPRaljd8hVJYfRQnejAE6DNDx1lmWoy7zmDFjsG7dOv/33/ve93DLLbckfF2mrFBVyHwBWw0qtlercn10trErrKu2YejzX8HYIvWkM+uaMPT5rwAgapCOVD3LdzyRoe54Xdh9KoZkj8S+xtKwu0gBQFnjdxAQIBBGZI/1Z7OHCt4jssemrP1Mu3QXoOPdDCHUMGa8duzYgaFDh8Lj8eDFF19ETU0Nbr311oSvy9RHTb3o2sN2OBpbcO5FA5VuSjsTu01B42t/9wdnH2OLGwNf2xw1QEcb+h2SPTKlAXrTqRJ/IA7XtlDLy3zHgfDBm7FIdBegu/XKxonqM3Gdn6h//etf+Pvf/w6n04kpU6Zg1apVPMStU3lFNhzYWQO3Ux2rH06fcKhuq8oh2SNRVt8U8jFLmOM+I7PHJXx/I8xwQ76KZonWGQ8XvBmLRndJYoWDe8TcKzYYCYXn9Ez4nosWLcKpU6fQ2NiITz75BOecc07C12TqNWh0QYffMYOR0Ku/LVpeUFKoMWHMVFAQ8nhLXlbY54zMHhdzIAu3bthm7I6fD7gnaqDPNnbF1J7TY7qX3IlljMVKdwE6u5sV3XrnRA3SvnXQ2bbMFLWM6UW4bSwHjyvEkPGFskybxEMtc+KB8u+9B5TZ/t+W22LEwVs7LPWEAUZM7Tk9rl7mjIIbOgTpQks/3FB0OwCp1xqpzKhv/jiWZC3eg5kpRXdD3ESEIRP6YN/W8MVKfMF5yITEipSw9BVuG0vfsX3bqlNWolONdcVzZ8wAANQ9+xxcNTUwFRSg8N57YLlsML4+sdq/HtlisPqTsOIVrbjHDUW3o+T4qnaZ1EaYcEnPtiS0EdljQyZx+YzMHsfLoZhi1PcvWwYGA2HoeX3QaG9G9f7jOFXbsRa33MVJGPPxBekOtb6TgaTENTXKnTHDH6j9x5Da9b/R5n/DZVon8sGBMbnoMkADUk86p5sVw84vUropLA2loidtNBMGjS5QVYKYFnESF1Mr3QZoxpSWV2RLypKs783kXh1j6UB3SWKMqYka54cZY9rAAZqxJFLr/DBjTP04QDOWRHlFNnTtIW9Colb3hmaMxYcDNGNJ1nJWvqpWgFTis77SLus1GWPqk1CAJqJxRLSBiLYT0WYimug9TkT0JyLaT0Q7iGiCPM2NnRACNfv2YsUzv8fzP/0v/N+NM/D8T/8LK55diJr9eyGEfKm1L7zwAoqLi2GxWDrU4F69ejWGDx+OLl264LLLLsPhw4dluy/ThmQUElFj9TDGmLwS7UH/AcBjQohxAB7xfg8A3wcwxPv/HQBeSvA+cXG7XPj4T4uw7ImHsG/TN3C1tgBCwNXagn0bv8ayxx/Cx39aBLdLnjfOwsJCzJs3D//93//d7vjx48dx3XXX4YknnsDJkydRXFyMG26IXFyB6U8yEsXUWD2MMSavRAO0AOArVJsLwDc5NhPA60KyAYCNiEIX55WZEAKf/uUZ7N+8Ea6Wlg49ZSEEXC0t2L95Az79yzOy9KSvu+46zJo1Cz169Gh3/L333sOoUaNw/fXXIzMzE/Pnz8d3332HPXv2JHxPph39RuTLXrGOs8MZ079EA/Q9ABYRUSWAPwKY6z3eB0BlwHlHvcc6IKI7vMPjm+vr6xNsDnBsfzn2b9ko9ZojcLW2Yv+WjThWUZ7wPcPZvXs3xo5t2/c1KysLgwcPxu7du5N2T6Y+eUU2nDO+ACazUZbrGYzE2eGMpYGoAZqIviCiXSH+nwngfwDcK4QoAnAvgH/E2wAhxCtCiGIhRHFeXl78ryDI5o/eh7u1NaZz3a2t2PzR8oTvGU5jYyNyc3PbHcvNzcWZM7Fvh8n0Ia/Ihok/GIbvzRwpFRrpbIeagMFjuXoYY+kg6jiZEOLycI8R0esA7vZ++w6Av3v/XAUgsMZmX++xpDuw9T8xD1sLIXBg66aktSU7OxunT7ffS/b06dPIyclJ2j2ZNvTqZ0PtYXuH4117WHH6pCNkeVCDkTg4M5ZGEp3IqgZwCYC1AKYC2Oc9/iGAu4hoCYBJABqEEDUJ3ismLmdsvWf/+TH2tjtj1KhRWLx4sf/7pqYmVFRUYNSoUUm7J9OGweMKAQC1R+xSMCYpaPuOA0B9pR1HyurQ4nDBYjWh34h8Ds6MpZFEA/QvADxPRCYAzZAytgHgYwA/ALAfwFkAtyV4n5iZzBlR55/bnZ+RkfA9XS4XXC4X3G433G43mpubYTKZcO211+L+++/Hv//9b0yfPh2PP/44xowZg+HDhyd8T6Z9g8cVtgvIwcJtackYSw8JJYkJIb4SQpwnhBgrhJgkhNjiPS6EEHcKIQYLIUYLITbL09zoBk04P+aMWSLCoAkTE77nggULYLVasXDhQrzxxhuwWq1YsGAB8vLy8O9//xsPP/wwunXrho0bN2LJkiUJ348xxpj+6W6tRvE11+LAtv/A1RK9F23MyEDxNbMSvuf8+fMxf/78kI9dfvnlvKyKMcZY3HRX6rP3OUNxznmTog5dmzIycM55k9B78NAUtYwxxhiLne4CNBHh6jvvwznFk2GyWDoMdxMRTBYLzimejKvvvE/2AhKMMcaYHHQ3xA0ARpMJP/jf+3GsohybV7wvDXm3tsKUkYFBEybi/GuuRe9zuOfMGGNMvXQZoAGpp1xwzjDMuHeO0k1hjDHG4qaZIW45d59Sq3R4jYwxxmKjiQBtNpvhcDiUbkbSORwOmM1mpZvBGGNMBTQRoPPz81FVVYWzZ8/qspcphMDZs2dRVVWF/HzeBIExxphG5qC7dpV2tKyurobT6VS4NclhNpvRq1cv/2tljDGW3jQRoAEpSHPwYowxli40McTNGGOMpRsO0IwxxpgKcYBmjDHGVIgDNGOMMaZCpKZlS0RUD+Cw0u2QQU8Ax5VuhAL4dacXft3phV938vQXQuQFH1RVgNYLItoshChWuh2pxq87vfDrTi/8ulOPh7gZY4wxFeIAzRhjjKkQB+jkeEXpBiiEX3d64dedXvh1pxjPQTPGGGMqxD1oxhhjTIU4QMuIiJYS0Xbv/4eIaLv3+AAicgQ89leFmyorIppPRFUBr+8HAY/NJaL9RLSXiK5Ssp1yI6JFRLSHiHYQ0ftEZPMe1/XPGwCI6Grvz3Q/Ec1Ruj3JQkRFRPQlEZUS0W4iutt7POzvvF5438N2el/fZu+x7kS0ioj2eb92U7qdciKiYQE/0+1EdJqI7lHq581D3ElCRP8HoEEI8TgRDQDwkRDiXIWblRRENB9AoxDij0HHRwJ4G8BEAIUAvgAwVAjhTnkjk4CIrgSwRgjhIqKnAUAI8WAa/LyNAMoBXAHgKID/ALhJCFGqaMOSgIgKABQIIbYSUQ6ALQBmAZiNEL/zekJEhwAUCyGOBxz7A4CTQoiF3g9m3YQQDyrVxmTy/p5XAZgE4DYo8PPmHnQSEBFB+gf8ttJtUdhMAEuEEC1CiIMA9kMK1roghPhcCOHyfrsBQF8l25NCEwHsF0IcEEK0AlgC6WetO0KIGiHEVu+fzwAoA9BH2VYpaiaAxd4/L4b0YUWvpgGoEEIoVjyLA3RyTAFQK4TYF3BsIBFtI6J1RDRFqYYl0V3eod5/Bgx79QFQGXDOUej3ze2/AXwS8L2ef97p9HP1846MjAew0Xso1O+8nggAnxPRFiK6w3uslxCixvvnYwB6KdO0lLgR7TtZKf95c4COExF9QUS7Qvwf2IO4Ce1/sDUA+gkhxgO4D8BbRKSpza2jvO6XAAwGMA7Sa/0/Jdsqp1h+3kT0MAAXgDe9hzT/82btEVE2gH8DuEcIcRo6/p0PcJEQYgKA7wO4k4guDnxQSPOjupwjJaIMAD8E8I73kCI/b1MqbqInQojLIz1ORCYA1wE4L+A5LQBavH/eQkQVAIYC2JzEpsoq2uv2IaK/AfjI+20VgKKAh/t6j2lGDD/vWwFcA2Ca9w1LFz/vKDT/c40HEZkhBec3hRDvAYAQojbg8cDfed0QQlR5v9YR0fuQpjZqiahACFHjnZ+vU7SRyfN9AFt9P2elft7cg5bf5QD2CCGO+g4QUZ434QBENAjAEAAHFGqf7Lz/UH2uBbDL++cPAdxIRBYiGgjpdW9KdfuShYiuBvAAgB8KIc4GHNf1zxtSUtgQIhro7WncCOlnrTvefJJ/ACgTQjwTcDzc77wuEFGWNykORJQF4EpIr/FDALd4T7sFwAfKtDDp2o2CKvXz5h60/ILnLQDgYgCPE5ETgAfAr4QQJ1PesuT5AxGNgzTcdQjALwFACLGbiJYBKIU0BHynXjK4vV4AYAGwSnofxwYhxK+g85+3N2v9LgCfATAC+KcQYrfCzUqWCwH8FMBO8i6bBPAQgJtC/c7rSC8A73t/r00A3hJCfEpE/wGwjIhuh7Tz4GwF25gU3g8kV6D9zzTke1zS28LLrBhjjDH14SFuxhhjTIU4QDPGGGMqxAGaMcYYUyEO0IwxxpgKcYBmjDHGVIgDNGOMMaZCHKAZY4wxFeIAzRhjjKnQ/weoSznIbyRseQAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 576x576 with 1 Axes>"
       ]
@@ -2310,13 +2628,13 @@
     {
      "data": {
       "text/html": [
-       "<style>#sk-container-id-7 {color: black;background-color: white;}#sk-container-id-7 pre{padding: 0;}#sk-container-id-7 div.sk-toggleable {background-color: white;}#sk-container-id-7 label.sk-toggleable__label {cursor: pointer;display: block;width: 100%;margin-bottom: 0;padding: 0.3em;box-sizing: border-box;text-align: center;}#sk-container-id-7 label.sk-toggleable__label-arrow:before {content: \"▸\";float: left;margin-right: 0.25em;color: #696969;}#sk-container-id-7 label.sk-toggleable__label-arrow:hover:before {color: black;}#sk-container-id-7 div.sk-estimator:hover label.sk-toggleable__label-arrow:before {color: black;}#sk-container-id-7 div.sk-toggleable__content {max-height: 0;max-width: 0;overflow: hidden;text-align: left;background-color: #f0f8ff;}#sk-container-id-7 div.sk-toggleable__content pre {margin: 0.2em;color: black;border-radius: 0.25em;background-color: #f0f8ff;}#sk-container-id-7 input.sk-toggleable__control:checked~div.sk-toggleable__content {max-height: 200px;max-width: 100%;overflow: auto;}#sk-container-id-7 input.sk-toggleable__control:checked~label.sk-toggleable__label-arrow:before {content: \"▾\";}#sk-container-id-7 div.sk-estimator input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-7 div.sk-label input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-7 input.sk-hidden--visually {border: 0;clip: rect(1px 1px 1px 1px);clip: rect(1px, 1px, 1px, 1px);height: 1px;margin: -1px;overflow: hidden;padding: 0;position: absolute;width: 1px;}#sk-container-id-7 div.sk-estimator {font-family: monospace;background-color: #f0f8ff;border: 1px dotted black;border-radius: 0.25em;box-sizing: border-box;margin-bottom: 0.5em;}#sk-container-id-7 div.sk-estimator:hover {background-color: #d4ebff;}#sk-container-id-7 div.sk-parallel-item::after {content: \"\";width: 100%;border-bottom: 1px solid gray;flex-grow: 1;}#sk-container-id-7 div.sk-label:hover label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-7 div.sk-serial::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: 0;}#sk-container-id-7 div.sk-serial {display: flex;flex-direction: column;align-items: center;background-color: white;padding-right: 0.2em;padding-left: 0.2em;position: relative;}#sk-container-id-7 div.sk-item {position: relative;z-index: 1;}#sk-container-id-7 div.sk-parallel {display: flex;align-items: stretch;justify-content: center;background-color: white;position: relative;}#sk-container-id-7 div.sk-item::before, #sk-container-id-7 div.sk-parallel-item::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: -1;}#sk-container-id-7 div.sk-parallel-item {display: flex;flex-direction: column;z-index: 1;position: relative;background-color: white;}#sk-container-id-7 div.sk-parallel-item:first-child::after {align-self: flex-end;width: 50%;}#sk-container-id-7 div.sk-parallel-item:last-child::after {align-self: flex-start;width: 50%;}#sk-container-id-7 div.sk-parallel-item:only-child::after {width: 0;}#sk-container-id-7 div.sk-dashed-wrapped {border: 1px dashed gray;margin: 0 0.4em 0.5em 0.4em;box-sizing: border-box;padding-bottom: 0.4em;background-color: white;}#sk-container-id-7 div.sk-label label {font-family: monospace;font-weight: bold;display: inline-block;line-height: 1.2em;}#sk-container-id-7 div.sk-label-container {text-align: center;}#sk-container-id-7 div.sk-container {/* jupyter's `normalize.less` sets `[hidden] { display: none; }` but bootstrap.min.css set `[hidden] { display: none !important; }` so we also need the `!important` here to be able to override the default hidden behavior on the sphinx rendered scikit-learn.org. See: https://github.com/scikit-learn/scikit-learn/issues/21755 */display: inline-block !important;position: relative;}#sk-container-id-7 div.sk-text-repr-fallback {display: none;}</style><div id=\"sk-container-id-7\" class=\"sk-top-container\"><div class=\"sk-text-repr-fallback\"><pre>TSNE(init=&#x27;random&#x27;, learning_rate=&#x27;auto&#x27;, random_state=42, verbose=1)</pre><b>In a Jupyter environment, please rerun this cell to show the HTML representation or trust the notebook. <br />On GitHub, the HTML representation is unable to render, please try loading this page with nbviewer.org.</b></div><div class=\"sk-container\" hidden><div class=\"sk-item\"><div class=\"sk-estimator sk-toggleable\"><input class=\"sk-toggleable__control sk-hidden--visually\" id=\"sk-estimator-id-7\" type=\"checkbox\" checked><label for=\"sk-estimator-id-7\" class=\"sk-toggleable__label sk-toggleable__label-arrow\">TSNE</label><div class=\"sk-toggleable__content\"><pre>TSNE(init=&#x27;random&#x27;, learning_rate=&#x27;auto&#x27;, random_state=42, verbose=1)</pre></div></div></div></div></div>"
+       "<style>#sk-container-id-2 {color: black;background-color: white;}#sk-container-id-2 pre{padding: 0;}#sk-container-id-2 div.sk-toggleable {background-color: white;}#sk-container-id-2 label.sk-toggleable__label {cursor: pointer;display: block;width: 100%;margin-bottom: 0;padding: 0.3em;box-sizing: border-box;text-align: center;}#sk-container-id-2 label.sk-toggleable__label-arrow:before {content: \"▸\";float: left;margin-right: 0.25em;color: #696969;}#sk-container-id-2 label.sk-toggleable__label-arrow:hover:before {color: black;}#sk-container-id-2 div.sk-estimator:hover label.sk-toggleable__label-arrow:before {color: black;}#sk-container-id-2 div.sk-toggleable__content {max-height: 0;max-width: 0;overflow: hidden;text-align: left;background-color: #f0f8ff;}#sk-container-id-2 div.sk-toggleable__content pre {margin: 0.2em;color: black;border-radius: 0.25em;background-color: #f0f8ff;}#sk-container-id-2 input.sk-toggleable__control:checked~div.sk-toggleable__content {max-height: 200px;max-width: 100%;overflow: auto;}#sk-container-id-2 input.sk-toggleable__control:checked~label.sk-toggleable__label-arrow:before {content: \"▾\";}#sk-container-id-2 div.sk-estimator input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-2 div.sk-label input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-2 input.sk-hidden--visually {border: 0;clip: rect(1px 1px 1px 1px);clip: rect(1px, 1px, 1px, 1px);height: 1px;margin: -1px;overflow: hidden;padding: 0;position: absolute;width: 1px;}#sk-container-id-2 div.sk-estimator {font-family: monospace;background-color: #f0f8ff;border: 1px dotted black;border-radius: 0.25em;box-sizing: border-box;margin-bottom: 0.5em;}#sk-container-id-2 div.sk-estimator:hover {background-color: #d4ebff;}#sk-container-id-2 div.sk-parallel-item::after {content: \"\";width: 100%;border-bottom: 1px solid gray;flex-grow: 1;}#sk-container-id-2 div.sk-label:hover label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-2 div.sk-serial::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: 0;}#sk-container-id-2 div.sk-serial {display: flex;flex-direction: column;align-items: center;background-color: white;padding-right: 0.2em;padding-left: 0.2em;position: relative;}#sk-container-id-2 div.sk-item {position: relative;z-index: 1;}#sk-container-id-2 div.sk-parallel {display: flex;align-items: stretch;justify-content: center;background-color: white;position: relative;}#sk-container-id-2 div.sk-item::before, #sk-container-id-2 div.sk-parallel-item::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: -1;}#sk-container-id-2 div.sk-parallel-item {display: flex;flex-direction: column;z-index: 1;position: relative;background-color: white;}#sk-container-id-2 div.sk-parallel-item:first-child::after {align-self: flex-end;width: 50%;}#sk-container-id-2 div.sk-parallel-item:last-child::after {align-self: flex-start;width: 50%;}#sk-container-id-2 div.sk-parallel-item:only-child::after {width: 0;}#sk-container-id-2 div.sk-dashed-wrapped {border: 1px dashed gray;margin: 0 0.4em 0.5em 0.4em;box-sizing: border-box;padding-bottom: 0.4em;background-color: white;}#sk-container-id-2 div.sk-label label {font-family: monospace;font-weight: bold;display: inline-block;line-height: 1.2em;}#sk-container-id-2 div.sk-label-container {text-align: center;}#sk-container-id-2 div.sk-container {/* jupyter's `normalize.less` sets `[hidden] { display: none; }` but bootstrap.min.css set `[hidden] { display: none !important; }` so we also need the `!important` here to be able to override the default hidden behavior on the sphinx rendered scikit-learn.org. See: https://github.com/scikit-learn/scikit-learn/issues/21755 */display: inline-block !important;position: relative;}#sk-container-id-2 div.sk-text-repr-fallback {display: none;}</style><div id=\"sk-container-id-2\" class=\"sk-top-container\"><div class=\"sk-text-repr-fallback\"><pre>TSNE(init=&#x27;random&#x27;, learning_rate=&#x27;auto&#x27;, random_state=42, verbose=1)</pre><b>In a Jupyter environment, please rerun this cell to show the HTML representation or trust the notebook. <br />On GitHub, the HTML representation is unable to render, please try loading this page with nbviewer.org.</b></div><div class=\"sk-container\" hidden><div class=\"sk-item\"><div class=\"sk-estimator sk-toggleable\"><input class=\"sk-toggleable__control sk-hidden--visually\" id=\"sk-estimator-id-2\" type=\"checkbox\" checked><label for=\"sk-estimator-id-2\" class=\"sk-toggleable__label sk-toggleable__label-arrow\">TSNE</label><div class=\"sk-toggleable__content\"><pre>TSNE(init=&#x27;random&#x27;, learning_rate=&#x27;auto&#x27;, random_state=42, verbose=1)</pre></div></div></div></div></div>"
       ],
       "text/plain": [
        "TSNE(init='random', learning_rate='auto', random_state=42, verbose=1)"
       ]
      },
-     "execution_count": 166,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2328,8 +2646,16 @@
     "    fingerprints = fingerprint_all(files_to_fingerprint)\n",
     "    return visualize(fingerprints, fingerprints_to_highlight = [fps1, fps2]) \n",
     "\n",
-    "train_and_fingerprint(0, .0005, fnames)"
+    "train_and_fingerprint(20, .0005, fnames)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f6da7af-1850-41dd-9c32-a694901b4212",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/TripletLossTutorial.ipynb
+++ b/TripletLossTutorial.ipynb
@@ -90,28 +90,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 1,
    "id": "70695725",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T13:57:56.754180Z",
+     "iopub.status.busy": "2022-08-16T13:57:56.753425Z",
+     "iopub.status.idle": "2022-08-16T13:57:58.619255Z",
+     "shell.execute_reply": "2022-08-16T13:57:58.618532Z",
+     "shell.execute_reply.started": "2022-08-16T13:57:56.754114Z"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "from fastai.vision import *\n",
-    "from fastai.basics import *\n",
+    "#from fastai.vision import *\n",
+    "#from fastai.basics import *\n",
     "from fastai.vision.all import *\n",
     "\n",
     "\n",
-    "from fastai.vision.augment import *\n",
-    "from fastai.vision.learner import cnn_learner\n",
-    "from fastai.vision.models import resnet34\n",
-    "from fastai.metrics import accuracy\n",
+    "#from fastai.vision.augment import *\n",
+    "#from fastai.vision.learner import cnn_learner\n",
+    "#from fastai.vision.models import resnet34\n",
+    "#from fastai.metrics import accuracy\n",
     "from fastai.data.core import DataLoaders"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 3,
    "id": "cf0f774d",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T13:58:06.977403Z",
+     "iopub.status.busy": "2022-08-16T13:58:06.976857Z",
+     "iopub.status.idle": "2022-08-16T13:58:06.981038Z",
+     "shell.execute_reply": "2022-08-16T13:58:06.980002Z",
+     "shell.execute_reply.started": "2022-08-16T13:58:06.977383Z"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import torch\n",
@@ -122,9 +140,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 4,
    "id": "ba5fc5c8",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T13:58:07.600191Z",
+     "iopub.status.busy": "2022-08-16T13:58:07.599534Z",
+     "iopub.status.idle": "2022-08-16T13:58:07.603257Z",
+     "shell.execute_reply": "2022-08-16T13:58:07.602459Z",
+     "shell.execute_reply.started": "2022-08-16T13:58:07.600171Z"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from scipy import spatial\n",
@@ -133,9 +160,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 5,
    "id": "5eee8960",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T13:58:09.852438Z",
+     "iopub.status.busy": "2022-08-16T13:58:09.852111Z",
+     "iopub.status.idle": "2022-08-16T13:58:09.996708Z",
+     "shell.execute_reply": "2022-08-16T13:58:09.995856Z",
+     "shell.execute_reply.started": "2022-08-16T13:58:09.852393Z"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%matplotlib inline \n",
@@ -159,17 +195,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 6,
    "id": "6db7e95b",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T13:58:11.269917Z",
+     "iopub.status.busy": "2022-08-16T13:58:11.269216Z",
+     "iopub.status.idle": "2022-08-16T13:58:11.276243Z",
+     "shell.execute_reply": "2022-08-16T13:58:11.275306Z",
+     "shell.execute_reply.started": "2022-08-16T13:58:11.269896Z"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'2.3.2'"
+       "'2.7.9'"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -181,9 +226,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 7,
    "id": "2f72706c",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T13:58:12.201549Z",
+     "iopub.status.busy": "2022-08-16T13:58:12.200727Z",
+     "iopub.status.idle": "2022-08-16T13:58:12.207786Z",
+     "shell.execute_reply": "2022-08-16T13:58:12.206300Z",
+     "shell.execute_reply.started": "2022-08-16T13:58:12.201528Z"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -191,7 +245,7 @@
        "True"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -202,9 +256,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 8,
    "id": "a6a0b375",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T13:58:13.054026Z",
+     "iopub.status.busy": "2022-08-16T13:58:13.053484Z",
+     "iopub.status.idle": "2022-08-16T13:58:13.062453Z",
+     "shell.execute_reply": "2022-08-16T13:58:13.061350Z",
+     "shell.execute_reply.started": "2022-08-16T13:58:13.054007Z"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "device = 0\n",
@@ -229,9 +292,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 9,
    "id": "0963c65b",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T13:58:16.174960Z",
+     "iopub.status.busy": "2022-08-16T13:58:16.174746Z",
+     "iopub.status.idle": "2022-08-16T13:58:16.445157Z",
+     "shell.execute_reply": "2022-08-16T13:58:16.444409Z",
+     "shell.execute_reply.started": "2022-08-16T13:58:16.174931Z"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "mnist = untar_data(URLs.MNIST)\n",
@@ -248,15 +320,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 10,
    "id": "1dc11dfc",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T13:58:18.230571Z",
+     "iopub.status.busy": "2022-08-16T13:58:18.230354Z",
+     "iopub.status.idle": "2022-08-16T13:58:21.768404Z",
+     "shell.execute_reply": "2022-08-16T13:58:21.767684Z",
+     "shell.execute_reply.started": "2022-08-16T13:58:18.230555Z"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# The proper label for an image is the name of the directory it's in. e.g., \"1\" is the proper label for `1/1.png`\n",
     "def label_func(x): return x.parent.name\n",
     "\n",
-    "dls = ImageDataLoaders.from_path_func(mnist, fnames, label_func)"
+    "dls = ImageDataLoaders.from_path_func(mnist, fnames, label_func, bs=512)"
    ]
   },
   {
@@ -273,24 +354,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 11,
    "id": "0653e678",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T13:58:21.769391Z",
+     "iopub.status.busy": "2022-08-16T13:58:21.769260Z",
+     "iopub.status.idle": "2022-08-16T13:58:21.773339Z",
+     "shell.execute_reply": "2022-08-16T13:58:21.772276Z",
+     "shell.execute_reply.started": "2022-08-16T13:58:21.769376Z"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# output_embedding_length = 128\n",
-    "output_embedding_length = 128"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 55,
-   "id": "67e56f84",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# dls.valid_dl.new(shuffle=True)\n",
-    "# Original is a fastai data (valid_dl etc.)"
+    "output_embedding_length = 32"
    ]
   },
   {
@@ -303,19 +382,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 13,
    "id": "c7b0afd0",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T13:59:26.951698Z",
+     "iopub.status.busy": "2022-08-16T13:59:26.951310Z",
+     "iopub.status.idle": "2022-08-16T13:59:27.224980Z",
+     "shell.execute_reply": "2022-08-16T13:59:27.224104Z",
+     "shell.execute_reply.started": "2022-08-16T13:59:26.951669Z"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "learn = cnn_learner(dls, resnet34, metrics=accuracy, loss_func=TripletLoss(device))"
+    "#learn = vision_learner(dls, resnet34, metrics=accuracy, loss_func=TripletLoss(device))\n",
+    "learn = vision_learner(dls, resnet34, metrics=[], loss_func=TripletLoss(device))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 14,
    "id": "b53ba4fd",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T13:59:30.815924Z",
+     "iopub.status.busy": "2022-08-16T13:59:30.815753Z",
+     "iopub.status.idle": "2022-08-16T13:59:30.822858Z",
+     "shell.execute_reply": "2022-08-16T13:59:30.821996Z",
+     "shell.execute_reply.started": "2022-08-16T13:59:30.815909Z"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -336,12 +434,13 @@
        ")"
       ]
      },
-     "execution_count": 91,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "# learn.model[0] contains the network's \"body\", and model[1] just the head:\n",
     "learn.model[1]"
    ]
   },
@@ -355,9 +454,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 15,
    "id": "aab61b3e",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T13:59:32.038280Z",
+     "iopub.status.busy": "2022-08-16T13:59:32.038095Z",
+     "iopub.status.idle": "2022-08-16T13:59:32.043105Z",
+     "shell.execute_reply": "2022-08-16T13:59:32.042223Z",
+     "shell.execute_reply.started": "2022-08-16T13:59:32.038264Z"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "class L2_norm(nn.Module):\n",
@@ -370,21 +478,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 16,
    "id": "2428d5fe",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T13:59:32.886293Z",
+     "iopub.status.busy": "2022-08-16T13:59:32.886113Z",
+     "iopub.status.idle": "2022-08-16T13:59:32.905455Z",
+     "shell.execute_reply": "2022-08-16T13:59:32.904730Z",
+     "shell.execute_reply.started": "2022-08-16T13:59:32.886277Z"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "layers = learn.model[1]\n",
-    "learn.model[1] = nn.Sequential(layers[0], layers[1], layers[2], layers[3], nn.Linear(in_features=1024, out_features=output_embedding_length, bias=False), L2_norm()).to(device)\n",
+    "learn.model[1] = nn.Sequential(\n",
+    "#    layers[0], layers[1], layers[2], layers[3], nn.Linear(in_features=1024, out_features=output_embedding_length, bias=False), L2_norm()\n",
+    "    layers[0], layers[1], layers[2], layers[3], layers[4], layers[5], layers[6], layers[7], \n",
+    "    nn.Linear(in_features=512, out_features=output_embedding_length, bias=False), L2_norm()\n",
+    ").to(device)\n",
     "    "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 17,
    "id": "5a6c7671",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T13:59:34.422847Z",
+     "iopub.status.busy": "2022-08-16T13:59:34.422603Z",
+     "iopub.status.idle": "2022-08-16T13:59:34.428400Z",
+     "shell.execute_reply": "2022-08-16T13:59:34.427427Z",
+     "shell.execute_reply.started": "2022-08-16T13:59:34.422817Z"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -397,12 +527,16 @@
        "  (1): Flatten(full=False)\n",
        "  (2): BatchNorm1d(1024, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
        "  (3): Dropout(p=0.25, inplace=False)\n",
-       "  (4): Linear(in_features=1024, out_features=128, bias=False)\n",
-       "  (5): L2_norm()\n",
+       "  (4): Linear(in_features=1024, out_features=512, bias=False)\n",
+       "  (5): ReLU(inplace=True)\n",
+       "  (6): BatchNorm1d(512, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "  (7): Dropout(p=0.5, inplace=False)\n",
+       "  (8): Linear(in_features=512, out_features=32, bias=False)\n",
+       "  (9): L2_norm()\n",
        ")"
       ]
      },
-     "execution_count": 94,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -435,10 +569,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 18,
    "id": "df59ac88",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T13:59:40.465505Z",
+     "iopub.status.busy": "2022-08-16T13:59:40.465293Z",
+     "iopub.status.idle": "2022-08-16T13:59:54.911629Z",
+     "shell.execute_reply": "2022-08-16T13:59:54.910289Z",
+     "shell.execute_reply.started": "2022-08-16T13:59:40.465475Z"
+    },
+    "tags": []
+   },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<style>\n",
+       "    /* Turns off some styling */\n",
+       "    progress {\n",
+       "        /* gets rid of default border in Firefox and Opera. */\n",
+       "        border: none;\n",
+       "        /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
+       "        background-size: auto;\n",
+       "    }\n",
+       "    progress:not([value]), progress:not([value])::-webkit-progress-bar {\n",
+       "        background: repeating-linear-gradient(45deg, #7e7e7e, #7e7e7e 10px, #5c5c5c 10px, #5c5c5c 20px);\n",
+       "    }\n",
+       "    .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
+       "        background: #F44336;\n",
+       "    }\n",
+       "</style>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "data": {
       "text/html": [],
@@ -452,16 +622,16 @@
     {
      "data": {
       "text/plain": [
-       "SuggestedLRs(lr_min=0.33113112449646, lr_steep=0.10000000149011612)"
+       "SuggestedLRs(valley=0.005248074419796467)"
       ]
      },
-     "execution_count": 95,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAEKCAYAAAAIO8L1AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAApKklEQVR4nO3deXxU9b3/8ddnZrIHCJCwRxYJSESWmlI3FJdWXK5Ye2+rVdv6cym91dr23v603v7u7e/Rzf5u21tbbS3de7tYa9XaitpeW1yqVYIEEAFlEQmLhCUJkHUyn98fM9AYB0hIDmcmeT8fjzzInGXmPQPMe873nDnH3B0REZGuImEHEBGRzKSCEBGRtFQQIiKSlgpCRETSUkGIiEhaKggREUkrFnaAvlRaWuoTJkwIO4aISNZYtmzZLncvSzevXxXEhAkTqK6uDjuGiEjWMLPNh5unISYREUkr0IIws/lmts7M1pvZ7WnmDzWzh8xspZm9aGbTO837lJmtNrOXzexXZpYfZFYREXmrwArCzKLAPcBFQCVwlZlVdlnsDqDG3WcAHwLuSq07FvgEUOXu04EocGVQWUVE5O2C3IKYA6x3943u3gbcByzoskwl8CSAu68FJpjZyNS8GFBgZjGgENgWYFYREekiyIIYC2zpdLs2Na2zFcAVAGY2BxgPjHP3rcDXgDeA7UCDu/8x3YOY2U1mVm1m1XV1dX38FEREBq4gC8LSTOt66tg7gaFmVgPcAiwH4mY2lOTWxkRgDFBkZtekexB3X+TuVe5eVVaW9kgtERE5BkEe5loLlHe6PY4uw0Tu3ghcB2BmBmxK/VwIbHL3utS8B4EzgJ8HmFcyVEt7B81tHbTEO2iLJygtzqMo7+j/dOMdCRpb4tQ3tdHc3kFLe4LW9g7iCceBhDt48k93iEaNEYPyGDk4n2GFuUQi6T7jiAwcQRbEUqDCzCYCW0nuZP5g5wXMrARoSu2juAF42t0bzewN4DQzKwSagfOBwL7gsGTdTgpzY5QU5lBSkENpcZ7eHI6Bu9PU1kFjSzv7WuLsb42zvyXOngNtbNp1gNd3H2BHQwulg/IYW1LAqMH5JFLrHGiN0xpPEE8kiHc4jS3tbNnTzJa9TdQ3tb/tsYYW5lA+rJDcaISmtg6a2zsOvfl3JJy2eIJ9rfFjfi45UWPk4HzGDClgdEk+IwblUZb6KSnIJT8nSkFulPycCLGIEY1EiJrhOAmHjoTTGk8WW3N7B8V5MU4cUczg/Jy3PE68I0Fz+9+Xi5iRG4uQE03eHwaW+qfY0eHEE07CHTOImGHAgdYOGprbaWxppyA3yugh+ZQV5xGL6ih26Z3ACsLd42Z2M/AEyaOQfuTuq81sYWr+vcA04Gdm1gG8AlyfmveCmT0AvATESQ49LQoq60f/exmt8cSh26dPGs7Pb3gXUZUEAImEU7u3mTU7Gnl91wH2NLVRf6A9+WdTG3sOtLG3qZ2G5nY6EukvQGXGoVJ4ZVsj//PKm295zXNjEfJjEWLR5BtucV6MccMKmTFuCGNKCijMjZKfEyUnGmHnvhZq9zZTu7eZeEeCksIcCnJj5MUOvlkbOdHIocIfUphDQU6M/JwI+TlRYhHDzEi9/xKNGIbR1pGgbl8LOxpa2NHYyo6GZrY1tPDSG3vZ2dj6lrzH6mDRNDS3U9/Uzv5elNiRRAxGDMpn1JB8Rg/JZ/SQAsYPL0z9FFFanEtxXgwz/RuXw7P+dEW5qqoq7+k3qd2d1dsaqW9qp765jZe3NnLvUxv4/D9U8pEzJx5a7kBrnN9Ub2H+9NGMGvLWr2S0xjuo25d8A2mLJzCDsuI8hh7DMEW8I8G+lnjyU2Xqk2VTWwcH2uI0t3WQcCcWSb4R7m+Ns37nftbv3M+OxhYG5ccYWpjLkIIcCnKj5EYj5MYi1O1rZdOuA2zadYDWeAejhuQzanABw4pyOJD69N7U2kEkAjnR5KfXtniCA23J6Vvrm9/yRpYbjTC0KIehhbkMLcxlWFFu8s24MIfB+TkMLsihOC9GcX6M4rzYoU/7ebHoW173vU3tRCNGYW7yjT+TuTv7W+PU7WulsSVOU1ucltSwVUdqqyWecCIHP9kb5MWiFOYmtzTqm9rZUJf8u9pzoO1QcQ0pyKEoN0ZBbpSCnCgJd9o7nLZ4Bx2efNyDYhEjGo0QMfDUvIRDUV6MIQU5DMqP0dzWwfaGFrY3NLO9oYU3G1vY3tDC1r3NNLd3vOU5xSJGSWEO08cO4cKTR3HBtJGUDco73i+thMzMlrl7Vdp5A70gunJ3PvzjpSx7fQ9/+vQ5jCkpoC2e4PqfLuWZ13ZRkBPlY/NO5Ma5k9jX0s7Pnt/ML17YzN40wyDRiFFWnMfIwXmpN+V8hhXlHXozbWhu59U39/Ham/up3dtMQ3PPP1FGI8b4YYWMLsk/NNRQ39RGS3uClngH7jAoL8aksiImlhZRkBtle0PyU3J9UzuFeVEG5SXfoBIO7R0J2jsS5EYjFOXFKMyNMnJwPtNGD+akUYOYPKJYnzyzkLtTt7+Vzbub2Ly7ib0H2tjb1Mbu/W08t3EXW/Y0YwYzxg5h9glDmX1CCbPLh1I+rEB/1/2cCqKHtuxp4t3/9RRnTS5j0bWn8un7a3i4Zhu3zT+JVVvrWbxqB6XFeTQ0txFPOO+eNpLzThpBQW6UvFiEjgTU7Wuhbn8rbza28mbjwWGLFva1vLUABuXHmDJyEOOHFR76RDk4P+fQJ8/8nOihT5iFuVEiZofG6Qtzo5ww/K2fzDtzT36qPTikIpKOu7N2xz6eWL2D5zfsZmVtw6GtjcH5MSrHDGbmuBJumDtJWxj9kAriGCx6egNfXryWM04cznMbdvOZC6fy8XMnA/DCxt3c+9QGxg8v4rozJzB+eFG377e9I3HoU35xXg4jB+fpzVsySrwjwdod+1hRW8/qbY2s3tbIK9saGFaUy3euPpVTxw8NO6L0IRXEMYh3JLjs7r/yyvZGPnLGBP7jHyr1Ri4D1ivbGln482Vsb2jm3y+t5JrTxuv/Qz+hgjhGr+86wFOv1nHtaeN12KsMeA1N7Xzq/hr+vHYncytK+eQFU7Q10Q+oIESkTyQSzo+fe517/rKePQfamFtRym3zT2L62CFhR5NjdKSCyOxjC0Uko0QixvVnTeTZ287ljotP4pVtjVy16G+s37k/7GgSABWEiPRYYW6Mm84+kUduOYu8nAg3/HQp9U1tYceSPqaCEJFjNrakgO9deyrb6lv451+8RHtH779tLplDBSEivXLq+GF85YpTeG7Dbm7/7SrebGwJO5L0kSBP1iciA8T7Th3Hxl37uecvG3hweS3vHD+My2eP5ao55TocNoupIESkT3zmwpN47+xxLF61nT+s3MYdD61iWFEO86ePDjuaHCMNMYlIn5k8ophPnF/B4k/MZVhRLo+9vCPsSNILKggR6XOxaIQLpo3gz2t20hrvOPoKkpFUECISiPnTR7GvNc5zG3aHHUWOkQpCRAJxxomlFOfF+ONqDTNlKxWEiAQiPyfKuSeN4I+r3zzslQYls6kgRCQw808exe4DbVS/vifsKHIMVBAiEph5U8vIjUV4XMNMWUkFISKBKcqLcXZFGU+8vIP+dObogUIFISKBmj99FNsaWli1tSHsKNJDKggRCdQF00aQG4vwyV/X8Mq2xrDjSA+oIEQkUCWFufzkI+9kX0ucy7/zV372/OsabsoSgRaEmc03s3Vmtt7Mbk8zf6iZPWRmK83sRTOb3mleiZk9YGZrzWyNmZ0eZFYRCc4Zk0t57Na5nHHicP79d6v5zAMrVRJZILCCMLMocA9wEVAJXGVmlV0WuwOocfcZwIeAuzrNuwt43N1PAmYCa4LKKiLBKy3O40cffic3nzuZB5bV8p0lG8KOJEcR5BbEHGC9u2909zbgPmBBl2UqgScB3H0tMMHMRprZYOBs4IepeW3uXh9gVhE5DiIR41/eM4XLZo7hP59Yp29ZZ7ggC2IssKXT7drUtM5WAFcAmNkcYDwwDpgE1AE/NrPlZvYDMysKMKuIHCdmxv/7xxnMHDeET/66hjXbteM6UwVZEOmuEtJ10PFOYKiZ1QC3AMuBOMnrVLwD+K67zwYOAG/bhwFgZjeZWbWZVdfV1fVVdhEJUH5OlEUfqmJQfoyFP1+mU3FkqCALohYo73R7HLCt8wLu3uju17n7LJL7IMqATal1a939hdSiD5AsjLdx90XuXuXuVWVlZX38FEQkKCMH5/O5SyrZvLuJv23UGV8zUZAFsRSoMLOJZpYLXAk80nmB1JFKuambNwBPp0pjB7DFzKam5p0PvBJgVhEJwbsrR1KcF+N3NVvDjiJpBFYQ7h4HbgaeIHkE0v3uvtrMFprZwtRi04DVZraW5NFOt3a6i1uAX5jZSmAW8OWgsopIOPJzolx48igeW7WDlnZdWCjTBHpNandfDCzuMu3eTr8/D1QcZt0aoCrIfCISvgWzxvDbl2pZsm6nrl+dYfRNahEJ1RknDqe0OJff1Ww7+sJyXKkgRCRUsWiES2eM4cm1O2lsaQ87jnSighCR0C2YNYa2eILHX9YX5zKJCkJEQjervITxwwt5RMNMGUUFISKhMzMWzBzDcxt2sbW+Oew4kqKCEJGM8P53lpMTjfDlR3VezkyhghCRjDBuaCE3nzuZR1dt56lXddqcTKCCEJGMcdM5k5hUVsS//+5lfXEuA6ggRCRj5MWifGHBdDbvbuK7ul5E6FQQIpJRzpxcymUzx/DdJRvYtOtA2HEGNBWEiGScz106jZyo8V9/ejXsKAOaCkJEMs6IQflcc/p4/rByGxvr9ocdZ8BSQYhIRrpx7iRyYxHu+Yv2RYRFBSEiGam0OI8PzhnPwzVbeWN3U9hxBiQVhIhkrI+eM4loxPjuU+vDjjIgqSBEJGONHJzPB6rKeWBZrU7BEQIVhIhktIXzTsQdvv/0xrCjDDgqCBHJaGNLCrjw5FH8YeU2OhIedpwBRQUhIhnv4lNGs2t/Gy9u2hN2lAFFBSEiGW/e1DLycyI89vL2sKMMKCoIEcl4RXkx5k0ZwWMv7yChYabjRgUhIlnh4hmjqdvXSvXmvWFHGTBUECKSFc47aQS5sQiLV2mY6XhRQYhIVijOi3HOlDIe1zDTcRNoQZjZfDNbZ2brzez2NPOHmtlDZrbSzF40s+ld5kfNbLmZ/SHInCKSHS45ZTQ7GltYvqU+7CgDQmAFYWZR4B7gIqASuMrMKrssdgdQ4+4zgA8Bd3WZfyugC9SKCADnTRtBblTDTMdLkFsQc4D17r7R3duA+4AFXZapBJ4EcPe1wAQzGwlgZuOAS4AfBJhRRLLI4Pwc5laU8vjLO3DXMFPQgiyIscCWTrdrU9M6WwFcAWBmc4DxwLjUvG8C/xtIHOlBzOwmM6s2s+q6Ol3oXKS/O2/aCLbWN7NRV5sLXJAFYWmmda38O4GhZlYD3AIsB+Jmdimw092XHe1B3H2Ru1e5e1VZWVlvM4tIhju7Ivn//JlX9YEwaEEWRC1Q3un2OGBb5wXcvdHdr3P3WST3QZQBm4AzgcvM7HWSQ1PnmdnPA8wqIlmifFghE4YX8sxru8KO0u8FWRBLgQozm2hmucCVwCOdFzCzktQ8gBuAp1Ol8Vl3H+fuE1Lr/dndrwkwq4hkkbkVZTy/cTdt8SOOQEsvBVYQ7h4HbgaeIHkk0v3uvtrMFprZwtRi04DVZraW5NFOtwaVR0T6j7MqSmlq6+ClN/St6iDFgrxzd18MLO4y7d5Ovz8PVBzlPpYASwKIJyJZ6vQThxONGM+8Vsdpk4aHHaff0jepRSTrDM7PYXZ5Cc9qP0SgVBAikpXmVpSxcmsDew+0hR2l31JBiEhWmjulFHf46wZtRQRFBSEiWWnG2CEMzo/xzKsqiKCoIEQkK8WiEc44sZRnXqvTaTcCooIQkax1ztQytjW08NDyrWFH6ZdUECKStd47eyynTxrOZx5YyZNr3gw7Tr+jghCRrJWfE+X7H67i5DGD+edfvMQLG3eHHalfUUGISFYrzovxk+vmMG5oATf8tJoNdfvDjtRvqCBEJOsNK8rlZ9e/i/1tcR6p2Xb0FaRbVBAi0i+MLSlg6shB1OhypH1GBSEi/cbsE0qo2VJPIqHDXvuCCkJE+o3Z5UNpaG5n025dba4vqCBEpN+YdUIJAMvfqA81R3+hghCRfmNyWTGD8mIs13Ui+oQKQkT6jUjEmFleoh3VfUQFISL9yuwTSli7Yx9NbfGwo2Q9FYSI9CuzykvoSDirahvCjpL1VBAi0q/MKi8BYLmGmXpNBSEi/crw4jzGDy/Ujuo+oIIQkX5ndnkJy9+o13UiekkFISL9zuwThrJzXyvbG1rCjpLVVBAi0u8c2g+hL8z1SrcKwsyKzCyS+n2KmV1mZjndWG++ma0zs/Vmdnua+UPN7CEzW2lmL5rZ9NT0cjP7i5mtMbPVZnZrT5+YiAxc00YPJjcWYdlm7Yfoje5uQTwN5JvZWOBJ4DrgJ0dawcyiwD3ARUAlcJWZVXZZ7A6gxt1nAB8C7kpNjwP/4u7TgNOAj6dZV0QkrdxYhNMnDeeJ1Tt04r5e6G5BmLs3AVcA33b395J80z+SOcB6d9/o7m3AfcCCLstUkiwc3H0tMMHMRrr7dnd/KTV9H7AGGNvNrCIivHf2WLbWN/Pi63vCjpK1ul0QZnY6cDXwaGpa7CjrjAW2dLpdy9vf5FeQLB3MbA4wHhjX5YEnALOBF7qZVUSE95w8ksLcKA8v3xp2lKzV3YL4JPBZ4CF3X21mk4C/HGUdSzOt67bencBQM6sBbgGWkxxeSt6BWTHwW+CT7t6Y9kHMbjKzajOrrqur685zEZEBoDA3xvyTR/Hoqu20tHeEHScrdasg3P0pd7/M3b+a2lm9y90/cZTVaoHyTrfHAW+5FqC7N7r7de4+i+Q+iDJgE0BqJ/hvgV+4+4NHyLbI3avcvaqsrKw7T0dEBoj3vmMs+1ri/HntzrCjZKXuHsX0SzMbbGZFwCvAOjP7zFFWWwpUmNlEM8sFrgQe6XK/Jal5ADcAT7t7o5kZ8ENgjbt/oydPSETkoDNOLGXEoDwefEnDTMeiu0NMlakhnsuBxcAJwLVHWsHd48DNwBMkdzLfnxqeWmhmC1OLTQNWm9lakkc7HTyc9czU/Z9nZjWpn4t78LxERIhGjAWzxrBk3U72HGgLO07WOdqO5oNyUkM+lwN3u3u7mR312DF3X0yyUDpPu7fT788DFWnWe5b0+zBERHrkvbPH8f1nNvHoym1ce/qEsONkle5uQXwPeB0oAp42s/FA2p3GIiKZpHLMYE4aNYiHdDRTj3V3J/W33H2su1/sSZuBcwPOJiLSJy48eRTLt9RT36Rhpp7o7k7qIWb2jYOHk5rZ10luTYiIZLy5FaW4w3MbdocdJat0d4jpR8A+4P2pn0bgx0GFEhHpSzPLSyjOi/HMa7vCjpJVuruT+kR3f1+n2/839eU2EZGMlxONcNqk4Ty7Xl+m7YnubkE0m9lZB2+Y2ZlAczCRRET63tyKUrbsaWbz7gNhR8ka3d2CWAj8zMyGpG7vBT4cTCQRkb53VkUpAM+u38X44dqF2h3dPYpphbvPBGYAM9x9NnBeoMlERPrQpNIixgzJ51nth+i2Hl1RLnXupIPff/h0AHlERAJhZpxVUcpzG3bToWtEdEtvLjmqbzqLSFY5q6KMhuZ2Vm1tCDtKVuhNQaiCRSSrnHnicACefU1HM3XHEQvCzPaZWWOan33AmOOUUUSkTwwvzqNy9GB9H6KbjlgQ7j7I3Qen+Rnk7t09AkpEJGPMrSjlpTf2cqA1fvSFB7jeDDGJiGSds6eU0d7hPK/TbhyVCkJEBpSqCUMpzI2y5FVdZe5oVBAiMqDkxaKccWIpS9bV4a5jbY5EBSEiA868qWXU7m1mQ51Ou3EkKggRGXDmTS0DYMk6DTMdiQpCRAaccUMLmTyimKde1fchjkQFISID0rwpZbywcQ9NbTrc9XBUECIyIJ0ztYy2joQOdz0CFYSIDEhzJg6jICfKknUaZjocFYSIDEjJw12Hs+TVnTrc9TBUECIyYM2bWsaWPTrc9XACLQgzm29m68xsvZndnmb+UDN7yMxWmtmLZja9u+uKiPTW+dNGkhuLcMdDq2iNd4QdJ+MEVhBmFgXuAS4CKoGrzKyyy2J3ADXuPgP4EHBXD9YVEemVMSUF/Oc/zuDFTXv47G9XaaipiyC3IOYA6919o7u3AfcBC7osUwk8CeDua4EJZjaym+uKiPTagllj+fS7p/Dg8q18+8/rw46TUYIsiLHAlk63a1PTOlsBXAFgZnOA8cC4bq5Lar2bzKzazKrr6nQ0goj03C3nTeaKd4zlG396lUdXbg87TsYIsiDSXZK06/bbncBQM6sBbgGWA/Furpuc6L7I3avcvaqsrKwXcUVkoDIzvnLFKcwqL+FzD69iz4G2sCNlhCALohYo73R7HLCt8wLu3uju17n7LJL7IMqATd1ZV0SkL+XFotz5vlPY1xLnK4vXhB0nIwRZEEuBCjObaGa5wJXAI50XMLOS1DyAG4Cn3b2xO+uKiPS1k0YN5sazJ/GbZbX6hjUBFoS7x4GbgSeANcD97r7azBaa2cLUYtOA1Wa2luQRS7cead2gsoqIHPSJ8yooH1bAvz2sQ1+tPx3WVVVV5dXV1WHHEJEst2TdTj7y46V88oIKPnnBlLDjBMrMlrl7Vbp5+ia1iEgX86aO4JIZo7n3qQ282dgSdpzQqCBERNK47cKT6Eg43/yf18KOEhoVhIhIGicML+Tqd43n/uotbKjbH3acUKggREQO4+bzJpMfi/C1J9aFHSUUKggRkcMoLc7jhrmTeOzlHdRsqQ87znEXCzuAiEgmu/HsSfz8b5v53MOruPiU0eREIhTnx7hs5hiK8vr3W2j/fnYiIr1UnBfjjouncdtvV/Ly1sZD03/8100suraKCaVFIaYLlr4HISLSDfGOBPGE096RoHrzXj716xoSCeeuq2Zz7tQRYcc7ZvoehIhIL8WiEfJzogzKz+HcqSP4/c1nMXZoIf/rJ0t5ePnWsOMFQgUhInIMyocV8uDHzmB2eQlffHQNB1rjYUfqcyoIEZFjVJAb5XOXVrJrfyvff2Zj2HH6nApCRKQX3nHCUC6aPopFT2+kbl9r2HH6lApCRKSXPnPhVFrjCe568tWwo/QpFYSISC9NKivmqjnl/OrFLWzsR6flUEGIiPSBW8+fQl4swhcfXUN/+fqACkJEpA+UDcrjX98zlT+v3cm9T/WPHdYqCBGRPnLdmRO4dMZo/vOJtfx1/a6w4/SaCkJEpI+YGV993wwmjyjmll8tZ2t9c9iRekXnYhIR6UNFeTHuveZUFtz9Vz7wveeZWV7C8KJcxg8v4trTxpMby57P5SoIEZE+NqmsmO9c8w6+/eR61mxrZE9TG/VN7bg7N8ydFHa8blNBiIgEYG5FGXMryg7d/uD3/8b3nt7INaeNJz8nGmKy7suebR0RkSx2y3kV1O1r5b4X3wg7SrepIEREjoPTJg3jnROGcu9TG2mNd4Qdp1sCLQgzm29m68xsvZndnmb+EDP7vZmtMLPVZnZdp3mfSk172cx+ZWb5QWYVEQmSmfGJ8yvY0djCA8tqw47TLYEVhJlFgXuAi4BK4Cozq+yy2MeBV9x9JjAP+LqZ5ZrZWOATQJW7TweiwJVBZRUROR7OmlzKrPISvvOXDbR3JMKOc1RBbkHMAda7+0Z3bwPuAxZ0WcaBQWZmQDGwBzh4UvUYUGBmMaAQ2BZgVhGRwCW3Iiaztb6Zn/9tc9hxjirIghgLbOl0uzY1rbO7gWkk3/xXAbe6e8LdtwJfA94AtgMN7v7HALOKiBwX504dwTlTyvjy4jUsfX1P2HGOKMiCsDTTup7B6kKgBhgDzALuNrPBZjaU5NbGxNS8IjO7Ju2DmN1kZtVmVl1XV9dX2UVEAmFmfOvK2YwbWsjHfr4so79tHWRB1ALlnW6P4+3DRNcBD3rSemATcBJwAbDJ3evcvR14EDgj3YO4+yJ3r3L3qrKysnSLiIhklCGFOXz/Q6fS0p7go/9dTXNbZh7VFGRBLAUqzGyimeWS3Mn8SJdl3gDOBzCzkcBUYGNq+mlmVpjaP3E+sCbArCIix9XkEYO468pZrN7WyBcffSXsOGkFVhDuHgduBp4g+eZ+v7uvNrOFZrYwtdgXgDPMbBXwJHCbu+9y9xeAB4CXSO6biACLgsoqIhKG86eN5Mp3lvPAsloaW9rDjvM21l8ubAFQVVXl1dXVYccQEem2FVvqWXDPX/nSe6dz9bvGH/fHN7Nl7l6Vbp6+SS0iEqIZ44YwdeQg7q/OvC/PqSBEREJkZrz/neWs2FLPuh37wo7zFioIEZGQXT5rDDlR4zfVW46+8HGkghARCdnw4jwumDaSh5ZvpS2eOafgUEGIiGSA91eVs/tAG39e+2bYUQ5RQYiIZIC5FaWMHJzHfUszZ5hJBSEikgFi0QhXv2s8S9bV8d0lG8KOA+iSoyIiGePj505mQ91+vvr4WmIR48azw71+tQpCRCRDRCPG1/9pJvGE86XFa4hEjOvPmhhaHhWEiEgGiUUjfPMDs0gknC/84RXeNXEY08cOCSWL9kGIiGSYnGiEO6+YQU7UeGRFeNdKU0GIiGSgIYU5nDm5lEdXbiesc+apIEREMtQlp4xma30zK2obQnl8FYSISIZ6T+UocqLG4lXbQ3l8FYSISIYKe5hJBSEiksHCHGZSQYiIZLAwh5lUECIiGSzMYSYVhIhIhjs4zFSzpf64Pq4KQkQkw72nchTFeTE+//tXaI13HLfHVUGIiGS4IYU5fO2fZrBiSz3//vDq4zbUpIIQEckC86eP5uZzJ/Pr6i388sU3jstjqiBERLLEp949hXlTy/j8I6tZtnlv4I+nghARyRLRiHHXB2YzYlA+X31sbeCPF2hBmNl8M1tnZuvN7PY084eY2e/NbIWZrTaz6zrNKzGzB8xsrZmtMbPTg8wqIpINhhTm8P6qcpZu3sPOxpZAHyuwgjCzKHAPcBFQCVxlZpVdFvs48Iq7zwTmAV83s9zUvLuAx939JGAmsCaorCIi2eSSGaNwh8de3hHo4wS5BTEHWO/uG929DbgPWNBlGQcGmZkBxcAeIG5mg4GzgR8CuHubu9cHmFVEJGtMHjGIihHFPBrwt6uDLIixwJZOt2tT0zq7G5gGbANWAbe6ewKYBNQBPzaz5Wb2AzMrSvcgZnaTmVWbWXVdXV2fPwkRkUx08SmjWfr6HnbuC26YKciCsDTTuh68eyFQA4wBZgF3p7YeYsA7gO+6+2zgAPC2fRgA7r7I3avcvaqsrKyPoouIZLZLZozGHZ4IcJgpyIKoBco73R5Hckuhs+uABz1pPbAJOCm1bq27v5Ba7gGShSEiIsCUkYOYHPAwU5AFsRSoMLOJqR3PVwKPdFnmDeB8ADMbCUwFNrr7DmCLmU1NLXc+8EqAWUVEss7Fp4zmxU17qNvXGsj9B1YQ7h4HbgaeIHkE0v3uvtrMFprZwtRiXwDOMLNVwJPAbe6+KzXvFuAXZraS5PDTl4PKKiKSjS45ZTQJh8dXBzPMFAvkXlPcfTGwuMu0ezv9vg14z2HWrQGqgswnIpLNpowsZlJZEYtXbufa08b3+f3rm9QiIlnKzLj0lNG0xDto70j0/f2HcZ3ToFRVVXl1dXXYMUREjptEwolE0h002j1mtszd047WaAtCRCSL9aYcjnrfgd2ziIhkNRWEiIikpYIQEZG0VBAiIpKWCkJERNJSQYiISFoqCBERSatffVHOzOqAzambQ4CGI/ze9c9SYBfd1/k+uzOv67Qw8/Um45Gm6TXUa9jbfEfKlC5XumkD/TU8Ur50uca7e/prJbh7v/wBFh3p9zR/Vh/r/XdnXtdpYebrTcajZNVrqNewV/mOlEmvYe/zHe41PNxPfx5i+v1Rfu/6Z2/uvzvzuk4LM9/h5ncn49Gm9YRew4H9Gh5u3uEyHS6PXsMjT+vOa5hWvxpi6g0zq/bDnI8kE2R6Psj8jJmeDzI/Y6bng8zPmOn5OuvPWxA9tSjsAEeR6fkg8zNmej7I/IyZng8yP2Om5ztEWxAiIpKWtiBERCQtFYSIiKSlghARkbRUEN1gZnPN7F4z+4GZPRd2nq7MLGJmXzKzb5vZh8PO05WZzTOzZ1Kv4byw8xyOmRWZ2TIzuzTsLF2Z2bTU6/eAmX0s7DzpmNnlZvZ9M/udmaW91nyYzGySmf3QzB4IO0tnqX93P029dleHnaezfl8QZvYjM9tpZi93mT7fzNaZ2Xozu/1I9+Huz7j7QuAPwE8zLR+wABgLtAO1GZjPgf1Afl/n68OMALcB92diPndfk/o3+H6gzw+R7KOMD7v7jcBHgA9kYL6N7n59X+Y6nB7mvQJ4IPXaXXY88nVbT77Rl40/wNnAO4CXO02LAhuASUAusAKoBE4hWQKdf0Z0Wu9+YHCm5QNuBz6aWveBDMwXSa03EvhFJv4dAxcAV5J8c7s00/Kl1rkMeA74YCa+hp3W+zrwjgzO16f/R/og72eBWallfhl0tp78xOjn3P1pM5vQZfIcYL27bwQws/uABe7+FSDt8IKZnQA0uHtjpuUzs1qgLXWzI9PydbIXyOvLfH2V0czOBYpI/odtNrPF7p7IlHyp+3kEeMTMHgV+2RfZ+jKjmRlwJ/CYu7+UafmOp57kJblVPQ6oIcNGdfp9QRzGWGBLp9u1wLuOss71wI8DS/RWPc33IPBtM5sLPB1ksJQe5TOzK4ALgRLg7kCT/V2PMrr7vwGY2UeAXX1VDkfQ09dwHsmhiDxgcZDBOunpv8NbSG6JDTGzye5+b5Dh6PlrOBz4EjDbzD6bKpLj6XB5vwXcbWaXcOyn4wjEQC0ISzPtiN8YdPf/CChLOj3K5+5NJAvseOlpvgdJltjx1OO/YwB3/0nfR0mrp6/hEmBJUGEOo6cZv0Xyze546Wm+3cDC4OIcVdq87n4AuO54h+mOjNqcOY5qgfJOt8cB20LKko7y9V6mZ8z0fJD5GTM9X1fZlnfAFsRSoMLMJppZLsmdk4+EnKkz5eu9TM+Y6fkg8zNmer6usi3vgDiK6VfAdv5+COj1qekXA6+SPKrg35QvO/NlQ8ZMz5cNGTM9X7bnPdyPTtYnIiJpDdQhJhEROQoVhIiIpKWCEBGRtFQQIiKSlgpCRETSUkGIiEhaKgjp18xs/3F+vD65Xoglr6HRYGbLzWytmX2tG+tcbmaVffH4IqCCEOkRMzvi+cvc/Yw+fLhn3H02MBu41MzOPMryl5M8G61InxioJ+uTAczMTgTuAcqAJuBGd19rZv8AfI7kufp3A1e7+5tm9nlgDDAB2GVmrwInkDyv/wnANz15ojrMbL+7F6fOvvp5YBcwHVgGXOPubmYXA99IzXsJmOTuhz09tbs3m1kNybOBYmY3Ajelcq4HrgVmkbxexDlm9jngfanV3/Y8j/V1k4FHWxAyEC0CbnH3U4F/Bb6Tmv4scFrqU/t9wP/utM6pJK818MHU7ZNInsJ8DvAfZpaT5nFmA58k+al+EnCmmeUD3wMucvezSL55H5GZDQUq+Pup3B9093e6+0xgDcnTODxH8rw+n3H3We6+4QjPU6RbtAUhA4qZFQNnAL9JXt8G+PtFjMYBvzaz0SQ/nW/qtOoj7t7c6faj7t4KtJrZTpJXy+t6OdUX3b029bg1JLdA9gMb3f3gff+K5NZAOnPNbCUwFbjT3Xekpk83sy+SvL5GMfBED5+nSLeoIGSgiQD17j4rzbxvA99w90c6DREddKDLsq2dfu8g/f+ldMukuybA4Tzj7pea2RTgWTN7yN1rgJ8Al7v7itQFjualWfdIz1OkWzTEJAOKJy8Zu8nM/gmSl8k0s5mp2UOAranfPxxQhLXApE6Xo/zA0VZw91eBrwC3pSYNAranhrWu7rTovtS8oz1PkW5RQUh/V2hmtZ1+Pk3yTfV6M1sBrCZ5XWBIbjH8xsyeIbkDuc+lhqn+GXjczJ4F3gQaurHqvcDZZjYR+D/AC8CfSBbOQfcBn0kdGnsih3+eIt2i032LHGdmVuzu+y25c+Ae4DV3/6+wc4l0pS0IkePvxtRO69Ukh7W+F24ckfS0BSEiImlpC0JERNJSQYiISFoqCBERSUsFISIiaakgREQkLRWEiIik9f8BJ6S/6/ajlTsAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAELCAYAAADDZxFQAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAAqeElEQVR4nO3deXwV9b3/8dfnZGXfkrAlrCIQBAQjLrhjRa0s0l9FL1btz6r3V5cuV1u93lpLa23vte29WpfaK221Vi7S5eKKG4it1RJEUGQVQcIa9n1J8vn9cSZwjCchgUzmJHk/H4/zyDnfmTnzPkPI58x8Z+Zr7o6IiEhVsagDiIhIalKBEBGRpFQgREQkKRUIERFJSgVCRESSUoEQEZGkQisQZjbFzDaZ2YfVTDcze9DMVpjZQjMbnjDtWjNbHjyuDSujiIhUz8K6DsLMzgF2A0+6+0lJpl8K3ApcCpwG/Je7n2ZmHYFioAhwYB5wirtvq2l9OTk53qtXr/r9ECIiTdy8efM2u3tusmnpYa3U3eeYWa8aZhlHvHg48I6ZtTezrsB5wKvuvhXAzF4FLgaeqWl9vXr1ori4uF6yi4g0F2a2urppUfZBdAfWJLwuCdqqaxcRkQbUqDupzexGMys2s+LS0tKo44iINClRFoi1QEHC6/ygrbr2z3H3x929yN2LcnOTHkITEZFjFFofRC3MAG4xs6nEO6l3uPt6M5sJ/NjMOgTzXQTcFVVIEWkaDh06RElJCfv37486SiSys7PJz88nIyOj1suEViDM7BniHc45ZlYCfB/IAHD3x4AXiZ/BtALYC3w1mLbVzH4IzA3eanJlh7WIyLEqKSmhTZs29OrVCzOLOk6Dcne2bNlCSUkJvXv3rvVyYZ7FdNVRpjtwczXTpgBTwsglIs3T/v37m2VxADAzOnXqRF37aqM8xJQSDpSV8+bSUtLTjLRYjPSYkRYzMtKM9FiMtJjFp5lhZlS4U1bulFc4zpFrSAzDDGLBL1+FV87zWZW/mmbxZSqfV1X5XpXzxSxYxuJZ0mLxaYmXsbjD59dYs6NdBlN1crLrZir/w9ln2mp+38rtVTVLsm1a9f1q+x/cOLINa5qn8kniv2HlshjEEv4tYmbEzEiPGbFY8/tD09g1x+JQ6Vg+e7MvELv2l3HjU/OijiGNUMz4zJeIjLQYGcHPzLQYrbLSaZMdf7TKSqdFRhotM9Nom51BXtsscttkkdcmm9w2WXRqlUl6WqM+qVDqWevWrdm9ezerVq3isssu48MPk96UIlTNvkC0a5HBC7edRXmFc6jcKSuviD+viD8vq3AqKjz+0/3wH4S0WPxbfSX3+F5DhQM4Mauc58hMld+O3Y98c/fDy/vhCu8en9OD96v8Zh1/Ht8zKatI/KYd/Ay++db2i4J75V5J8vYj7//ZGazK5078bIltNa238vN99n2P5E+c5zNzVfPejn8mp+OH36PC/XOfITHz4c9weLvHl0n8Wbn9K18fqvw9KXfKKyrivzsVFZSVOwfLKzhQVsGeA2Xs3l/Gqs172XOwjH0Hy9l7sJx9h8o/l8UMOrXKol9eawq7tWVg17b0zmlFt/bZ5LXJJk17Kw1v4TR4fTLsKIF2+TDqHhhyRdSpGlSzLxAZaTEGdWsXdQxpRg6UlVO66wCluw6wKfhZuusAG3bsZ8nGXfz+ndUcKKs4PH9azOjWPpueHVvRs1NLeue0YkCXtgzs2oZOrbMi/CRN2MJp8NxtcGhf/PWONfHXcMxF4s4776SgoICbb453vd57772kp6cza9Ystm3bxqFDh/jRj37EuHHjqn2P8vJy7rzzTmbPns2BAwe4+eabuemmm7jmmmuYMGEC48ePB2DSpElcccUVNb5XbTT7AiHS0LLS08jv0JL8Di2TTi8rr2DVlr2s2bqXdTv2sW77Pkq27WPVlr288MF6tu89dHje3DZZDM1vz7Ae7RlW0J6hBe1plaX/1sft9clHikOlQ/vi7cdYICZOnMg3v/nNwwVi2rRpzJw5k9tuu422bduyefNmTj/9dMaOHVttf8ETTzxBu3btmDt3LgcOHGDkyJFcdNFFXH/99fziF79g/Pjx7Nixg7fffpvf/e53x5QzkX6TRFJMelqME/Jac0Je66TTt+w+wJINu1i8ficfrdvJ+2u289rijUB8b2NQt7YU9ezIGX07cWbfTioYx2JHSd3aa2HYsGFs2rSJdevWUVpaSocOHejSpQvf+ta3mDNnDrFYjLVr17Jx40a6dOmS9D1eeeUVFi5cyPTp0+Nxduxg+fLlXHTRRXz961+ntLSUP/7xj3zpS18iPf34/931myPSyHRqncXIE7IYeULO4bbtew8yf8123lu9jbmrtvL0u6uZ8rdPyEyLcWrvDpx3Yh4XDMyjb27yoiNVtMuPH1ZK1n4cvvzlLzN9+nQ2bNjAxIkTefrppyktLWXevHlkZGTQq1evGi/kc3ceeughRo8e/blp11xzDb///e+ZOnUqv/nNb44rZyUVCJEmoH3LTM7vn8f5/fMAOFhWQfHqrby5tJTZS0u578XF3PfiYnrntOILhZ35+nl9ad8yM+LUKWzUPZ/tgwDIaBFvPw4TJ07khhtuYPPmzbz55ptMmzaNvLw8MjIymDVrFqtXV3tjVQBGjx7No48+ygUXXEBGRgbLli2je/futGrViuuuu44RI0bQpUsXCgsLjytnJRUIkSYoMz3GmX1zOLNvDnddOpC12/fxxuKNvL5kE1P++gkvLFzP709bTe/3f9asz9KpVuV2qOezmAYNGsSuXbvo3r07Xbt2ZdKkSYwZM4bBgwdTVFTEgAEDalz+a1/7GqtWrWL48OG4O7m5ufzlL38BoHPnzgwcOPBwR3V9CG3AoIZWVFTkGg9C5OgWrNnOn5/8Bd85+Agt7eCRCRktYMyDTbZILF68mIEDB0YdIzR79+5l8ODBvPfee7Rrl/zMzGTbwMzmuXtRsvl1ZY5IMzO0oD33tJj+2eIAR87SkUbntddeY+DAgdx6663VFodjoUNMIs1QbGfSO+gf11k6Ep0LL7zwqP0Xx0J7ECLNUTVn41S01eCNcoQKhEhzNOqeeJ9Dgr2eyX9xFXsPlkUUKnxNpc/1WBzLZ1eBEGmOhlwR75BuVwAYtCtg2Yj7eKh0GDc8Wcz+JPeLauyys7PZsmVLsywSleNBZGdn12k5ncUkIof96b0Svj1tARcMyOOxq08hM73pfIfUiHLJR5Sr6SwmdVKLyGEThuez92A5//aXD7n5D+/xwP8ZSruWtR+iMpVlZGTUaTQ10SEmEani6tN78v0xhbyxZBMX/uJNZi7aEHUkiYgKhIh8zldH9uZ/bx5JTussbnpqHrc+M58DZU2vX0JqpgIhIkmd1L0dM24ZyTdG9eO5Bev4n7lJbl4nTZoKhIhUKyMtxjcv7MepvTrw8KwVTfLsJqleqAXCzC42s6VmtsLM7kwyvaeZvW5mC81stpnlJ0z7dzNbZGaLzexBa86jjYtEyMz41oUnsnHnAZ75x6dRx5EGFFqBMLM04GHgEqAQuMrMqt6D9gHgSXcfAkwG7g+WPRMYCQwBTgJOBc4NK6uI1OyMvp04rXdHHpn9sfYimpEw9yBGACvcfaW7HwSmAlUHSC0E3giez0qY7kA2kAlkARnAxhCzikgNzIxvfeFESncd4Ol3tRfRXIRZILoDib1aJUFbogXAhOD55UAbM+vk7n8nXjDWB4+Z7r44xKwichSn9+nEGX068ejsj9l3UHsRzUHUndS3A+ea2Xzih5DWAuVmdgIwEMgnXlQuMLOzqy5sZjeaWbGZFZeWljZkbpFm6VtfOJHNuw/wxF9XRh1FGkCYBWItUJDwOj9oO8zd17n7BHcfBtwdtG0nvjfxjrvvdvfdwEvAGVVX4O6Pu3uRuxfl5uaG9DFEpNKI3h25eFAXfjlrBWu27o06joQszAIxF+hnZr3NLBO4EpiROIOZ5ZhZZYa7gCnB80+J71mkm1kG8b0LHWISSQH3jCkkZsYPnvso6igSstAKhLuXAbcAM4n/cZ/m7ovMbLKZjQ1mOw9YambLgM7AfUH7dOBj4APi/RQL3P25sLKKSO11a9+Cb4zqx2uLN/LaRzp3pCnT3VxFpM4OlVdw6X+9xb5D5bz6rXNpkZkWdSQ5RhqTWkTqVUZajB+OP4mSbft4ZPaKqONISFQgROSYnN6nE+NO7sbjc1ZSsk0d1k2RCoSIHLPvXjwAM/jpy0ujjiIhUIEQkWPWrX0LbjqnL88tWMe81VujjiP1TAVCRI7LTef2oUvbbCY/9xEVFU3jpBeJU4EQkePSMjOd717SnwUlO/jL+2uPvoA0GioQInLcxg3tztCC9vzkpSXsPlAWdRypJyoQInLcYjHj+2MK2bTrAA/P0mmvTYUKhIjUi+E9OvCl4fk88dYnfLJ5T9RxpB6oQIhIvfnuxf3JTI/xo+d1n6amQAVCROpNXttsbht1Aq8v2cSsJZuijiPHSQVCROrVdWf2pk9OKyY//xGHyiuijiPHQQVCROpVZnqM714ygE827+H1xbrba2OmAiEi9W7UgDy6tM1m6tw1R59ZUpYKhIjUu/S0GF8uyufNZaWs274v6jhyjFQgRCQUVxQV4A7PFpdEHUWOkQqEiISioGNLzjohh2nFa3SPpkZKBUJEQjPx1ALWbt/H3z7eHHUUOQYqECISmosGdaZ9ywx1VjdSKhAiEpqs9DQuH9adVxZtYOueg1HHkTpSgRCRUF15ag8OlTvTirUX0diEWiDM7GIzW2pmK8zsziTTe5rZ62a20Mxmm1l+wrQeZvaKmS02s4/MrFeYWUUkHP27tOGMPp343durdGV1IxNagTCzNOBh4BKgELjKzAqrzPYA8KS7DwEmA/cnTHsS+A93HwiMAHRjF5FG6v+e1Zv1O/Yzc9GGqKNIHYS5BzECWOHuK939IDAVGFdlnkLgjeD5rMrpQSFJd/dXAdx9t7vvDTGriIRo1IA8enZqyRN//STqKFIHYRaI7kDiQceSoC3RAmBC8PxyoI2ZdQJOBLab2Z/MbL6Z/UewRyIijVAsZnz1zF7M/3Q77326Leo4UktRd1LfDpxrZvOBc4G1QDmQDpwdTD8V6ANcV3VhM7vRzIrNrLi0tLTBQotI3X25qIA22elM0V5EoxFmgVgLFCS8zg/aDnP3de4+wd2HAXcHbduJ7228HxyeKgP+AgyvugJ3f9zdi9y9KDc3N5xPISL1olVWOleeWsBLH27Q/ZkaiTALxFygn5n1NrNM4EpgRuIMZpZjZpUZ7gKmJCzb3swq/+pfAGiIKpFG7toze+HuPP3u6qijSC2EViCCb/63ADOBxcA0d19kZpPNbGww23nAUjNbBnQG7guWLSd+eOl1M/sAMODXYWUVkYaR36ElI0/I4eUPdTZTY5Ae5pu7+4vAi1Xa7kl4Ph2YXs2yrwJDwswnIg1v1IA87n3uIz7ZvIfeOa2ijiM1iLqTWkSamVEDOwNotLlGQAVCRBpUQceWDOjShtdUIFKeCoSINLhRA/OYu2obO/YeijqK1EAFQkQa3KiBnSmvcGYv0x10UpkKhIg0uJPz25PTOpPXFqtApDIVCBFpcLGYccGAPGYv3aQ7vKYwFQgRicSogZ3Ztb+MuZ9sjTqKVEMFQkQicXa/HDLTY7yqs5lSlgqEiESiZWY6Z52QwyuLNlJR4VHHkSRUIEQkMmOGdmXt9n0Ur9YtwFORCoSIROaiwi60yEjjz/NLoo4iSahAiEhkWmWlc/FJXXh+4Xr2HyqPOo5UoQIhIpG6fFh3du0vY9YSXRORalQgRCRSZ/btRG6bLP40f+3RZ5YGpQIhIpFKT4sxbmg3Zi/dxLY9B6OOIwlUIEQkcpcP786hcuf5D9ZHHUUSqECISOQKu7alf+c2/Pk9nc2USlQgRCRyZsb4Yd1579PtrN6yJ+o4ElCBEJGUMPbkbgA8t2BdxEmkkgqEiKSE7u1bUNSzA88tUD9EqlCBEJGUMfbkbizduIulG3ZFHUUIuUCY2cVmttTMVpjZnUmm9zSz181soZnNNrP8KtPbmlmJmf0yzJwikhouHdyVtJgxY4GuiUgFoRUIM0sDHgYuAQqBq8yssMpsDwBPuvsQYDJwf5XpPwTmhJVRRFJLTusszuzbiecWrMddd3iNWph7ECOAFe6+0t0PAlOBcVXmKQTeCJ7PSpxuZqcAnYFXQswoIilmzNBufLp1L++v2R51lGYvzALRHViT8LokaEu0AJgQPL8caGNmncwsBvwMuD3EfCKSgkYP6kJmWowZOpspclF3Ut8OnGtm84FzgbVAOfB14EV3r/GqGTO70cyKzay4tLQ0/LQiErp2LTI4r38uzy9cT7kGEopUmAViLVCQ8Do/aDvM3de5+wR3HwbcHbRtB84AbjGzVcT7Ka4xs59UXYG7P+7uRe5elJubG86nEJEGN/bkbpTuOsCcZfriF6UwC8RcoJ+Z9TazTOBKYEbiDGaWExxOArgLmALg7pPcvYe79yK+l/Gku3/uLCgRaZq+UNiZgo4t+MlLSygrr4g6TrMVWoFw9zLgFmAmsBiY5u6LzGyymY0NZjsPWGpmy4h3SN8XVh4RaTyy0tP410sGsnTjLqbOXXP0BSQU1lROJSsqKvLi4uKoY4hIPXF3rnz8HZZv2s2s28+jXYuMqCM1SWY2z92Lkk2LupNaRCQpM+N7lxWybe9BfvnG8qjjNEsqECKSsk7q3o4rTingt2+v4pPNustrQ6tVgTCzVpWdyWZ2opmNNTPt74lI6G4f3Z+s9DS+M32BOqwbWG33IOYA2WbWnfiVzV8BfhtWKBGRSrltsrjv8pOYu2obD7yyLOo4zUptC4S5+17iVz0/4u5fBgaFF0tE5IhxJ3fnqhE9eOzNj3ljycao4zQbtS4QZnYGMAl4IWhLCyeSiMjnfX9MIQO7tuXb0xawdvu+qOM0C7UtEN8kfiHbn4NrGfoQv7meiEiDyM5I45FJwykrd745dT4Vug1H6GpVINz9TXcf6+4/DTqrN7v7bSFnExH5jN45rbh37CDmrtrGU++sjjpOk1fbs5j+EAze0wr4EPjIzO4IN5qIyOd9aXh3zjkxl5++vISSbXujjtOk1fYQU6G77wTGAy8BvYmfySQi0qDMjB9ffhIA//rnDzWwUIhqWyAygusexgMz3P0QoH8VEYlEfoeWfPfiAcxZVsqf3tPwpGGpbYH4FbAKaAXMMbOewM6wQomIHM1XTu9JUc8O/OC5RazZqkNNYahtJ/WD7t7d3S/1uNXA+SFnExGpVixm/OyKoQDc8GQxew+WRZyo6altJ3U7M/t55ehtZvYz4nsTIiKR6dmpFQ/903CWbdzFHc8uVH9EPavtIaYpwC7giuCxE/hNWKFERGrr3BNz+c7FA3jhg/U8+ubHUcdpUtJrOV9fd/9SwusfmNn7IeQREamzm87pw6J1O/mPmUs5rXdHTunZMepITUJt9yD2mdlZlS/MbCSga91FJCWYGT/90mByWmfxk5eW6FBTPaltgfhn4GEzW2Vmq4BfAjeFlkpEpI5aZqZz26h+zF21jdlLS6OO0yTU9iymBe4+FBgCDHH3YcAFoSYTEamjiUUF9OjYkn+fuVT3aqoHdRpRzt13BldUA3w7hDwiIscsMz3Gv1x0IovX7+S5heuijtPoHc+Qo1ZvKURE6smYId0Y0KUNP391GYc0At1xOZ4CcdT9NzO72MyWmtkKM7szyfSeZva6mS00s9lmlh+0n2xmfzezRcG0iceRU0SakVjMuGN0f1Zv2cvv3l4VdZxGrcYCYWa7zGxnkscuoNtRlk0DHgYuAQqBq8yssMpsDwBPuvsQYDJwf9C+F7jG3QcBFwP/aWbt6/rhRKR5umBAHqMG5PHTl5cw/9NtUcdptGosEO7ext3bJnm0cfejXUMxAljh7ivd/SAwFRhXZZ5C4I3g+azK6e6+zN2XB8/XAZuA3Lp9NBFprszit+Ho3Dabm59+j617DkYdqVE6nkNMR9MdWJPwuiRoS7SA+DjXAJcDbcysU+IMZjYCyAR0iaSI1Fr7lpk8OukUNu8+yDemzqdcZzXVWZgFojZuB841s/nAucBaoLxyopl1BZ4Cvurun+ttMrMbK+8PVVqq855F5LMG57fj3rGDeGv5Zh6etSLqOI1OmAViLVCQ8Do/aDvM3de5+4Tguoq7g7btAGbWFngBuNvd30m2And/3N2L3L0oN1dHoETk864aUcCYod345RsrWLV5T9RxGpUwC8RcoJ+Z9TazTOBKYEbiDGaWE4xxDXAX8ZsCEsz/Z+Id2NNDzCgiTZyZ8b0vDiQjzfjRCx9FHadRCa1AuHsZcAswE1gMTHP3RWY22czGBrOdByw1s2VAZ+C+oP0K4BzgOjN7P3icHFZWEWna8tpmc9uofry2eBOzl26KOk6jYU3lplZFRUVeXFwcdQwRSVEHyyoY/Z9zMIOXv3EOmelRd8GmBjOb5+5FyaZpC4lIs5CZHuOeywpZWbpHF9DVkgqEiDQb5w/I44IBeTz4+nJ27DsUdZyUpwIhIs3Kt79wIrsOlDH1H59GHSXlqUCISLNyUvd2jDyhE7/52yoOlulmfjVRgRCRZufGc/qyYed+ZizQLcFrogIhIs3OOf1yGNClDb+es1LDk9ZABUJEmh0z44az+7B04y7eXKbb9FRHBUJEmqUxQ7vRpW02j89ZGXWUlKUCISLNUmZ6jP97Vi/e/ngLH67dEXWclKQCISLN1sRTe9AiI42n/r466igpSQVCRJqtdi0yGD+sO/+7YC3b92pQoapUIESkWbvmjJ7sP1TBs8UlUUdJOSoQItKsDezalhG9OvLUO6up0Khzn6ECISLN3lfO6MmnW/fqlNcqVCBEpNkbPagLuW2yePLvq6KOklJUIESk2ctMj3HViB7MXlbK6i0alrSSCoSICDDptB5kpMW4dso/+GjdzqjjpAQVCBERoHPbbP7wtdPYd6icyx/5G88Wr4k6UuRUIEREAkW9OvLCbWdzSs8O3DF9Ife/uDjqSJFSgRARSZDTOounrj+NSaf14FdzVvLHec33+ggVCBGRKtJixg/GDuL0Ph351z9/0Gzv1RRqgTCzi81sqZmtMLM7k0zvaWavm9lCM5ttZvkJ0641s+XB49owc4qIVJWeFuOX/zScjq0yuempeWzb0/xuxRFagTCzNOBh4BKgELjKzAqrzPYA8KS7DwEmA/cHy3YEvg+cBowAvm9mHcLKKiKSTE7rLB67+hRKdx/gtqnzKW9mV1qHuQcxAljh7ivd/SAwFRhXZZ5C4I3g+ayE6aOBV919q7tvA14FLg4xq4hIUkML2jN57CDeWr6Zx978OOo4DSrMAtEdSDxPrCRoS7QAmBA8vxxoY2adarmsiEiDmHhqAZcN6crPX13GvNVbo47TYKLupL4dONfM5gPnAmuB8toubGY3mlmxmRWXluoeKiISDjPjxxMG0619Nrc98z479h6KOlKDCLNArAUKEl7nB22Hufs6d5/g7sOAu4O27bVZNpj3cXcvcvei3Nzceo4vInJE2+wMHrpqOBt37ue7f1yIe9PvjwizQMwF+plZbzPLBK4EZiTOYGY5ZlaZ4S5gSvB8JnCRmXUIOqcvCtpERCJzckF77hjdn5cXbeDmP7zH3oNlUUcKVXpYb+zuZWZ2C/E/7GnAFHdfZGaTgWJ3nwGcB9xvZg7MAW4Olt1qZj8kXmQAJrt78znwJyIp68Zz+mAGP3lpCZ9s3suvrzmF/A4to44VCmsqu0lFRUVeXFwcdQwRaSZmL93Erc/MJyMtxpTrTuXkgvZRRzomZjbP3YuSTYu6k1pEpFE6r38ef7l5JK2z0vnKE++ysGR71JHqnQqEiMgx6pvbmqk3nk77lhlc/d/vNrlbcqhAiIgch27tW/CHr51Om+wMrn7iXd5cVtpkrrhWgRAROU4FHVvyzA2n0yoznWun/INT73uNO55dQPGqxn1ujQqEiEg96NGpJa986xwemTScs/vl8PKHG5j4+Du8sHB91NGOWWinuYqINDetstK5dHBXLh3cld0Hyvjqb/7BbVPnA/DFIV0jTld32oMQEQlB66x0fvvVEQzv0Z7bps5vlHsSKhAiIiFpVaVILFizPepIdaICISISolZZ6Txx3anktcni9mcXcKCs1vcjjZwKhIhIyNpmZ/DjCYNZvmk3D76+POo4taYCISLSAM7vn8cVRfk89ubKRnPVtQqEiEgDufuLheS2bjyHmlQgREQaSLsWGdz/pcEs27ibR2en/vClKhAiIg3o/P55jBnajUdmf8wnm/dEHadGKhAiIg3se18cSFZajHv+98OUHplOBUJEpIHltc3m9tH9eWv5Zp5P4QvoVCBERCJw9ek9Gdy9HZOf/4id+w9FHScpFQgRkQikxYz7Lj+JzbsP8NOXlkQdJykVCBGRiAzJb8/1I3vz9Luf8uay0qjjfI4KhIhIhG4f3Z9+ea35zvQF7NibWoeaVCBERCKUnZHGz684mS27D3LPjA+jjvMZoRYIM7vYzJaa2QozuzPJ9B5mNsvM5pvZQjO7NGjPMLPfmdkHZrbYzO4KM6eISJQG57fj1gv68b/vr+P5heuijnNYaAXCzNKAh4FLgELgKjMrrDLbvwHT3H0YcCXwSND+ZSDL3QcDpwA3mVmvsLKKiETt6+f3ZXD3dtz/4pKUuTYizD2IEcAKd1/p7geBqcC4KvM40DZ43g5Yl9DeyszSgRbAQWBniFlFRCKVkRbjqyN7sXb7PuanyLgRYRaI7sCahNclQVuie4GrzawEeBG4NWifDuwB1gOfAg+4e+Me/VtE5CguLOxMZlqM5xekxsVzUXdSXwX81t3zgUuBp8wsRnzvoxzoBvQG/sXM+lRd2MxuNLNiMysuLU29U8REROqibXYG5/bP5cUP1lNREf1hpjALxFqgIOF1ftCW6HpgGoC7/x3IBnKAfwJedvdD7r4J+BtQVHUF7v64uxe5e1Fubm4IH0FEpGFdNqQrG3buZ96n26KOEmqBmAv0M7PeZpZJvBN6RpV5PgVGAZjZQOIFojRovyBobwWcDqTmpYYiIvVo1MDOZKXHeCEF7tEUWoFw9zLgFmAmsJj42UqLzGyymY0NZvsX4AYzWwA8A1zn8e77h4HWZraIeKH5jbsvDCuriEiqaJ2Vzvn983jxg/WUR3yYKT3MN3f3F4l3Pie23ZPw/CNgZJLldhM/1VVEpNm5bGhXXl60gbmrtnJ6n06R5Yi6k1pERKq4YEAe2RnRH2ZSgRARSTEtM9MZNaAzL324PtKxq1UgRERS0FUjerB590EefmNFZBlUIEREUtBZ/XKYMKw7j8z+mEXrdkSSQQVCRCRF3TOmkA6tMrnj2YUcKq9o8PWrQIiIpKj2LTP50fiT+Gj9Th6d/XGDr18FQkQkhY0e1IUxQ7vx0BvLWbFpV4OuWwVCRCTF3TumkMy0GA81cIe1CoSISIrr1DqLSaf35LkF61i9ZU+DrVcFQkSkEfjaWb1JT4vx2JsrG2ydKhAiIo1AXttsrijK54/zStiwY3+DrFMFQkSkkbjpnL6Uu/PfbzXMXoQKhIhII1HQsSXjhnbj6Xc/Zeueg6GvTwVCRKQR+fr5fdlfVs6v5oR/XYQKhIhII3JCXhsmDMtnyl8/4ePS3aGuSwVCRKSRufOSAWRnpHHvjEXEx1gLhwqEiEgjk9smiztG9+et5Zt58YMNoa1HBUJEpBGadFpPBnVryw+f/4g9B8pCWYcKhIhII5QWMyaPO4kNO/fz4BvLQ1mHCoSISCN1Ss8OXFGUz8rSPVRU1H9fRHq9v6OIiDSYH44/icy0GGZW7++tAiEi0ohlpaeF9t6hHmIys4vNbKmZrTCzO5NM72Fms8xsvpktNLNLE6YNMbO/m9kiM/vAzLLDzCoiIp8V2h6EmaUBDwNfAEqAuWY2w90/Spjt34Bp7v6omRUCLwK9zCwd+D3wFXdfYGadgENhZRURkc8Lcw9iBLDC3Ve6+0FgKjCuyjwOtA2etwPWBc8vAha6+wIAd9/i7uUhZhURkSrCLBDdgTUJr0uCtkT3AlebWQnxvYdbg/YTATezmWb2npl9J9kKzOxGMys2s+LS0tL6TS8i0sxFfZrrVcBv3T0fuBR4ysxixA99nQVMCn5ebmajqi7s7o+7e5G7F+Xm5jZkbhGRJi/MArEWKEh4nR+0JboemAbg7n8HsoEc4nsbc9x9s7vvJb53MTzErCIiUkWYBWIu0M/MeptZJnAlMKPKPJ8CowDMbCDxAlEKzAQGm1nLoMP6XOAjRESkwViYdwIMTlv9TyANmOLu95nZZKDY3WcEZy79GmhNvMP6O+7+SrDs1cBdQfuL7p60HyJhXaXA6uBlO2BHwuTK14ntVdtygM11+HhV13G0adVlqu55Q+erKVOyXMnamvs2rClfslzJ2rQNtQ0bOl9Pd09+jN7dm9wDeDzZ68T2qm3Ei9Yxr+No06rLVItcDZKvpkzahsefT9tQ2zBV89X0iLqTOizPVfP6uaO0Hc86jjatukzVPW/ofDVlqi6PtmHNbdqG2obJftZV2PmqFeohpsbEzIrdvSjqHNVJ9XyQ+hlTPR+kfsZUzwepnzHV8yVqqnsQx+LxqAMcRarng9TPmOr5IPUzpno+SP2MqZ7vMO1BiIhIUtqDEBGRpFQgREQkKRUIERFJSgXiKMzsbDN7zMz+28zejjpPMmYWM7P7zOwhM7s26jxVmdl5ZvZWsB3PizpPdcysVXDzx8uizlKVmQ0Mtt90M/t/UedJxszGm9mvzex/zOyiqPNUZWZ9zOwJM5sedZZEwe/d74JtNynqPImadIEwsylmtsnMPqzSXuNARonc/S13/2fgeeB3qZiR+G3U84mPmVGSgvkc2E38Vir1mq8eMwJ8l+DeYKmWz90XB7+HVwAjUzTjX9z9BuCfgYkpmG+lu19fn7mqU8e8E4DpwbYb2xD5aq0uV/Q1tgdwDvGb/H2Y0JYGfAz0ATKBBUAhMJh4EUh85CUsNw1ok4oZgTuBm4Jlp6dgvliwXGfg6RTdhl8gfr+w64DLUi1fsMxY4CXgn1JxGyYs9zNgeArnq9f/I/WQ9y7g5GCeP4SdrS6PJj0mtbvPMbNeVZoPD2QEYGZTgXHufj+Q9NCCmfUAdrj7rlTMGIyncTB4Wa8DK9XXNgxsA7LqM199ZQwOfbUi/h92n5m96O4VqZIveJ8ZwAwzewH4Q31kq8+MZmbAT4CX3P29VMvXkOqSl/hedT7wPil2VKdJF4hqJBvI6LSjLHM98JvQEn1eXTP+CXjIzM4G5oQZLFCnfGY2ARgNtAd+GWqyI+qU0d3vBjCz64DN9VUcalDXbXge8UMRWcRvf98Q6vp7eCtwIdDOzE5w98fCDEfdt2En4D5gmJndFRSShlRd3geBX5rZFzn223GEojkWiDpz9+9HnaEmHh8zo0GOrR4Ld/8T8SKW8tz9t1FnSMbdZwOzI45RI3d/kPgfu5Tk7luI94+kFHffA3w16hzJpNTuTAOpzUBGUUv1jKmeD1I/Y6rng9TPmOr5qmpseZtlgajNQEZRS/WMqZ4PUj9jqueD1M+Y6vmqamx5m/xZTM8A6zly+uf1QfulwDLiZxTcrYyNN19jyJjq+RpDxlTP19jzVvfQzfpERCSp5niISUREakEFQkREklKBEBGRpFQgREQkKRUIERFJSgVCRESSUoGQJs3Mdjfw+uplzBCLj6Gxw8zeN7MlZvZALZYZb2aF9bF+EVCBEKkTM6vx/mXufmY9ru4tdz8ZGAZcZmZHGwdiPPG70YrUCxUIaXbMrK+ZvWxm8yw+0t2AoH2Mmb1rZvPN7DUz6xy032tmT5nZ34CngtdTzGy2ma00s9sS3nt38PO8YPr0YA/g6eB22JjZpUHbPDN70Myerymvu+8jfivo7sHyN5jZXDNbYGZ/NLOWZnYm8fEi/iPY6+hb3ecUqS0VCGmOHgdudfdTgNuBR4L2vwKnu/swYCrwnYRlCoEL3f2q4PUA4rcwHwF838wykqxnGPDNYNk+wEgzywZ+BVwSrD/3aGHNrAPQjyO3cv+Tu5/q7kOBxcRv4/A28fv63OHuJ7v7xzV8TpFa0e2+pVkxs9bAmcCzwRd6ODKIUT7wP2bWlfiIX58kLDoj+CZf6QV3PwAcMLNNxEfLqzqc6j/cvSRY7/tAL+JDr65098r3fga4sZq4Z5vZAuLF4T/dfUPQfpKZ/Yj4+BqtgZl1/JwitaICIc1NDNgeHNuv6iHg5+4+Ixig596EaXuqzHsg4Xk5yf8v1Waemrzl7peZWW/gHTOb5u7vA78Fxrv7gmCAo/OSLFvT5xSpFR1ikmbF3XcCn5jZlyE+TKaZDQ0mt+PI/fmvDSnCUqBPwnCUE4+2QLC38RPgu0FTG2B9cFhrUsKsu4JpR/ucIrWiAiFNXUszK0l4fJv4H9Xrg8M3i4iPCwzxPYZnzWwesDmMMMFhqq8DLwfr2QXsqMWijwHnBIXle8C7wN+AJQnzTAXuCDrZ+1L95xSpFd3uW6SBmVlrd98dnNX0MLDc3X8RdS6RqrQHIdLwbgg6rRcRP6z1q2jjiCSnPQgREUlKexAiIpKUCoSIiCSlAiEiIkmpQIiISFIqECIikpQKhIiIJPX/Aa4yenTVSwJKAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -486,210 +656,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 21,
    "id": "c60ffae1",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: left;\">\n",
-       "      <th>epoch</th>\n",
-       "      <th>train_loss</th>\n",
-       "      <th>valid_loss</th>\n",
-       "      <th>accuracy</th>\n",
-       "      <th>time</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <td>0</td>\n",
-       "      <td>0.177247</td>\n",
-       "      <td>0.101637</td>\n",
-       "      <td>0.035429</td>\n",
-       "      <td>00:26</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>1</td>\n",
-       "      <td>0.133270</td>\n",
-       "      <td>0.196480</td>\n",
-       "      <td>0.010714</td>\n",
-       "      <td>00:26</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>2</td>\n",
-       "      <td>0.104465</td>\n",
-       "      <td>0.110250</td>\n",
-       "      <td>0.018786</td>\n",
-       "      <td>00:26</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>3</td>\n",
-       "      <td>0.110900</td>\n",
-       "      <td>0.179141</td>\n",
-       "      <td>0.026286</td>\n",
-       "      <td>00:26</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>4</td>\n",
-       "      <td>0.084999</td>\n",
-       "      <td>0.066289</td>\n",
-       "      <td>0.000214</td>\n",
-       "      <td>00:26</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>5</td>\n",
-       "      <td>0.086911</td>\n",
-       "      <td>0.054963</td>\n",
-       "      <td>0.078786</td>\n",
-       "      <td>00:26</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>6</td>\n",
-       "      <td>0.067234</td>\n",
-       "      <td>0.051094</td>\n",
-       "      <td>0.000143</td>\n",
-       "      <td>00:26</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>7</td>\n",
-       "      <td>0.065434</td>\n",
-       "      <td>0.047903</td>\n",
-       "      <td>0.000643</td>\n",
-       "      <td>00:27</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>8</td>\n",
-       "      <td>0.062790</td>\n",
-       "      <td>0.051135</td>\n",
-       "      <td>0.000786</td>\n",
-       "      <td>00:27</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>9</td>\n",
-       "      <td>0.052330</td>\n",
-       "      <td>0.042803</td>\n",
-       "      <td>0.000357</td>\n",
-       "      <td>00:28</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>10</td>\n",
-       "      <td>0.048953</td>\n",
-       "      <td>0.041971</td>\n",
-       "      <td>0.025214</td>\n",
-       "      <td>00:27</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>11</td>\n",
-       "      <td>0.054041</td>\n",
-       "      <td>0.042071</td>\n",
-       "      <td>0.002929</td>\n",
-       "      <td>00:27</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>12</td>\n",
-       "      <td>0.042994</td>\n",
-       "      <td>0.036293</td>\n",
-       "      <td>0.002071</td>\n",
-       "      <td>00:26</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>13</td>\n",
-       "      <td>0.039893</td>\n",
-       "      <td>0.038717</td>\n",
-       "      <td>0.002643</td>\n",
-       "      <td>00:26</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>14</td>\n",
-       "      <td>0.034311</td>\n",
-       "      <td>0.030208</td>\n",
-       "      <td>0.000286</td>\n",
-       "      <td>00:26</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>15</td>\n",
-       "      <td>0.029148</td>\n",
-       "      <td>0.032281</td>\n",
-       "      <td>0.000214</td>\n",
-       "      <td>00:26</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>16</td>\n",
-       "      <td>0.026229</td>\n",
-       "      <td>0.029817</td>\n",
-       "      <td>0.000429</td>\n",
-       "      <td>00:26</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>17</td>\n",
-       "      <td>0.019406</td>\n",
-       "      <td>0.028295</td>\n",
-       "      <td>0.000429</td>\n",
-       "      <td>00:26</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>18</td>\n",
-       "      <td>0.022481</td>\n",
-       "      <td>0.026837</td>\n",
-       "      <td>0.000429</td>\n",
-       "      <td>00:26</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>19</td>\n",
-       "      <td>0.019967</td>\n",
-       "      <td>0.027598</td>\n",
-       "      <td>0.000500</td>\n",
-       "      <td>00:26</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "lr = 0.2\n",
-    "epochs = 20\n",
-    "learn.fit_one_cycle(epochs, slice(lr))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 97,
-   "id": "0e3d7bc3",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T14:01:26.646743Z",
+     "iopub.status.busy": "2022-08-16T14:01:26.646159Z",
+     "iopub.status.idle": "2022-08-16T14:01:26.840653Z",
+     "shell.execute_reply": "2022-08-16T14:01:26.839916Z",
+     "shell.execute_reply.started": "2022-08-16T14:01:26.646722Z"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "model_name = f'{epochs}_epochs_{output_embedding_length}_features'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 98,
-   "id": "6aa71b79",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Path('/home/larry/.fastai/data/mnist_png/models/20_epochs_128_features.pth')"
-      ]
-     },
-     "execution_count": 98,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "learn.save(model_name)"
+    "epochs = 20\n",
+    "model_name = f'{epochs}_epochs_{output_embedding_length}_features'\n",
+    "\n",
+    "try:\n",
+    "    learn = learn.load(model_name)\n",
+    "except:\n",
+    "    lr = 0.13\n",
+    "    epochs = 20\n",
+    "    learn.fit_one_cycle(epochs, slice(lr))\n",
+    "    learn.save(model_name)"
    ]
   },
   {
@@ -704,10 +694,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": 22,
    "id": "fe76a6b6",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T14:01:30.833579Z",
+     "iopub.status.busy": "2022-08-16T14:01:30.833018Z",
+     "iopub.status.idle": "2022-08-16T14:01:31.008581Z",
+     "shell.execute_reply": "2022-08-16T14:01:31.007519Z",
+     "shell.execute_reply.started": "2022-08-16T14:01:30.833559Z"
+    },
+    "tags": []
+   },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<style>\n",
+       "    /* Turns off some styling */\n",
+       "    progress {\n",
+       "        /* gets rid of default border in Firefox and Opera. */\n",
+       "        border: none;\n",
+       "        /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
+       "        background-size: auto;\n",
+       "    }\n",
+       "    progress:not([value]), progress:not([value])::-webkit-progress-bar {\n",
+       "        background: repeating-linear-gradient(45deg, #7e7e7e, #7e7e7e 10px, #5c5c5c 10px, #5c5c5c 20px);\n",
+       "    }\n",
+       "    .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
+       "        background: #F44336;\n",
+       "    }\n",
+       "</style>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "data": {
       "text/html": [],
@@ -722,28 +748,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[-0.02685654 -0.0664409  -0.05282405  0.13128084 -0.16404235 -0.07902745\n",
-      "  0.08757315  0.04591833  0.09448856  0.01192271  0.02990094 -0.11192217\n",
-      "  0.02426052 -0.11717128  0.0025574  -0.17599596  0.15398207  0.12705527\n",
-      " -0.01652165 -0.07636456  0.03214346 -0.02710077 -0.03165281 -0.09398835\n",
-      "  0.00557938 -0.06097703 -0.0593987  -0.14500326  0.06538934 -0.03287405\n",
-      "  0.08287285  0.0071555  -0.02219413  0.04588227  0.00681522 -0.05818627\n",
-      "  0.21943285  0.01785547 -0.07002068  0.01615722  0.06546357 -0.12865682\n",
-      "  0.07639893  0.02150108  0.16297878 -0.10354443  0.01103313  0.13249438\n",
-      " -0.04289509  0.05735078  0.1058455  -0.03898425  0.01511058 -0.2929563\n",
-      "  0.12001532 -0.09284744 -0.03732519 -0.08481045 -0.09474694  0.20084213\n",
-      " -0.07365731 -0.04899035  0.12747276 -0.00408068  0.07489217  0.12264564\n",
-      "  0.00444675  0.02223329  0.07396491 -0.04335451 -0.01111529  0.036444\n",
-      "  0.01753991 -0.03333655  0.08519194 -0.16348155  0.00404831 -0.10400955\n",
-      "  0.10535397 -0.10148597 -0.03572354 -0.02180829  0.07839018  0.12441708\n",
-      "  0.03234182 -0.01856228  0.02411585  0.01353186 -0.12009303  0.0624846\n",
-      " -0.06032163  0.01560514  0.08370986 -0.03827897  0.04181376  0.10300457\n",
-      " -0.03709866  0.07879037  0.0777318  -0.01733054 -0.0251196  -0.13124625\n",
-      " -0.02960008 -0.07544337 -0.1568369  -0.18274102  0.01196139 -0.06327308\n",
-      " -0.00958959  0.07967961 -0.06267074 -0.01098066  0.1326987   0.10144944\n",
-      " -0.02543458  0.0866252  -0.03869989 -0.00857842  0.11712065  0.01843295\n",
-      " -0.08457572 -0.19174434  0.09137879 -0.04997712 -0.1490273  -0.07461419\n",
-      "  0.06260093 -0.0003249 ]\n"
+      "[-0.10099696 -0.08450948  0.03510209 -0.15825109 -0.04520801  0.20577735\n",
+      "  0.10355564  0.01773667  0.05295658 -0.09321447  0.03732459  0.0393499\n",
+      "  0.02228327 -0.06537104  0.09933136  0.08348498 -0.02667931 -0.22959505\n",
+      " -0.04327893 -0.07219108 -0.09431483  0.0125113  -0.46360245 -0.11086255\n",
+      "  0.35560194  0.18639638  0.06533853  0.28910112  0.13699105  0.15609336\n",
+      " -0.30878097  0.42498502]\n"
      ]
     }
    ],
@@ -766,9 +776,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": 23,
    "id": "4117ef00",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T14:01:35.782917Z",
+     "iopub.status.busy": "2022-08-16T14:01:35.782458Z",
+     "iopub.status.idle": "2022-08-16T14:01:35.829946Z",
+     "shell.execute_reply": "2022-08-16T14:01:35.829005Z",
+     "shell.execute_reply.started": "2022-08-16T14:01:35.782898Z"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -776,7 +795,7 @@
        "10000"
       ]
      },
-     "execution_count": 100,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -788,17 +807,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 24,
    "id": "afdbf8b5",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T14:01:37.390863Z",
+     "iopub.status.busy": "2022-08-16T14:01:37.390647Z",
+     "iopub.status.idle": "2022-08-16T14:01:37.397059Z",
+     "shell.execute_reply": "2022-08-16T14:01:37.396243Z",
+     "shell.execute_reply.started": "2022-08-16T14:01:37.390834Z"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Path('/home/larry/.fastai/data/mnist_png/testing/0/7129.png')"
+       "Path('/home/jav/.fastai/data/mnist_png/testing/4/7818.png')"
       ]
      },
-     "execution_count": 101,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -809,37 +837,78 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
-   "id": "45f8fb50",
+   "execution_count": 25,
+   "id": "d83ab8c7-b1fb-49c7-b4b0-f0a84c9d1afd",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T14:01:39.217500Z",
+     "iopub.status.busy": "2022-08-16T14:01:39.217285Z",
+     "iopub.status.idle": "2022-08-16T14:04:31.302623Z",
+     "shell.execute_reply": "2022-08-16T14:04:31.301333Z",
+     "shell.execute_reply.started": "2022-08-16T14:01:39.217470Z"
+    },
     "tags": [
      "hide-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<style>\n",
+       "    /* Turns off some styling */\n",
+       "    progress {\n",
+       "        /* gets rid of default border in Firefox and Opera. */\n",
+       "        border: none;\n",
+       "        /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
+       "        background-size: auto;\n",
+       "    }\n",
+       "    progress:not([value]), progress:not([value])::-webkit-progress-bar {\n",
+       "        background: repeating-linear-gradient(45deg, #7e7e7e, #7e7e7e 10px, #5c5c5c 10px, #5c5c5c 20px);\n",
+       "    }\n",
+       "    .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
+       "        background: #F44336;\n",
+       "    }\n",
+       "</style>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <div>\n",
+       "      <progress value='10000' class='' max='10000' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+       "      100.00% [10000/10000 02:52&lt;00:00]\n",
+       "    </div>\n",
+       "    "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "# Outputs a blank line for each for some reason. Use %%capture when calling\n",
     "def fingerprint_all(fnames):\n",
     "    fingerprints = {}\n",
-    "    for f in fnames:\n",
+    "    for f in progress_bar(fnames):\n",
     "        category = label_func(f)\n",
     "        img = PILImage.create(f)\n",
-    "        result = learn.predict(img)\n",
+    "        with learn.no_bar():\n",
+    "            result = learn.predict(img)\n",
     "        fingerprint = result[1].numpy()\n",
     "        fingerprints[(category,f)] = fingerprint\n",
-    "    return fingerprints\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 103,
-   "id": "1f462a50",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%capture \n",
-    "# Suppresses output\n",
-    "# Takes about 3 minutes on a 2080\n",
+    "    return fingerprints\n",
+    "\n",
     "fingerprint_db = fingerprint_all(fnames)"
    ]
   },
@@ -855,9 +924,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": 26,
    "id": "2390d32b",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T14:04:53.622571Z",
+     "iopub.status.busy": "2022-08-16T14:04:53.621578Z",
+     "iopub.status.idle": "2022-08-16T14:04:53.626145Z",
+     "shell.execute_reply": "2022-08-16T14:04:53.625324Z",
+     "shell.execute_reply.started": "2022-08-16T14:04:53.622550Z"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Find k nearest neighbour using cosine similarity. Normalized vectors, so easy...\n",
@@ -868,371 +946,658 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
-   "id": "cc16c697",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([5306, 5065, 4995, 5714, 5609, 5281, 5600, 5089, 5681, 5326])"
-      ]
-     },
-     "execution_count": 105,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "fps = list(fingerprint_db.values())\n",
-    "closest = find_k_nearest_neighbors(fps, query_fingerprint, 10)\n",
-    "closest"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 106,
-   "id": "a3f64fe4",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(('8', Path('/home/larry/.fastai/data/mnist_png/testing/8/4601.png')),\n",
-       " array([ 0.01670307, -0.09334327, -0.04035507,  0.14034109, -0.1390653 ,\n",
-       "        -0.02997699,  0.0691412 , -0.01965449,  0.14879996, -0.0307778 ,\n",
-       "         0.0499967 , -0.09715722,  0.03967079, -0.12546353,  0.00465879,\n",
-       "        -0.12868424,  0.1673229 ,  0.14279988,  0.00981914, -0.1257291 ,\n",
-       "        -0.04629233, -0.02733118,  0.00387376, -0.11382929,  0.03242231,\n",
-       "        -0.05249896, -0.0671302 , -0.1337653 ,  0.06506158, -0.03965495,\n",
-       "         0.09792112, -0.0035671 ,  0.01463524,  0.06439284, -0.00860449,\n",
-       "        -0.01265145,  0.15822726,  0.06589206, -0.02866904,  0.02266427,\n",
-       "         0.05323914, -0.11058905,  0.08238242,  0.0728654 ,  0.14486936,\n",
-       "        -0.10078606, -0.007328  ,  0.14902319, -0.04762946,  0.04559135,\n",
-       "         0.08897641, -0.0766572 ,  0.03898349, -0.3038692 ,  0.07756894,\n",
-       "        -0.13703844, -0.05287901, -0.09189159, -0.05284088,  0.20026134,\n",
-       "        -0.0715245 , -0.04721208,  0.10749867,  0.01726143,  0.06433553,\n",
-       "         0.10477507,  0.02108847,  0.0091063 ,  0.05986425, -0.09090011,\n",
-       "        -0.03856177,  0.0225267 ,  0.01547802, -0.07009684,  0.04933351,\n",
-       "        -0.20559575,  0.02978103, -0.09852843,  0.10115103, -0.0619239 ,\n",
-       "        -0.0938134 , -0.05666979,  0.0307138 ,  0.12218301,  0.07559568,\n",
-       "        -0.01842191,  0.00236265, -0.00506003, -0.12281424,  0.07476256,\n",
-       "        -0.06825907,  0.05655899,  0.04785315, -0.03564778,  0.04038844,\n",
-       "         0.06739844, -0.03968165,  0.08115924,  0.09150132,  0.00057375,\n",
-       "        -0.02548034, -0.13561288, -0.06721403, -0.08430342, -0.11926533,\n",
-       "        -0.20367351,  0.0118809 , -0.09045237, -0.00445576,  0.06755832,\n",
-       "        -0.04638288,  0.00143136,  0.13788123,  0.04862857, -0.06847995,\n",
-       "         0.06520806, -0.02769817, -0.05655945,  0.14175507, -0.01106928,\n",
-       "        -0.0630332 , -0.1380761 ,  0.11638069, -0.07756015, -0.17415078,\n",
-       "        -0.05959132,  0.04788565, -0.01032123], dtype=float32))"
-      ]
-     },
-     "execution_count": 106,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "list(fingerprint_db.items())[closest[0]]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": 27,
    "id": "09966276",
    "metadata": {
-    "scrolled": true
+    "execution": {
+     "iopub.execute_input": "2022-08-16T14:04:58.706649Z",
+     "iopub.status.busy": "2022-08-16T14:04:58.706471Z",
+     "iopub.status.idle": "2022-08-16T14:04:58.812765Z",
+     "shell.execute_reply": "2022-08-16T14:04:58.811999Z",
+     "shell.execute_reply.started": "2022-08-16T14:04:58.706632Z"
+    },
+    "scrolled": true,
+    "tags": []
    },
    "outputs": [
     {
      "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAAeklEQVR4nNWQyxGDMAxEHzQWURnqTKayzcGQMUb2TI7sTdqPPvAmLACY7ZSjdkrpJK4Otb2meVtb2N1qvfjkA/csy65pHpGwLskwSZlbUoSkxPk7KZ0Kg20rhpmnseFuHzKAY0D2gS35WDJ/fEJ+ZsLpkbPv4DH0/YsvgaZpcV1JKgwAAAAASUVORK5CYII=\n",
       "text/plain": [
-       "[(('8', Path('/home/larry/.fastai/data/mnist_png/testing/8/4601.png')),\n",
-       "  0.050738394260406494),\n",
-       " (('8', Path('/home/larry/.fastai/data/mnist_png/testing/8/7265.png')),\n",
-       "  0.05101466178894043),\n",
-       " (('8', Path('/home/larry/.fastai/data/mnist_png/testing/8/2425.png')),\n",
-       "  0.05178546905517578),\n",
-       " (('8', Path('/home/larry/.fastai/data/mnist_png/testing/8/486.png')),\n",
-       "  0.051842331886291504),\n",
-       " (('8', Path('/home/larry/.fastai/data/mnist_png/testing/8/6839.png')),\n",
-       "  0.053469955921173096),\n",
-       " (('8', Path('/home/larry/.fastai/data/mnist_png/testing/8/5680.png')),\n",
-       "  0.05356067419052124),\n",
-       " (('8', Path('/home/larry/.fastai/data/mnist_png/testing/8/3583.png')),\n",
-       "  0.055361032485961914),\n",
-       " (('8', Path('/home/larry/.fastai/data/mnist_png/testing/8/128.png')),\n",
-       "  0.0555570125579834),\n",
-       " (('8', Path('/home/larry/.fastai/data/mnist_png/testing/8/1499.png')),\n",
-       "  0.05637812614440918),\n",
-       " (('8', Path('/home/larry/.fastai/data/mnist_png/testing/8/4020.png')),\n",
-       "  0.05665343999862671)]"
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
       ]
      },
-     "execution_count": 107,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/1530.png'),\n",
+       " 0.046761393547058105,\n",
+       " array([-0.15196997, -0.03608787,  0.00868906, -0.1474988 , -0.07871772,\n",
+       "         0.18009232,  0.06617993, -0.07894154,  0.12192538, -0.02143634,\n",
+       "         0.04440383,  0.10302673,  0.03750927, -0.07367066,  0.09718364,\n",
+       "         0.12069038,  0.0224285 , -0.25404668, -0.11400666, -0.16254014,\n",
+       "        -0.0650501 , -0.10554277, -0.3876711 , -0.04148291,  0.3751997 ,\n",
+       "         0.14719807, -0.00786453,  0.28334555,  0.04159332,  0.13660236,\n",
+       "        -0.338259  ,  0.44309753], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAABKElEQVR4nGNgGNxAY8u/9/lsjBOvWWJIaW75+e/v26ezKv/+3Ysmxdz35e+76c4SEpv//f0SgGbitL8fJ0ozMDA0/P33FU2u7fu/7SYMDAwMFb///qtGkWJa8O+2NwMDAwODwr9//zaj6qv/+1AWoqrt799bIlBRFgglzvAnmeHb5O/8q1wYljS8QdXJ175376uXT2Y8/vd3Px+2AODmln/5999LcSSXIJhfv/5lZPzOKIdNIwND3Me/xyRWfwzBJqf98e85DuZFf9djkXP88neXBEPq378rMeV0r/7bLsTg/e/vO2MMOY4T/2YxMFh/+X+UH1Pjwr8XRBgCv/49KoApF/3lozRz2ZdHs7HoY9jyd3bkib+7JLD5gqHn79+/xzOZscpRHQAA/XV6p7us4F4AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/9695.png'),\n",
+       " 0.05765575170516968,\n",
+       " array([-0.14378099, -0.01904452,  0.02563651, -0.16199934, -0.0731125 ,\n",
+       "         0.17124939,  0.04726793, -0.07125276,  0.1401669 , -0.03016548,\n",
+       "         0.08940042,  0.09959242,  0.03449062, -0.08187288,  0.08232458,\n",
+       "         0.1259517 ,  0.037958  , -0.27090096, -0.08992128, -0.15366232,\n",
+       "        -0.0683461 , -0.1331811 , -0.35772353, -0.02952323,  0.35062593,\n",
+       "         0.17712657, -0.0079319 ,  0.27478832,  0.03862523,  0.11074734,\n",
+       "        -0.3604329 ,  0.45798868], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAAx0lEQVR4nGNgGLyAkT2yad6/f//+XQllRJcTmf4XDqbxosoxzfmLBNK4USTl/6KA88LIkv1/0WQDGBiYUA3/8Q3G0jNEknzNwMDA8GLKF6weEUYz9m8mAwMLTPLPS3EkpS/vH5uJxGVdh6TraQGKqSxIrn3WrYZqJS9c6rm/Crp7imByx5Qx3Jr7CiZ5ASlooP4UhQvpqmBIGsIFjlzAkLyNkPyJIQkPtf4GDPcwcB6HOGclhjcYGBgYfP7+/fs6l5UJmxy1AQDgVqLo4CL5NQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/7845.png'),\n",
+       " 0.05808192491531372,\n",
+       " array([-1.07208796e-01,  1.58861019e-02,  1.01681929e-02, -1.64128333e-01,\n",
+       "        -7.68265128e-02,  1.69703022e-01,  8.00302997e-02, -3.77415568e-02,\n",
+       "         1.36849627e-01, -9.14011709e-03,  9.38586593e-02,  1.22826666e-01,\n",
+       "         2.78840382e-02, -1.06367722e-01,  7.64094442e-02,  1.00307576e-01,\n",
+       "         2.54410412e-02, -2.66223699e-01, -9.38874185e-02, -1.80105120e-01,\n",
+       "        -1.01681605e-01, -1.25512525e-01, -3.67389411e-01, -3.09003498e-02,\n",
+       "         3.22947919e-01,  1.96895123e-01,  3.48446702e-05,  2.83417195e-01,\n",
+       "         6.25862926e-02,  8.62728059e-02, -3.62059206e-01,  4.55357343e-01],\n",
+       "       dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA5ElEQVR4nGNgGLqAxX7GmycT1GBcRhhD1NHnjmCgHAMDA8PsdJhaKG26XQjTICYIxbdaiIGBgeFHutFKhGEw0Pzv379///595GBQ//evFE1SsKzdY/+/f/82sE/5d8ERi1N5Ov78+3fw5b8K7D4p+/fv3z9ckvz7/v37988UuySDyL9//3YxoXsFCn6jqkWVlGVgYNDkxW6q9L5///7908Cu086BgYGBIQC7pDkOdzIwMDDovP/3b8a/L05YdarzMzCIMxzah8O1DAz+vzZgN9bjw79//ybhstTj3793ingcRTwAAPS4S0rWnQxaAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/4978.png'),\n",
+       " 0.059948503971099854,\n",
+       " array([-0.13393578, -0.01838107, -0.00534778, -0.17210366, -0.07266845,\n",
+       "         0.18902731,  0.03273853, -0.08977108,  0.13195774, -0.02636713,\n",
+       "         0.09701853,  0.1159689 ,  0.02596068, -0.09155644,  0.10679887,\n",
+       "         0.15774828,  0.01430953, -0.24548481, -0.13471584, -0.16768138,\n",
+       "        -0.04165975, -0.1139208 , -0.39835957, -0.02385826,  0.35113412,\n",
+       "         0.1411736 ,  0.03943544,  0.27782732,  0.02119364,  0.11498547,\n",
+       "        -0.33189255,  0.43487713], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA6UlEQVR4nM2RIXTCMBCG//RNMQt2SKgFTfVmq9G1vDc3zTQWdDXVs4PJPFDwkEOue3O1uTtE2kIacIjdqeRL7v//BPhnpS4XnScAm+sHE02GzEcCxLqBuism2++ZUNZy4NjQZQ8cuCImpmPBxCQkewDBmYrI+vXlS0SE5Xft3Yw6Wak7aztwYcik2ip+Thpuw6Jyy8vYi5mWPnfTlseGZU498p8nzMuEbZ8N80rR14vz+m2+m2Mf97VTYoqq7QcAwFtPBHWLC0MVcMAKCgrbw5879vnH6uXzgfsb1pAujmlyJYWt/k1y9zoBsSK4GWpO+WIAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/7923.png'),\n",
+       " 0.061333417892456055,\n",
+       " array([-0.13801472,  0.00621954,  0.01324526, -0.15497565, -0.07363982,\n",
+       "         0.18480222,  0.06190637, -0.07731929,  0.14280462, -0.01529375,\n",
+       "         0.06797428,  0.12477075,  0.03360037, -0.09421641,  0.08267348,\n",
+       "         0.1202066 ,  0.02800406, -0.23831494, -0.12120299, -0.17994858,\n",
+       "        -0.07378727, -0.12906069, -0.37269413, -0.03644777,  0.3587743 ,\n",
+       "         0.15787394, -0.00156036,  0.28049743,  0.04324026,  0.09545978,\n",
+       "        -0.3575211 ,  0.4439831 ], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAABB0lEQVR4nMXQIUhDURQG4P8OEfVpGHsgPhCGwSAMw6KgVaPFZBmCXbCoxWDSKoMhqAOzdYaJCEbRYbZZxtJwsiH8/67B59N331udp1zO+bjncA7wn1E8tpJOvTSbu6ZI8j6bgjekGrUGdZC0+TapTWTLekriIsnmGICNnRSUtOsWM+Hb61jrD9ykQva2ftN8DKf2qI9ymCw/P8Q3Gj8Uu3UPAM47ZMHpXJKkkwtJVvtxWq+K5PeZPo9mYpZ7ZYS3K07PK0b4MunsCR9ANQiCR2BhIqyN/KAxyNy1AGMA42LLor/97vlFC1hnJHL1aGZl1EUsXYb4NhuN+sPTa6t5dGtn7cTHIcYXmSqKVRrT5rgAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/8522.png'),\n",
+       " 0.06222796440124512,\n",
+       " array([-0.12476783,  0.00766327,  0.01253117, -0.15939318, -0.0901918 ,\n",
+       "         0.14988562,  0.0321156 , -0.07108332,  0.12217312, -0.05132951,\n",
+       "         0.07190754,  0.11549593,  0.02556554, -0.12640232,  0.08192091,\n",
+       "         0.14909093,  0.04484734, -0.229729  , -0.08162493, -0.17374739,\n",
+       "        -0.07640947, -0.10110657, -0.34674266, -0.01630255,  0.3628034 ,\n",
+       "         0.1782804 ,  0.02545982,  0.29276216,  0.03688889,  0.08349589,\n",
+       "        -0.36321253,  0.47145176], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA7UlEQVR4nM3RsUtCURTH8a9CDcKbHgSB4RqCi24FPUhoSHAq/Av8A9RZwaGlubG1IRqiNkEkwyEwWpsDRSiDwMHld8jBBw33vq3Bs/y493POPcOFDatUnJ3u9Bbg7XHhNrUnkkxS3zNJbrc2e6Z2lK8M3NHSOhp29neXjrN5H7+UwsXfrRCA0/mLi+zchUD5YDlxVwZjDSPoqe0aBJdf9nT8anUfQvbCJPkNqErqnYd+3JNkGkZ+NKt2ZjYOEiazhO9qxOe00/Hdp5iIFLlO2LlPYer5FiAz0s3Jh1peJPqU6Wrbjxz+2EMuwf6tVpn0UrAs+pFvAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/1899.png'),\n",
+       " 0.06499218940734863,\n",
+       " array([-1.27346948e-01, -1.83118563e-02, -1.64001400e-03, -1.12126172e-01,\n",
+       "        -9.83644724e-02,  1.20315835e-01,  6.54301345e-02, -5.12091704e-02,\n",
+       "         1.52682900e-01, -2.65320949e-02,  1.01760603e-01,  1.01684757e-01,\n",
+       "         4.37608658e-04, -9.08510759e-02,  1.15145333e-01,  1.16071053e-01,\n",
+       "         1.89567525e-02, -2.89904714e-01, -2.81014871e-02, -1.68478966e-01,\n",
+       "        -8.66025165e-02, -1.19814016e-01, -3.51793557e-01, -3.32695502e-03,\n",
+       "         3.51190627e-01,  1.90500647e-01, -1.87768824e-02,  2.90717572e-01,\n",
+       "         4.80326265e-02,  9.30584893e-02, -3.63771588e-01,  4.61655587e-01],\n",
+       "       dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA3ElEQVR4nM2SLQ/CQAyG2zGFZbNgmUXghgTsZtGbx47/gECR8BcIdpowjYJMkuAuAQVBXW+I21e2SgStufS5t9ePA/gzw+po9wMnBQDYpZ/mNf8mJGm/tHJsSZUe6pBZCr0MKtdmFDCwERHHHTNBxEcjq0uSJC3AF9yb/kuRoqVQ9B62u4ryWmXE9XzUte45BjNJkuS1y8KBUKSEUwXMGnR7WQaHlBWCns6EZStda8yxeT7XNQeLnVgMCzOtFJww1joxqsXKrVgGIuJzc67B8pt4UwfS5HRnG/mtfQG+9omQ6hxlYQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/580.png'),\n",
+       " 0.06748747825622559,\n",
+       " array([-0.13130559, -0.00427955,  0.00618431, -0.17756099, -0.07211003,\n",
+       "         0.19607309,  0.03610032, -0.07650073,  0.13990745, -0.00601777,\n",
+       "         0.09886124,  0.1305777 ,  0.03129087, -0.0902622 ,  0.09924899,\n",
+       "         0.13972628,  0.0141205 , -0.25533268, -0.12707938, -0.1729454 ,\n",
+       "        -0.05700621, -0.1422437 , -0.38782725, -0.02004008,  0.33749428,\n",
+       "         0.14314933,  0.02332693,  0.26700094,  0.02538364,  0.09330878,\n",
+       "        -0.33804575,  0.44703257], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA90lEQVR4nM3QMUvDUBTF8ZMOdTGUIt3EtQScBOlHcFEXwUFBnRtpXTPp3rEIThLpF/AbWMVJRBAUnAQ3IaVDNejwfzwHIYnNcxQ84/lx7+Nd6e/jR5E99N1WH4JhWHdiDBg4zYpKcavu2+eo6RqtXdGWwpRlx6S1knTcy5sCTkbalvTsRElLq5rddH9l54Pr/gX5mz+yBYZfcOPWGGtMx2X7n4BhUHFYJwVuDJe1snXf4W13rjkhLF/oEe72JIVp4bg5PjQkSUcka2VMToIgkBZeSFpTGL0CcBbHYxh8d16m8+uNrud7VpKeFqdQkmYOvFZ1JcN/ly/IdmwbWpa5jgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/1955.png'),\n",
+       " 0.0702618956565857,\n",
+       " array([-0.13201681,  0.02472456,  0.00523583, -0.17277762, -0.08472393,\n",
+       "         0.16207097,  0.03596724, -0.08537581,  0.13170849, -0.02398622,\n",
+       "         0.08799887,  0.11950567,  0.0326271 , -0.11376908,  0.07973925,\n",
+       "         0.14595453,  0.03395455, -0.23491602, -0.11099958, -0.17845914,\n",
+       "        -0.05886613, -0.12497291, -0.36913148, -0.0124557 ,  0.3447679 ,\n",
+       "         0.15837647,  0.01603587,  0.28382334,  0.03426813,  0.08366528,\n",
+       "        -0.35784483,  0.45983088], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA+klEQVR4nMXQoUtDURQG8A8RRJSFhYfXafIPMA3MBqPBNlh5D0EQDEZd0zIYBsGi+wtsA2VrCoKYDG6Wh2ls4WF/G+L3oeGNDd49WU/6uD/OuYcD/G+5Wir9KN1dMLBDkiJ5MnmYm1m083Xm3IoLseo3tvpbAIDnaeesSsNeFpKm8efTxxIAoAIAxRweKprm9eMchulobRKD27v83FN2s5VKDb7m0bXZ3wCi1lDc83e60dvVQNL4fNHHanahuOzTfPBJivf7y75FHZJ8uLbOfjES2X6sGIRLadw7aujdwoRxiCoZ2tgM6t98sQwJKbK7beJmTPGgYNpf1i+Cym8Z+mpaAQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/5771.png'),\n",
+       " 0.07090085744857788,\n",
+       " array([-0.12781088,  0.00892572,  0.00189792, -0.18430823, -0.08083843,\n",
+       "         0.18911533,  0.01223383, -0.08254232,  0.12467169, -0.04286132,\n",
+       "         0.08438423,  0.12680066,  0.02134114, -0.1101879 ,  0.10012072,\n",
+       "         0.1764467 ,  0.02061235, -0.22360286, -0.13817692, -0.17863664,\n",
+       "        -0.05047771, -0.11878041, -0.37152535, -0.01739322,  0.35964054,\n",
+       "         0.13495684,  0.05790193,  0.28195673,  0.01602801,  0.08603457,\n",
+       "        -0.33482018,  0.44657353], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
     "## Put it together\n",
     "\n",
-    "def best_match_mnist(fingerprint_db, fingerprint, k):\n",
+    "def best_match_mnist(fingerprint_db, fingerprint, k, display_data=False):\n",
     "    fps = list(fingerprint_db.values())\n",
     "    keys = list(fingerprint_db.keys())\n",
     "    match_indices = find_k_nearest_neighbors(fps,fingerprint,k)\n",
     "    for i in match_indices:\n",
     "        match_fp = fps[i]\n",
     "        distance = spatial.distance.cosine(match_fp, fingerprint)\n",
+    "        if display_data:\n",
+    "            display(Image.open(keys[i][1]))    \n",
+    "            display([keys[i][0], keys[i][1], distance, match_fp])\n",
     "        yield (keys[i], distance)\n",
     "        \n",
-    "list(best_match_mnist(fingerprint_db, query_fingerprint, 10))"
+    "list(best_match_mnist(fingerprint_db, query_fingerprint, 10, display_data=True));"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": 28,
    "id": "c31c0e03",
    "metadata": {
-    "scrolled": true
+    "execution": {
+     "iopub.execute_input": "2022-08-16T14:05:03.652454Z",
+     "iopub.status.busy": "2022-08-16T14:05:03.652278Z",
+     "iopub.status.idle": "2022-08-16T14:05:03.657790Z",
+     "shell.execute_reply": "2022-08-16T14:05:03.656941Z",
+     "shell.execute_reply.started": "2022-08-16T14:05:03.652438Z"
+    },
+    "scrolled": true,
+    "tags": []
    },
    "outputs": [],
    "source": [
-    "def fingerprint_file(path) :\n",
+    "def fingerprint_file(path, display_data=False) :\n",
     "    img = PILImage.create(path)\n",
     "    result = learn.predict(img)\n",
     "    fingerprint = result[1].numpy()\n",
+    "    if display_data:\n",
+    "        display(img)\n",
     "    return fingerprint"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 109,
+   "execution_count": 29,
    "id": "c2342ec7",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[(('4', Path('/home/larry/.fastai/data/mnist_png/testing/4/4929.png')),\n",
-       "  0.011352241039276123),\n",
-       " (('4', Path('/home/larry/.fastai/data/mnist_png/testing/4/6019.png')),\n",
-       "  0.01591700315475464),\n",
-       " (('4', Path('/home/larry/.fastai/data/mnist_png/testing/4/8280.png')),\n",
-       "  0.017027199268341064),\n",
-       " (('4', Path('/home/larry/.fastai/data/mnist_png/testing/4/3490.png')),\n",
-       "  0.01715630292892456),\n",
-       " (('4', Path('/home/larry/.fastai/data/mnist_png/testing/4/1274.png')),\n",
-       "  0.017175495624542236)]"
-      ]
-     },
-     "execution_count": 109,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "fp4 = fingerprint_file('media/4.png')\n",
-    "list(best_match_mnist(fingerprint_db, fp4, 5))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 110,
-   "id": "4d44ee49",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[(('8', Path('/home/larry/.fastai/data/mnist_png/testing/8/4601.png')),\n",
-       "  0.050738394260406494)]"
-      ]
-     },
-     "execution_count": 110,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "fps1 = fingerprint_file('stars/Star1.png')\n",
-    "fps2 = fingerprint_file('stars/Star2.png')\n",
-    "list(best_match_mnist(fingerprint_db, fps1, 1))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 111,
-   "id": "2e01e6dc",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.698689341545105"
-      ]
-     },
-     "execution_count": 111,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "spatial.distance.cosine(fps2, fps1)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 112,
-   "id": "8f4b9ee3",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[(('7', Path('/home/larry/.fastai/data/mnist_png/testing/7/2607.png')),\n",
-       "  0.30452412366867065)]"
-      ]
-     },
-     "execution_count": 112,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "list(best_match_mnist(fingerprint_db, fps2, 1))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 113,
-   "id": "3f76e6c0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fingerprint_db[('*','/stars/Star1.png')] = fps1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 114,
-   "id": "ebc200ba",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[(('7', Path('/home/larry/.fastai/data/mnist_png/testing/7/2607.png')),\n",
-       "  0.30452412366867065),\n",
-       " (('7', Path('/home/larry/.fastai/data/mnist_png/testing/7/3767.png')),\n",
-       "  0.3672325015068054),\n",
-       " (('7', Path('/home/larry/.fastai/data/mnist_png/testing/7/1226.png')),\n",
-       "  0.38205158710479736),\n",
-       " (('7', Path('/home/larry/.fastai/data/mnist_png/testing/7/1754.png')),\n",
-       "  0.3908657431602478),\n",
-       " (('7', Path('/home/larry/.fastai/data/mnist_png/testing/7/3604.png')),\n",
-       "  0.4022327661514282),\n",
-       " (('7', Path('/home/larry/.fastai/data/mnist_png/testing/7/1903.png')),\n",
-       "  0.4049708843231201),\n",
-       " (('7', Path('/home/larry/.fastai/data/mnist_png/testing/7/5906.png')),\n",
-       "  0.41332465410232544),\n",
-       " (('7', Path('/home/larry/.fastai/data/mnist_png/testing/7/3808.png')),\n",
-       "  0.41522079706192017),\n",
-       " (('7', Path('/home/larry/.fastai/data/mnist_png/testing/7/6577.png')),\n",
-       "  0.4156973958015442),\n",
-       " (('7', Path('/home/larry/.fastai/data/mnist_png/testing/7/358.png')),\n",
-       "  0.41868728399276733)]"
-      ]
-     },
-     "execution_count": 114,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "(list(m for m in best_match_mnist(fingerprint_db, fps2, 10)))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 115,
-   "id": "2b9407f2",
    "metadata": {
-    "scrolled": false
+    "execution": {
+     "iopub.execute_input": "2022-08-16T14:05:05.154866Z",
+     "iopub.status.busy": "2022-08-16T14:05:05.154095Z",
+     "iopub.status.idle": "2022-08-16T14:05:05.375282Z",
+     "shell.execute_reply": "2022-08-16T14:05:05.373509Z",
+     "shell.execute_reply.started": "2022-08-16T14:05:05.154813Z"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "\n",
+       "<style>\n",
+       "    /* Turns off some styling */\n",
+       "    progress {\n",
+       "        /* gets rid of default border in Firefox and Opera. */\n",
+       "        border: none;\n",
+       "        /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
+       "        background-size: auto;\n",
+       "    }\n",
+       "    progress:not([value]), progress:not([value])::-webkit-progress-bar {\n",
+       "        background: repeating-linear-gradient(45deg, #7e7e7e, #7e7e7e 10px, #5c5c5c 10px, #5c5c5c 20px);\n",
+       "    }\n",
+       "    .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
+       "        background: #F44336;\n",
+       "    }\n",
+       "</style>\n"
+      ],
       "text/plain": [
-       "[(('7', Path('/home/larry/.fastai/data/mnist_png/testing/7/2607.png')),\n",
-       "  0.30452412366867065),\n",
-       " (('7', Path('/home/larry/.fastai/data/mnist_png/testing/7/3767.png')),\n",
-       "  0.3672325015068054),\n",
-       " (('7', Path('/home/larry/.fastai/data/mnist_png/testing/7/1226.png')),\n",
-       "  0.38205158710479736),\n",
-       " (('7', Path('/home/larry/.fastai/data/mnist_png/testing/7/1754.png')),\n",
-       "  0.3908657431602478),\n",
-       " (('7', Path('/home/larry/.fastai/data/mnist_png/testing/7/3604.png')),\n",
-       "  0.4022327661514282),\n",
-       " (('7', Path('/home/larry/.fastai/data/mnist_png/testing/7/1903.png')),\n",
-       "  0.4049708843231201),\n",
-       " (('7', Path('/home/larry/.fastai/data/mnist_png/testing/7/5906.png')),\n",
-       "  0.41332465410232544),\n",
-       " (('7', Path('/home/larry/.fastai/data/mnist_png/testing/7/3808.png')),\n",
-       "  0.41522079706192017),\n",
-       " (('7', Path('/home/larry/.fastai/data/mnist_png/testing/7/6577.png')),\n",
-       "  0.4156973958015442),\n",
-       " (('7', Path('/home/larry/.fastai/data/mnist_png/testing/7/358.png')),\n",
-       "  0.41868728399276733)]"
+       "<IPython.core.display.HTML object>"
       ]
      },
-     "execution_count": 115,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAABeklEQVR4nGNgGAVkgaVLl3Jzc2OVYiLPRD4+PklJyZ8/f5JpqK6uLqagurr6y5cv//z5Q46hDg4Oq1evxhQ3MTG5efMmLl34DNXQ0MjMzExISMBq6Llz5/A7CAvg4uI6efJkaGgoVtmrV68KCAiQbOLs2bMbGxuZmZkxZQ0MDLZt24ZHOwtW0ZSUFC4urvr6eqyytra2JPvdxMRk5cqVioqKuBSsWrXK19cXjwlYXNrU1DRv3rz79+8jC4qIiGhpaamoqMjLy3t6enJwcKiqqvb19RFlaGlpKQ8PDwMDQ2BgICSFy8rKysrKsrGxPXny5OHDh9++fXv+/HlBQcHLly+JdenJkyclJCQsLS3/////5cuXV69ebdy48erVq0+fPoUoiI2NPXz48L179/B4n2QwefLk3Nxc/GpIzvu6urrnz58n10k4wNOnT4WEhPCrIc2lEOPevXtHTUMVFRXRktpgNVRWVvbhw4dUNlRKSurOnTskaRkFgxgAAIIffhnooLd0AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "PILImage mode=RGB size=28x28"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAAw0lEQVR4nGNgGHAgdOoobsn+f4Y45TTebWdF4jKhSGYLnP+NS5JDjOEzAw5JxkmhuF2j8e/fv2m4JHf/+/fvEg450V//TqFKItlZz7L1Bi5DNb/++/Du33U2ZBfCWYetGRgYGBgufljLIO70MApFo8qXfzca7/yDgqsMDAwMDCwwyX//Zta/UlA6NsePgYFh3Tk0O9mZGBgW/qtEFoLrZPiJ6UbUgOdjwBUIDAwMv88j+wRVpy3Txl84JQ//e43bVDoBANdbQi67gdv3AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['4',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/4/5677.png'),\n",
+       " 0.002303779125213623,\n",
+       " array([-3.13590840e-02, -2.15366315e-02,  1.10434815e-01, -2.51350909e-01,\n",
+       "         3.23935688e-01,  1.10073201e-01,  1.43108398e-01, -1.58630833e-01,\n",
+       "         4.42154333e-02, -2.16500740e-02,  1.73474327e-01, -2.91183650e-01,\n",
+       "         1.03035815e-01, -1.76725745e-01,  5.88470399e-02, -1.80038989e-01,\n",
+       "         2.79691927e-02,  3.16117406e-01, -3.16662580e-01,  3.13063711e-02,\n",
+       "         2.00232908e-01, -5.57611473e-02, -9.26752612e-02, -7.05756024e-02,\n",
+       "        -3.18065286e-01,  1.91690296e-01,  2.55467087e-01, -1.15748597e-02,\n",
+       "         2.07241531e-02, -5.14973290e-02, -2.25168813e-04, -3.16742092e-01],\n",
+       "       dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA60lEQVR4nGNgGLRARJeBgYGB4fo/Z7gQE5w1JYOBgYGB4f///1gk2Xxxm6r38WcUAwOD3OO/m+FiLDBGEQ+DIAMDg4MUgwimsdJwIR5BdFP1X/59raKpmXT679+/AWhynHP//v289O+/v3+xSAb+/fv371+I5C9vTK/AwdmtaJK3XjIxMTIynuj8ysiIqX7C3zeTXHnZGVL//j2OIckuJcbAwMDAcA1ZEhYIP58xMDAwMEQrY7oBBhRu/kXWiWp7pAoDA8M8HDrVvv79e14Uh051FgYGMVySan8YGL5+xeUi4w9//zrhdjB1AADuA0/BpOUT7AAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['4',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/4/2886.png'),\n",
+       " 0.004014790058135986,\n",
+       " array([-0.03786912, -0.03118558,  0.08279644, -0.21122247,  0.32699743,\n",
+       "         0.12728068,  0.13448665, -0.18832497,  0.05738041, -0.03265832,\n",
+       "         0.14865893, -0.2861046 ,  0.09195897, -0.18459581,  0.10036085,\n",
+       "        -0.14381559,  0.0293766 ,  0.33007255, -0.319167  ,  0.02344558,\n",
+       "         0.23082243, -0.04694476, -0.12151314, -0.02910761, -0.28864992,\n",
+       "         0.16973186,  0.27506524, -0.01407119,  0.00416797, -0.06371135,\n",
+       "         0.0178963 , -0.33486405], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA7klEQVR4nM3OrUuDcRTF8e82Vx7BNiYWmS/ggrAyEIyGNTEYtK4ImqyWJf+FJU0Dg2ltMFk1qCA2HStrK1MekMHYuWhQ8GHXX1vYjffDOffCHM+2XQOX1sz8gxfSPrxIud9F+s+yFShAgdaHx/NduOc0IpbHBRg8cpK4k8BNOKS8Brf+nVKs8Sp70kPWJ+uLNPorBzCYuGDxXXq660s6chZ1JEkm6Xl5GvNmZmZfZjYqOZQUtz9N6lRdbV662qBnqqWdkYqiFMWhdXPefp5qyNrJRbJk/RjeAkGq0nArlNyB3msIgZtQK2fSUhBnON9VgFyMLllSUAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['4',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/4/7361.png'),\n",
+       " 0.004868447780609131,\n",
+       " array([-0.05694573, -0.04604704,  0.08696871, -0.21627809,  0.3156083 ,\n",
+       "         0.11708419,  0.14291759, -0.19755293,  0.06709458, -0.03699708,\n",
+       "         0.15461129, -0.30813265,  0.09053328, -0.1794673 ,  0.09742116,\n",
+       "        -0.14840591,  0.02772097,  0.3262057 , -0.3035298 ,  0.05381545,\n",
+       "         0.22480297, -0.05314825, -0.10575383, -0.04030157, -0.30172822,\n",
+       "         0.18327418,  0.25570568, -0.00873607,  0.0249078 , -0.04829767,\n",
+       "        -0.00615531, -0.33080208], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA+0lEQVR4nM3Rr0tDURjG8ceNK97gDBd1Y4KwpqhZNCtjGlxfELXZDGb/gk1MRk1WsQkXXBE0G7YVUXcn/mgq+IsvM1yQy7t7m8E3ns95Hjjvkf7xpI66O2lJhetmvgezwKrknMB+eDuCOUmXUm5JerBB5xZaI3LPoeHZ5NqY5L9oY1Y6fbPJDgQF6Rn2+q0dAGVp/hsWrbkBPE3IfYT2uLHpOoC/cAwf28YGt/idG1u6SxyGT8nMSdL7YWBDklQDqA17V3G1lc+vC68vtQm80p40WlxWuHhG1+OqpRngbCDeVAVKCebcQ92NnkR+petLQ0mtWuFuKp2Efzg/N/R9GUe8pJwAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['4',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/4/7376.png'),\n",
+       " 0.005374610424041748,\n",
+       " array([-0.03907151, -0.04383761,  0.07805806, -0.21245532,  0.31159526,\n",
+       "         0.12885717,  0.13754822, -0.18394949,  0.05765934, -0.04241817,\n",
+       "         0.14189789, -0.28625816,  0.08501954, -0.17751908,  0.10637633,\n",
+       "        -0.13228597,  0.02483746,  0.33107218, -0.33575127,  0.02612962,\n",
+       "         0.23956959, -0.03736461, -0.13207437, -0.03730523, -0.28433457,\n",
+       "         0.1630143 ,  0.28086212, -0.00990892,  0.00472082, -0.04490199,\n",
+       "         0.02159508, -0.33755064], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA8UlEQVR4nM3PP0uCURTH8S9qSQlKS4K1OGaKLtLWO8glCOsdRCnoIG0Nbg2OvYCaHHR2srlGaWgxEBpcFOwPCPK7tvjn4XmeuzV04HI558M95x74vxE+2QI4M297XqypAfAg1b04VC8GfK0xsLJshPcJ5Ddh6sHqNkMgG2J0726a/tT4ELiTbj0TS9I1EHyVjpa10OKOlmGeyR0nDnyWvJQ0kIwkPYZdH9pfHICLmKvtUxFofyTLmEHz26c10JJe/AUwUsFmV0bPG+s04LSdU+jMLA8LMkpbbLcn049bsCLNb5wF58wU/HRtCJzbt/y7+AXgPVApXFyFXgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['4',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/4/7366.png'),\n",
+       " 0.005693972110748291,\n",
+       " array([-0.0610164 , -0.04146182,  0.09034172, -0.20866331,  0.31622782,\n",
+       "         0.11861764,  0.14218827, -0.20755155,  0.06992757, -0.03209638,\n",
+       "         0.1469732 , -0.30364928,  0.09821688, -0.18159218,  0.10560269,\n",
+       "        -0.14999603,  0.02323291,  0.3320828 , -0.301837  ,  0.04858053,\n",
+       "         0.22180717, -0.05564872, -0.11786508, -0.03112294, -0.3008989 ,\n",
+       "         0.17155057,  0.2510369 , -0.00963419,  0.02120073, -0.05657816,\n",
+       "        -0.00504775, -0.33360884], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "(list(m for m in best_match_mnist(fingerprint_db, fps2, 10000) if m[0][0] != \"8\"))[0:10]"
+    "fp4 = fingerprint_file('media/4.png', display_data=True)\n",
+    "list(best_match_mnist(fingerprint_db, fp4, 5, display_data=True));"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 116,
-   "id": "ab962be2",
-   "metadata": {},
+   "execution_count": 30,
+   "id": "4d44ee49",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T14:05:10.666707Z",
+     "iopub.status.busy": "2022-08-16T14:05:10.666512Z",
+     "iopub.status.idle": "2022-08-16T14:05:10.935091Z",
+     "shell.execute_reply": "2022-08-16T14:05:10.933717Z",
+     "shell.execute_reply.started": "2022-08-16T14:05:10.666690Z"
+    },
+    "tags": []
+   },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<style>\n",
+       "    /* Turns off some styling */\n",
+       "    progress {\n",
+       "        /* gets rid of default border in Firefox and Opera. */\n",
+       "        border: none;\n",
+       "        /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
+       "        background-size: auto;\n",
+       "    }\n",
+       "    progress:not([value]), progress:not([value])::-webkit-progress-bar {\n",
+       "        background: repeating-linear-gradient(45deg, #7e7e7e, #7e7e7e 10px, #5c5c5c 10px, #5c5c5c 20px);\n",
+       "    }\n",
+       "    .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
+       "        background: #F44336;\n",
+       "    }\n",
+       "</style>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAACqklEQVR4nO2SPUhqYRjH33OOCeZbYAcySCoFQYxsEgkcPbW4ODgJUtCQi0NBIAoJjmcRHAzcJPADvzJBkAwRdEhsiAh0KeFkdsBUBMs0vYPhLTGty4XLhf7T+3z9eP68DwA/+idCUVSn00UiEZIk/xqUIIirq6ulpaV8Pj81NfUnCARBGAxGP8Rx3Ov1rq2tAQBcLpdCoRhPGIj5fP7R0dHr62ur1apWq7VabWFhAULo9/tfXl7W19ebzeb5+TmEcGZmZnp6GkJos9ni8fh7CGMAen9/DyGUy+VMJnN2dlYoFBqNxlAo1Gg0mEzm4+Mjj8erVCoURTWbTbVazWazi8XiePuHh4dbW1u9t9FotFgs/ZJMJnO73QAApVJJUdTu7u54XE9isfj29hZCyOFwLi8v5+bm+iUul5tOp+12u9frXV1d/YwwaB8AcH19HQ6Hd3Z25ufnj4+PS6VSL49hmEQiEYlEJycnBoOhWq1+dc2eeDxePB4vl8soivaTJElms9lMJrO4uDh6HB2apSiq1Wrl8/lOpwMAEIvFsViMzWbLZLJCocDhcEZDh9gHAPD5fAzD7u7uCILodrvb29tOp9Pj8bTb7aenp7H3Pxy6ubl5enqaTCYDgUC9XtdoNJlMplfqdDoIMnjdAxpiXygULi8vezyejY0NmqYvLi5ubm5+D6Bou93+NnR/fz+VSu3t7QkEAoIgcrmc0+mcmJh4s8ZgfBuq1+u5XK5UKkUQRKvV0jR9cHCQTqcTiYREIgEAsFiser0+GvpBSqUyl8sFAgGSJCcnJ9+XVCqVz+dbWVk5OzvDcXw058NH4ThO03QymbRarQN9wWDw+fk5HA4/PDyUy+WvronjeCwWM5lMnzUgCOJwOKLR6FeJAACVSmU2mzEM+8bMj/5v/QKdDw1VV/HIUgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "PILImage mode=RGB size=28x28"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<style>\n",
+       "    /* Turns off some styling */\n",
+       "    progress {\n",
+       "        /* gets rid of default border in Firefox and Opera. */\n",
+       "        border: none;\n",
+       "        /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
+       "        background-size: auto;\n",
+       "    }\n",
+       "    progress:not([value]), progress:not([value])::-webkit-progress-bar {\n",
+       "        background: repeating-linear-gradient(45deg, #7e7e7e, #7e7e7e 10px, #5c5c5c 10px, #5c5c5c 20px);\n",
+       "    }\n",
+       "    .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
+       "        background: #F44336;\n",
+       "    }\n",
+       "</style>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAADcklEQVR4nOWUS0hyWxTH97ldjqiUnLDSNCktMvAFkQSOROhBRpg06EEPqRCMDAfNmiVhSZMaNRAzhUY5qDxxCKKikkYammFkDVJTKgoUIpFzB8K5ZqYG3+z7z/ba//VjrbUfABRTa2trNBptb28v6iT0T1GHXC4/Pz/X6/UQBJXOLSQIgpxOp0AgCAQCfD6/xKwilYpEonQ67fP5lpeX9Xr9n4H29PScnZ0BAGw2G4/Hk0gkpUD/Lbwtk8nm5+cBAOl02uFwaLVao9GIIAiZTIZhGMfxzKBxHE8kEh6PJ5P1ZfYkEonD4bDZbCaTWV1d3dTU1N3d7Xa7y8vLaTQagiAcDuf29jYWi318fKRSqexEsVisUqm8Xu//ldbW1mIYRqFQIpFIJBKJx+PRaJRKpV5dXVkslpeXl+fn59fXV4PBkEwmV1dXs0upq6tbXFy0Wq3BYPBLm2VlZZeXlxqNJju4sbHR39+fHZFIJAcHB9kRFovl8/kmJyfzj4/L5TocjsHBQeI+ejweOp2e7YFh2OVyNTc3ExNHUXR0dDQ/keAGg8GRkREAgEgkcrlc3y+80WjU6XQAALVajaKoQqH4zvly+qFQSC6Xr6+vJ5NJNpvt8XhwHM9JOD091Wg07+/vCwsLXV1d9/f3hcokJBaLj46Ojo+PlUrl910EQd7e3ra2thoaGkrCERIKhZ+fn3lbW1tbi8fjHR0dBdLzvygKhXJ9fa3ValtaWohgTU2N3W6HYdhisQgEgl9DlUrl3t6e1Wrd399nsVgAAB6PZzabA4GAwWC4uLiQyWQFoHkEQdDJyYlUKoUgaGJiwm63q1Sqp6engYGBjIHBYITD4d9Bq6qqHh4eiKXD4YhEIm1tbdmex8dHBoPxEyFP+729vSiKAgDIZLLZbKbT6RiGTU9PU6lUwuP1eoVC4S+gCoXC6XRWVFRYLBYajdbZ2Tk1NUUikTLfVUahUKjAlcqFMplMPp8fi8VsNpvf75+dnQUApFKpmZmZxsbG8fHxjC0cDhdoP1c6nW57e/vw8DDnKwEA8Hg8t9utVqsBAHNzc0tLSz9Bcj/psbGxysrKvr4+v9+fs3V3dzc8PLy5uZlIJCAI+v6C82hoaAjDsJubm/r6+gI2qVS6s7Ozu7trMplKgppMpuwj/kkcDmdlZYXL5RaH/pX6DwbiTErUhEX7AAAAAElFTkSuQmCC\n",
@@ -1240,20 +1605,497 @@
        "PILImage mode=RGB size=28x28"
       ]
      },
-     "execution_count": 116,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cosine Distance between stars: 0.0862153172492981  best matches for each star:\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAAeklEQVR4nNWQyxGDMAxEHzQWURnqTKayzcGQMUb2TI7sTdqPPvAmLACY7ZSjdkrpJK4Otb2meVtb2N1qvfjkA/csy65pHpGwLskwSZlbUoSkxPk7KZ0Kg20rhpmnseFuHzKAY0D2gS35WDJ/fEJ+ZsLpkbPv4DH0/YsvgaZpcV1JKgwAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/1530.png'),\n",
+       " 0.046761393547058105,\n",
+       " array([-0.15196997, -0.03608787,  0.00868906, -0.1474988 , -0.07871772,\n",
+       "         0.18009232,  0.06617993, -0.07894154,  0.12192538, -0.02143634,\n",
+       "         0.04440383,  0.10302673,  0.03750927, -0.07367066,  0.09718364,\n",
+       "         0.12069038,  0.0224285 , -0.25404668, -0.11400666, -0.16254014,\n",
+       "        -0.0650501 , -0.10554277, -0.3876711 , -0.04148291,  0.3751997 ,\n",
+       "         0.14719807, -0.00786453,  0.28334555,  0.04159332,  0.13660236,\n",
+       "        -0.338259  ,  0.44309753], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAAeklEQVR4nNWQyxGDMAxEHzQWURnqTKayzcGQMUb2TI7sTdqPPvAmLACY7ZSjdkrpJK4Otb2meVtb2N1qvfjkA/csy65pHpGwLskwSZlbUoSkxPk7KZ0Kg20rhpmnseFuHzKAY0D2gS35WDJ/fEJ+ZsLpkbPv4DH0/YsvgaZpcV1JKgwAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/1530.png'),\n",
+       " 0.17046701908111572,\n",
+       " array([-0.15196997, -0.03608787,  0.00868906, -0.1474988 , -0.07871772,\n",
+       "         0.18009232,  0.06617993, -0.07894154,  0.12192538, -0.02143634,\n",
+       "         0.04440383,  0.10302673,  0.03750927, -0.07367066,  0.09718364,\n",
+       "         0.12069038,  0.0224285 , -0.25404668, -0.11400666, -0.16254014,\n",
+       "        -0.0650501 , -0.10554277, -0.3876711 , -0.04148291,  0.3751997 ,\n",
+       "         0.14719807, -0.00786453,  0.28334555,  0.04159332,  0.13660236,\n",
+       "        -0.338259  ,  0.44309753], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "query_img = PILImage.create(\"stars/Star2.png\")\n",
-    "query_img"
+    "fps1 = fingerprint_file('stars/Star1.png', display_data=True)\n",
+    "fps2 = fingerprint_file('stars/Star2.png', display_data=True)\n",
+    "print('Cosine Distance between stars:', spatial.distance.cosine(fps2, fps1),\" best matches for each star:\")\n",
+    "list(best_match_mnist(fingerprint_db, fps1, 1, display_data=True));\n",
+    "list(best_match_mnist(fingerprint_db, fps2, 1, display_data=True));"
    ]
   },
   {
-   "cell_type": "raw",
-   "id": "883a839c",
+   "cell_type": "markdown",
+   "id": "1c229c64-129c-4ade-979f-d54d67f7f0e5",
    "metadata": {},
+   "source": [
+    "By adding a star to the list of fingerprints we should be able to find it, and if all went well, also find the other star:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "3f76e6c0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T14:05:17.166001Z",
+     "iopub.status.busy": "2022-08-16T14:05:17.165820Z",
+     "iopub.status.idle": "2022-08-16T14:05:17.225973Z",
+     "shell.execute_reply": "2022-08-16T14:05:17.225286Z",
+     "shell.execute_reply.started": "2022-08-16T14:05:17.165986Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAACqklEQVR4nO2SPUhqYRjH33OOCeZbYAcySCoFQYxsEgkcPbW4ODgJUtCQi0NBIAoJjmcRHAzcJPADvzJBkAwRdEhsiAh0KeFkdsBUBMs0vYPhLTGty4XLhf7T+3z9eP68DwA/+idCUVSn00UiEZIk/xqUIIirq6ulpaV8Pj81NfUnCARBGAxGP8Rx3Ov1rq2tAQBcLpdCoRhPGIj5fP7R0dHr62ur1apWq7VabWFhAULo9/tfXl7W19ebzeb5+TmEcGZmZnp6GkJos9ni8fh7CGMAen9/DyGUy+VMJnN2dlYoFBqNxlAo1Gg0mEzm4+Mjj8erVCoURTWbTbVazWazi8XiePuHh4dbW1u9t9FotFgs/ZJMJnO73QAApVJJUdTu7u54XE9isfj29hZCyOFwLi8v5+bm+iUul5tOp+12u9frXV1d/YwwaB8AcH19HQ6Hd3Z25ufnj4+PS6VSL49hmEQiEYlEJycnBoOhWq1+dc2eeDxePB4vl8soivaTJElms9lMJrO4uDh6HB2apSiq1Wrl8/lOpwMAEIvFsViMzWbLZLJCocDhcEZDh9gHAPD5fAzD7u7uCILodrvb29tOp9Pj8bTb7aenp7H3Pxy6ubl5enqaTCYDgUC9XtdoNJlMplfqdDoIMnjdAxpiXygULi8vezyejY0NmqYvLi5ubm5+D6Bou93+NnR/fz+VSu3t7QkEAoIgcrmc0+mcmJh4s8ZgfBuq1+u5XK5UKkUQRKvV0jR9cHCQTqcTiYREIgEAsFiser0+GvpBSqUyl8sFAgGSJCcnJ9+XVCqVz+dbWVk5OzvDcXw058NH4ThO03QymbRarQN9wWDw+fk5HA4/PDyUy+WvronjeCwWM5lMnzUgCOJwOKLR6FeJAACVSmU2mzEM+8bMj/5v/QKdDw1VV/HIUgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=RGB size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['*',\n",
+       " 'stars/Star1.png',\n",
+       " 0,\n",
+       " array([-0.10099696, -0.08450948,  0.03510209, -0.15825109, -0.04520801,\n",
+       "         0.20577735,  0.10355564,  0.01773667,  0.05295658, -0.09321447,\n",
+       "         0.03732459,  0.0393499 ,  0.02228327, -0.06537104,  0.09933136,\n",
+       "         0.08348498, -0.02667931, -0.22959505, -0.04327893, -0.07219108,\n",
+       "        -0.09431483,  0.0125113 , -0.46360245, -0.11086255,  0.35560194,\n",
+       "         0.18639638,  0.06533853,  0.28910112,  0.13699105,  0.15609336,\n",
+       "        -0.30878097,  0.42498502], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAACqklEQVR4nO2SPUhqYRjH33OOCeZbYAcySCoFQYxsEgkcPbW4ODgJUtCQi0NBIAoJjmcRHAzcJPADvzJBkAwRdEhsiAh0KeFkdsBUBMs0vYPhLTGty4XLhf7T+3z9eP68DwA/+idCUVSn00UiEZIk/xqUIIirq6ulpaV8Pj81NfUnCARBGAxGP8Rx3Ov1rq2tAQBcLpdCoRhPGIj5fP7R0dHr62ur1apWq7VabWFhAULo9/tfXl7W19ebzeb5+TmEcGZmZnp6GkJos9ni8fh7CGMAen9/DyGUy+VMJnN2dlYoFBqNxlAo1Gg0mEzm4+Mjj8erVCoURTWbTbVazWazi8XiePuHh4dbW1u9t9FotFgs/ZJMJnO73QAApVJJUdTu7u54XE9isfj29hZCyOFwLi8v5+bm+iUul5tOp+12u9frXV1d/YwwaB8AcH19HQ6Hd3Z25ufnj4+PS6VSL49hmEQiEYlEJycnBoOhWq1+dc2eeDxePB4vl8soivaTJElms9lMJrO4uDh6HB2apSiq1Wrl8/lOpwMAEIvFsViMzWbLZLJCocDhcEZDh9gHAPD5fAzD7u7uCILodrvb29tOp9Pj8bTb7aenp7H3Pxy6ubl5enqaTCYDgUC9XtdoNJlMplfqdDoIMnjdAxpiXygULi8vezyejY0NmqYvLi5ubm5+D6Bou93+NnR/fz+VSu3t7QkEAoIgcrmc0+mcmJh4s8ZgfBuq1+u5XK5UKkUQRKvV0jR9cHCQTqcTiYREIgEAsFiser0+GvpBSqUyl8sFAgGSJCcnJ9+XVCqVz+dbWVk5OzvDcXw058NH4ThO03QymbRarQN9wWDw+fk5HA4/PDyUy+WvronjeCwWM5lMnzUgCOJwOKLR6FeJAACVSmU2mzEM+8bMj/5v/QKdDw1VV/HIUgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=RGB size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['*',\n",
+       " 'stars/Star1.png',\n",
+       " 0.0862153172492981,\n",
+       " array([-0.10099696, -0.08450948,  0.03510209, -0.15825109, -0.04520801,\n",
+       "         0.20577735,  0.10355564,  0.01773667,  0.05295658, -0.09321447,\n",
+       "         0.03732459,  0.0393499 ,  0.02228327, -0.06537104,  0.09933136,\n",
+       "         0.08348498, -0.02667931, -0.22959505, -0.04327893, -0.07219108,\n",
+       "        -0.09431483,  0.0125113 , -0.46360245, -0.11086255,  0.35560194,\n",
+       "         0.18639638,  0.06533853,  0.28910112,  0.13699105,  0.15609336,\n",
+       "        -0.30878097,  0.42498502], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fingerprint_db[('*','stars/Star1.png')] = fps1\n",
+    "list(best_match_mnist(fingerprint_db, fps1, 1, display_data=True));\n",
+    "list(best_match_mnist(fingerprint_db, fps2, 1, display_data=True));"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "ebc200ba",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T14:05:24.975445Z",
+     "iopub.status.busy": "2022-08-16T14:05:24.975221Z",
+     "iopub.status.idle": "2022-08-16T14:05:25.096222Z",
+     "shell.execute_reply": "2022-08-16T14:05:25.095230Z",
+     "shell.execute_reply.started": "2022-08-16T14:05:24.975415Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAACqklEQVR4nO2SPUhqYRjH33OOCeZbYAcySCoFQYxsEgkcPbW4ODgJUtCQi0NBIAoJjmcRHAzcJPADvzJBkAwRdEhsiAh0KeFkdsBUBMs0vYPhLTGty4XLhf7T+3z9eP68DwA/+idCUVSn00UiEZIk/xqUIIirq6ulpaV8Pj81NfUnCARBGAxGP8Rx3Ov1rq2tAQBcLpdCoRhPGIj5fP7R0dHr62ur1apWq7VabWFhAULo9/tfXl7W19ebzeb5+TmEcGZmZnp6GkJos9ni8fh7CGMAen9/DyGUy+VMJnN2dlYoFBqNxlAo1Gg0mEzm4+Mjj8erVCoURTWbTbVazWazi8XiePuHh4dbW1u9t9FotFgs/ZJMJnO73QAApVJJUdTu7u54XE9isfj29hZCyOFwLi8v5+bm+iUul5tOp+12u9frXV1d/YwwaB8AcH19HQ6Hd3Z25ufnj4+PS6VSL49hmEQiEYlEJycnBoOhWq1+dc2eeDxePB4vl8soivaTJElms9lMJrO4uDh6HB2apSiq1Wrl8/lOpwMAEIvFsViMzWbLZLJCocDhcEZDh9gHAPD5fAzD7u7uCILodrvb29tOp9Pj8bTb7aenp7H3Pxy6ubl5enqaTCYDgUC9XtdoNJlMplfqdDoIMnjdAxpiXygULi8vezyejY0NmqYvLi5ubm5+D6Bou93+NnR/fz+VSu3t7QkEAoIgcrmc0+mcmJh4s8ZgfBuq1+u5XK5UKkUQRKvV0jR9cHCQTqcTiYREIgEAsFiser0+GvpBSqUyl8sFAgGSJCcnJ9+XVCqVz+dbWVk5OzvDcXw058NH4ThO03QymbRarQN9wWDw+fk5HA4/PDyUy+WvronjeCwWM5lMnzUgCOJwOKLR6FeJAACVSmU2mzEM+8bMj/5v/QKdDw1VV/HIUgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=RGB size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['*',\n",
+       " 'stars/Star1.png',\n",
+       " 0.0862153172492981,\n",
+       " array([-0.10099696, -0.08450948,  0.03510209, -0.15825109, -0.04520801,\n",
+       "         0.20577735,  0.10355564,  0.01773667,  0.05295658, -0.09321447,\n",
+       "         0.03732459,  0.0393499 ,  0.02228327, -0.06537104,  0.09933136,\n",
+       "         0.08348498, -0.02667931, -0.22959505, -0.04327893, -0.07219108,\n",
+       "        -0.09431483,  0.0125113 , -0.46360245, -0.11086255,  0.35560194,\n",
+       "         0.18639638,  0.06533853,  0.28910112,  0.13699105,  0.15609336,\n",
+       "        -0.30878097,  0.42498502], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAAeklEQVR4nNWQyxGDMAxEHzQWURnqTKayzcGQMUb2TI7sTdqPPvAmLACY7ZSjdkrpJK4Otb2meVtb2N1qvfjkA/csy65pHpGwLskwSZlbUoSkxPk7KZ0Kg20rhpmnseFuHzKAY0D2gS35WDJ/fEJ+ZsLpkbPv4DH0/YsvgaZpcV1JKgwAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/1530.png'),\n",
+       " 0.17046701908111572,\n",
+       " array([-0.15196997, -0.03608787,  0.00868906, -0.1474988 , -0.07871772,\n",
+       "         0.18009232,  0.06617993, -0.07894154,  0.12192538, -0.02143634,\n",
+       "         0.04440383,  0.10302673,  0.03750927, -0.07367066,  0.09718364,\n",
+       "         0.12069038,  0.0224285 , -0.25404668, -0.11400666, -0.16254014,\n",
+       "        -0.0650501 , -0.10554277, -0.3876711 , -0.04148291,  0.3751997 ,\n",
+       "         0.14719807, -0.00786453,  0.28334555,  0.04159332,  0.13660236,\n",
+       "        -0.338259  ,  0.44309753], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA5ElEQVR4nGNgGLqAxX7GmycT1GBcRhhD1NHnjmCgHAMDA8PsdJhaKG26XQjTICYIxbdaiIGBgeFHutFKhGEw0Pzv379///595GBQ//evFE1SsKzdY/+/f/82sE/5d8ERi1N5Ov78+3fw5b8K7D4p+/fv3z9ckvz7/v37988UuySDyL9//3YxoXsFCn6jqkWVlGVgYNDkxW6q9L5///7908Cu086BgYGBIQC7pDkOdzIwMDDovP/3b8a/L05YdarzMzCIMxzah8O1DAz+vzZgN9bjw79//ybhstTj3793ingcRTwAAPS4S0rWnQxaAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/4978.png'),\n",
+       " 0.19324219226837158,\n",
+       " array([-0.13393578, -0.01838107, -0.00534778, -0.17210366, -0.07266845,\n",
+       "         0.18902731,  0.03273853, -0.08977108,  0.13195774, -0.02636713,\n",
+       "         0.09701853,  0.1159689 ,  0.02596068, -0.09155644,  0.10679887,\n",
+       "         0.15774828,  0.01430953, -0.24548481, -0.13471584, -0.16768138,\n",
+       "        -0.04165975, -0.1139208 , -0.39835957, -0.02385826,  0.35113412,\n",
+       "         0.1411736 ,  0.03943544,  0.27782732,  0.02119364,  0.11498547,\n",
+       "        -0.33189255,  0.43487713], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA80lEQVR4nM2PL0tDcRSG359FHF4MSzoQi2ax3W8gTvwQGi1rGo0WP8EwiFE0iU0UnWk2qzDumMiEwYpanpcZ/Hd391szeMo5vA/ve86R/nvN7fl6elRev8mydvYMXiuihd03wPCI97+08NkmF0+WBi/1B0mdRph/GvKl4PtZSdI2rgyHpvag8j0dFDamP2dcwEwBJnXcrUra7FM0SqUj060mSQdqo1/qDLi8gsOVCNSx7YEbMSRNbYC5zSkTv+N7SZKSctx6B4bzJAp3oNbLX5uLVQih9RpCPHYV2stNelGYgpt9iMLyVsswBkoycDoO/lV9ABHSeGo+SxS/AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/1149.png'),\n",
+       " 0.2018195390701294,\n",
+       " array([-0.12702534, -0.00469792, -0.009922  , -0.18974611, -0.07716948,\n",
+       "         0.21863632, -0.00714376, -0.09015532,  0.11959117, -0.00474182,\n",
+       "         0.11099031,  0.14397548,  0.01711641, -0.0858542 ,  0.10849203,\n",
+       "         0.18830577, -0.01769255, -0.22273687, -0.19109313, -0.18539554,\n",
+       "        -0.02787323, -0.11901999, -0.42014134, -0.03187113,  0.35428157,\n",
+       "         0.08303296,  0.07685167,  0.2601822 , -0.00407309,  0.10560863,\n",
+       "        -0.29776138,  0.40547028], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA+0lEQVR4nGNgGNRAd+bThQwMDAwMDvck0eXSvl6aEsjAwMAgtXczmhRr74drshCm0087VDnjo3+nQ81yeXqbF1Vy97/ZUDn2Vf8tUKTEnv3LY4EwOY//jWJClpNb+Pcs1CT+ZZ8WoZq55u9fFyjz8N/VqHJS7//9+/fv8sIMBfYz/6bAhRkhVBXnhxgONQbGR9fcF+R9ZcAEnHr+K//+vY1FBgIy/v79q4RDTurfvyf/yhF8ZA/x7mHwX/JfAaska4v6+QNPGCSxSnJ4M5R/VmB4j91YRkYG3kDG41idw3r5b2ji3zc4HLv/78MXnyJwSPI/+femEIccNQEATwZV3Vt4OpcAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/5183.png'),\n",
+       " 0.20350545644760132,\n",
+       " array([-0.10779518,  0.01560267, -0.01500396, -0.18105853, -0.06782977,\n",
+       "         0.19930756,  0.01427122, -0.09341715,  0.12315948, -0.02313614,\n",
+       "         0.10789926,  0.13603845,  0.01581355, -0.10072555,  0.10688944,\n",
+       "         0.18113281,  0.01356881, -0.2025257 , -0.18652841, -0.2082253 ,\n",
+       "        -0.02865512, -0.10153925, -0.3971089 , -0.02807097,  0.36581576,\n",
+       "         0.11472838,  0.06546995,  0.27885213,  0.00611124,  0.10469785,\n",
+       "        -0.3225268 ,  0.41033518], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA6UlEQVR4nM2RIXTCMBCG//RNMQt2SKgFTfVmq9G1vDc3zTQWdDXVs4PJPFDwkEOue3O1uTtE2kIacIjdqeRL7v//BPhnpS4XnScAm+sHE02GzEcCxLqBuism2++ZUNZy4NjQZQ8cuCImpmPBxCQkewDBmYrI+vXlS0SE5Xft3Yw6Wak7aztwYcik2ip+Thpuw6Jyy8vYi5mWPnfTlseGZU498p8nzMuEbZ8N80rR14vz+m2+m2Mf97VTYoqq7QcAwFtPBHWLC0MVcMAKCgrbw5879vnH6uXzgfsb1pAujmlyJYWt/k1y9zoBsSK4GWpO+WIAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/7923.png'),\n",
+       " 0.20535790920257568,\n",
+       " array([-0.13801472,  0.00621954,  0.01324526, -0.15497565, -0.07363982,\n",
+       "         0.18480222,  0.06190637, -0.07731929,  0.14280462, -0.01529375,\n",
+       "         0.06797428,  0.12477075,  0.03360037, -0.09421641,  0.08267348,\n",
+       "         0.1202066 ,  0.02800406, -0.23831494, -0.12120299, -0.17994858,\n",
+       "        -0.07378727, -0.12906069, -0.37269413, -0.03644777,  0.3587743 ,\n",
+       "         0.15787394, -0.00156036,  0.28049743,  0.04324026,  0.09545978,\n",
+       "        -0.3575211 ,  0.4439831 ], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAAh0lEQVR4nM2RQRLDIAwDdzr9V/w052WGl6kHUsgY59ZDdcqwsZAF/LEsJMlL5hqyCobkEIoKSgL85vvKvzTaw53p5DZ5QMryXp+TmNGyt0mBe0gqEoe+8s2WPoxPfE872rMdTNdi6Mrj2ladg5GLXSUYHaPXsNCCJ4dTt35tUr4lAB5Pm/xWH3n+VQ+JElsGAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/9572.png'),\n",
+       " 0.2056165337562561,\n",
+       " array([-0.13871859,  0.00794921, -0.00714709, -0.16992597, -0.07731196,\n",
+       "         0.18034327,  0.02632423, -0.07574032,  0.13707913, -0.00746076,\n",
+       "         0.09539922,  0.1278962 ,  0.02255916, -0.10655132,  0.11078995,\n",
+       "         0.13779849,  0.01083361, -0.22742479, -0.14258838, -0.19795327,\n",
+       "        -0.05902013, -0.12295273, -0.39121884, -0.01822287,  0.35681796,\n",
+       "         0.12615526,  0.03557264,  0.27636376,  0.0111395 ,  0.09952669,\n",
+       "        -0.34341872,  0.43269384], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAABCElEQVR4nMXRTytEYRTH8V9muiVJ1DWLSZZGSVLK7Cy8Ac3OBgsUspPlbPxJNhrFDONdTE2SnY2XYGOnWdyowc1N39PYMDf3PmvO8vfp9JxzHumfq3Rg1in3O20rAoxqN8jGtn2Y1f3D5JTn6Jt/h5tBlaIdBy5Aa0LStKeho2IC/Wu4y0mSZl7a67nfWmxDWdLAeKUFG4nelTc+FvP5BkCwlHx2GTCA19OxpI1Uv7EymqS1SzMz6xzv+6lNCk8Q1MEc1ys8QnMuc4XtpXETan1SBQuGu2FP7PVQkhSaCyV5Oens2YW+5Jek8zj5+bLQMrVb9UqNKD2QTj4BCGcdJq1eAOw67Q/rC2njd+YEmNW1AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/9575.png'),\n",
+       " 0.2076045274734497,\n",
+       " array([-0.1331005 ,  0.00942803, -0.00043982, -0.18562244, -0.07275735,\n",
+       "         0.19512178,  0.02175655, -0.08774138,  0.13060835, -0.01647614,\n",
+       "         0.09030168,  0.13614202,  0.01462775, -0.11180203,  0.10697227,\n",
+       "         0.15972283,  0.00986198, -0.21282187, -0.16065034, -0.19177778,\n",
+       "        -0.04452091, -0.11539748, -0.39441586, -0.02117794,  0.35692507,\n",
+       "         0.11903383,  0.05488091,  0.27992192,  0.01625808,  0.08508871,\n",
+       "        -0.32969016,  0.42906052], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA9klEQVR4nM3Pr0tDYRTG8WciDMxrQzBNERaEFYNFhrDgNakgY0UwLAmCwR/J4p9gEa4o/kBBjGKxiqCYLgarDFa8vnIZY9+LQTfmvcdm8Ekv58M57znSf079KI73ly2ZWG90ADq7aTuM+M5jrzbYfXhZ6eVG+VlragisSNP9nT/QLWr8FT+NtXsgXM0NF/LzZ8FOQiuXDrieu3gGPiaTzdX37sLRSXr02he581LiFEnKSJJuN+6Ma3wHgNcrDPRhe0gukpZMLEtXT9KoidLDZlZ6M37UVMjBArRmLBxrctoAa1VJAUB7y8YqwLZtKh7D3sgv+If5BHsFeneuZrOfAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/277.png'),\n",
+       " 0.20783281326293945,\n",
+       " array([-1.24270067e-01,  2.43610330e-03, -1.17951035e-02, -1.92144334e-01,\n",
+       "        -7.65644014e-02,  2.06153139e-01,  8.63673176e-06, -8.66443664e-02,\n",
+       "         1.18992284e-01, -3.14740348e-03,  1.11963585e-01,  1.48036689e-01,\n",
+       "         1.99435558e-02, -1.01394281e-01,  1.07662492e-01,  1.79325625e-01,\n",
+       "        -3.35485861e-03, -2.20356420e-01, -1.79223344e-01, -1.95037887e-01,\n",
+       "        -3.24723795e-02, -1.18083686e-01, -4.10369486e-01, -2.41548866e-02,\n",
+       "         3.47002447e-01,  9.94626656e-02,  7.00019300e-02,  2.65486211e-01,\n",
+       "         8.39820132e-04,  1.00934029e-01, -3.08309078e-01,  4.18250412e-01],\n",
+       "       dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA+klEQVR4nGNgGLaAp+Tp95diDAzSEgwMDCyoctIVxmtkXjIZ+7IHqWNojDBmYRDy5t76728TmozZ5GghFgYG5lmvv29rRpHpeHAxwFWBgYGBfdHPf38sUbXlf/v3764qA4P55X/nA2XQrVMwP/bzrVfFi3//bLD6w//fv3//LpVyYpMTW/3v378CrFIMojf///v3zxqbFOfil//uHKn5eQpTiiP/0r8fzVIMDFdei6PLaV/59/OWKQMDg/D9P/rokk/+XYgSZ+UQ0pmUksqDEGZkYGBgYDA6aD3r1U32yq9yrhKXNqNJSjBksNf9ZmBgSGRb/gmrVwYHAABmK1aAjnS+AAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['8',\n",
+       " Path('/home/jav/.fastai/data/mnist_png/testing/8/9629.png'),\n",
+       " 0.2087579369544983,\n",
+       " array([-0.11165629,  0.02385902, -0.01111764, -0.17699666, -0.06776313,\n",
+       "         0.2086679 ,  0.0387623 , -0.10095822,  0.12849547, -0.02318227,\n",
+       "         0.10139351,  0.12179026,  0.02673438, -0.09662878,  0.10835069,\n",
+       "         0.1599886 ,  0.01882683, -0.21521384, -0.17701268, -0.20212372,\n",
+       "        -0.03210105, -0.11860982, -0.40316784, -0.0160803 ,  0.35840863,\n",
+       "         0.1322023 ,  0.03488598,  0.2792674 ,  0.02634823,  0.09203189,\n",
+       "        -0.3286124 ,  0.408755  ], dtype=float32)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "list(m for m in best_match_mnist(fingerprint_db, fps2, 10, display_data=True));"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "efdb8a93-f978-4cd1-98a5-b92a29146a6f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T14:05:50.347680Z",
+     "iopub.status.busy": "2022-08-16T14:05:50.347106Z",
+     "iopub.status.idle": "2022-08-16T14:05:50.951379Z",
+     "shell.execute_reply": "2022-08-16T14:05:50.950093Z",
+     "shell.execute_reply.started": "2022-08-16T14:05:50.347660Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD7CAYAAACscuKmAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAABkcElEQVR4nO39V5Bd2X3YC//2yTnnzgGNOBjMYAInkzMcDkWKpCxWyZJsF2/ZVaqyr6uuq/xgXX8Pvm9X3/fgKlVd+0F1qbJM25ITJVKmJAZwcgQwMxjEBjqHc06fnPM5+3sA1prTQDfQDXTu86vq6u590t7r7P9a//WPiqqq9OjR4+Cj2e0T6NGjx87QE/YePQ4JPWHv0eOQ0BP2Hj0OCT1h79HjkNAT9h49DgmPJOyKonxTUZRJRVGmFEX5w606qR49emw9ysP62RVF0QI3gdeBJeA88Huqql7butPr0aPHVqF7hNc+A0ypqjoDoCjKXwDfA9YVdkVRehE8q0mpqupf64HeWK1GVVVlvcd6Y7Wa9cbqUdT4PmCx6/+lO8d6bJz53T6BHoeHR1nZN4SiKH8A/MF2f85BoDdWG6c3VpvnUfbszwH/l6qqb9z5//8EUFX1/77Pa3rq1mouqqr61FoP9MZqNT01fuNshxp/HjiiKMqIoigG4HeBnz7C+/Xo0WMbeWg1XlXVlqIo/xz4OaAF/lRV1atbdmY9evTYUh5ajX+oD+upW3fTU+M3SE+N3zjbocb36NFjH9ET9h49Dgnb7nrbCyiKgtvtxuv1YjQacblc6PV6arUajUaDfD7PwsICjUZjt0+1R49t48ALu6IoKIpCf38/Z86cwe12c+LECWw2G+l0mmw2y61bt0ilUj1h73GgOdDCrigKBoMBnU6H0+nE7/djs9lQVZVGo4HJZMLn85FIJNDpdCiKQq8mX4+DyoEWdr1ez+DgIE6nk7Nnz/LVr36VdDrNuXPnyGazfO1rX+OZZ56h0Whgs9kolUo0m03a7fZun3qPHlvOgRZ2rVaLw+HA6/USDAbp6+uj2WyyvLzM0tISzz//PH6/H5fLhdFoRKfT0Wq1dvu0HxlFUVb97mYrNZeeFrQ23eN+93fQPWY7PX77TtjF4N1voLRaLXq9HrvdztjYGAMDA9RqNX79618Tj8eJxWLk83nS6TQrKytUKhU8Hg+tVotEIkGxWNypy9kStFotHo8Hk8mE3W7H6XTKa7darfJ5tVqNTCZDs9kkm81SqVQe+jM7nY58j3K5TC6Xo9PpbMXl7DvEdlEsGn6/H4/Hg9VqJRgMotPp6HQ6qKpKPp8nmUxSrVZZXFykWCxSq9WoVqvbfp77StgVRUGjue0tFIO3FlqtFrPZjMvl4tixYxw9epRLly7xzjvvkMvlWFxcpNFokEwmiUajVCoVAoEAOp2OUqm074Rdr9cTCoVwu9309/czPDxMJBLh29/+NqFQSD4vk8lw69YtSqUS09PTJBKJh/7MVqvF1NQUiUSClZUVCoXCoRR2cU+aTCb6+vpwOBycOnWKiYkJQqEQZ86cwWKxyO3hwsICly9fJpVK8e6777K0tEQ2m6VWq237Sr+nhV2n06HRaHC5XLjd7nuEXQi8+C3+NplM2Gw2PB4PLpcLi8WCyWTCaDRisVjwer20Wi0sFguKomA0GvH5fOj1egqFgrTgix+NRrPqbwCNRoOqqpTLZSqVCq1Wa0e+sLXQaDRYrVacTieBQICBgQGCwSA2mw2TySSfZ7VapQZQrVZXPbZZWq0WiqLg9XoJBAK43e77boE6nQ7Ly8uPNMHsBBqNBo1Gg06nw2g0yoVDr9fT6XRoNpurnmcymbBYLNhsNoaHh7Hb7YyMjBCJRPB6vdjtdkwmE61Wi06ng8fjIRwOYzQaCYfDtFotWq0WmUxm269tzwq7VqvF6XRiMpl46aWXeO2119BqtVKY2u02nU6HVqtFvV6n3W5Tr9elEAuVKhgMYrFY6OvrY3x8nEajwcjICACjo6OYzWbC4TAWi4V6vc7IyAjJZBKdToder5dftvjfYDCg0WgwGAx0Oh0uX77M5OQkuVyOubm5XXHf6fV6uaI/9dRTPP/885jNZpxO56rnWa1WRkdHabfbjI6OPpJ9QlVVOd7NZpN6vX7fia5er/Pv/t2/47/8l/+yp/f6RqMRo9GI0+lkaGgIm83G2NgYfr+fSqVCNpsFwGQySQPwyMgIZrOZQCCA0WjEbDbLx81ms1wYVFWV91uhUMBgMLC4uMj777/P0tLSttuL9qywK4qCTqfDYDDg8/k4cuQIWq2WRqNBp9NZJey1Wo12u02tVqPVamGz2fB6vXLvLoTTarXK1V1RFKxWKxqNBqPRiNfrpdlsUi6X5cxuMBjQarVYrVZ0Oh0mkwmTyYRWq8VkMtHpdFhZWWF5eZl6vS5X/Z1Go9FgNpux2+1y5dDp7v1qdTrdmse3E/EdVSoVvF7vjn72ZhCam9FoxGazSS3JbrczODhIJBKhWCxit9tRVRWLxYJer2d8fJyjR49iMpnweDwYDIb7fo7BYMBms2E0GgkEAtTrdWw2245c454V9k6nQ6VSod1u02q10Ov15HI5zp07RzKZlIY6jUaDVqtFUZRVs20gEABgaWmJcrlMKpVatfpoNBqazSbValWqbBqNhk6nI40lqqpK1V2j0RAKhejr65OrvFDrisUilUrlUO5ZH0QqleKtt94iGo1y5cqV3T6dNdHr9Xg8HiwWC88//zxnzpzBZrMRDAblFs9ms9FoNOS9IbaYbrcbt9uNTqdDq9Xu8pXcnz0r7KqqyhW73W6j1+splUq8/fbb3Lp1C61Wi1arxWAwYLfb0ev1+P1+7HY7VqsVrVZLp9MhHo+TTCap1+s0m00URZFfitAKzGazXMU7nY5UT4UW0Wq15Gw+MDCAVquVFtZWq0W5XN61/fpeJ5vN8qtf/YqbN28yMzOzJ8dIr9fj9Xpxu928/PLL/NZv/ZbUBIW95iCwp4VdVVXa7TbVapV8Pk+tVpORcKVSSa6mQv3SarVSJcpkMjQaDRYWFohGo3JvCciJotlsyvc0Go20222SySSLi4vo9XqMRiMGg4G+vj6sVit2u51CoUC73aZUKlGr1VhYWJB/79bK3m63KRaLZDIZotEoU1NTWK1WuYfcaVRVJR6Ps7y8zMzMDNFolHQ6vSPupc0gtDa73c6xY8cIhULSeCZW7vttzcQ9KhamWCxGrVaTORdmsxmfz4fBYMDhcGA2m3fw6u7lgcKuKMqfAr8JJFRVPXXnmAf4r8AwMAf8jqqq2a0+OWHBzGQyzM7OUqlUGB0dxe12c+XKFVKpFACFQgGz2czJkyfp6+tDURSmpqbI5/O89dZbzM7Oyi/lzvmj0Wjo7+8nFAoxMDAg/dGXL1/mo48+IhwOMz4+TiAQ4MUXX2RsbIzr169z+fJlEokE77//PqlUimq1KgV9tyLvms0mS0tL8iZLp9OEw2Fee+01uZ3ZSVRV5fz58/yP//E/SCQSfP755+RyuT0XsCTsMn19fXz/+9/n6NGjhMNhrFar3MM/CPG9JxIJ/uZv/oZoNEo8HieVSjEwMMBLL72E1+vl5MmT9Pf3y9fthrawkZX9PwD/D/Afu479IXBOVdU/utMc4g+Bf7X1p/elOi+CNux2u7SQd6+knU5HGlc6nQ75fJ5sNks+nyefz9/zvoqiSLeIx+Oh3W5La7/Yq+v1evR6vdyPNZtN8vk8mUyGRCIhJ5vdRtgZisUi6XRaTlzJZFKuTsKuIX6LnIGNIFyawkYhJre736PT6dBoNGi1WsTjcRYXF8lms5RKJer1+rZc+6Og1+uxWq04HA4CgYB0V25WdRdbv0QiQTQaJRqNkkgk0Gg00tV49/WLMRWG5p3ggd+2qqrvKIoyfNfh7wFfvfP3nwFvsY3Cvri4yHvvvSdXWZvNRiqVYnJyElVVpSo2NjbGk08+yZUrV3jzzTfJZrPSVbIWlUqFTCZDJBLBbrdjs9l4+eWXZTy933+7pPt7773Hr371K+bm5piamqJSqeypwJtWq8Xy8rIMErp27RoWi4X33nsPi8VCIBDA4/Fgs9kIhULYbDZOnz7N4ODght5fVVVSqRSZTIapqSn+9m//lmq1yuOPP77qPcrlMp9++ikrKyssLCwwPT1No9HYk4IOMDQ0xGOPPcbo6CiRSASXy/VAa/rdiEmwWCxy9epVJicnpcFW2HFE7MPY2Jh8XbvdJp/Pk0qlKJfLW31pa/Kwe/agqqqxO3/HgeAWnc+aZDIZbt68CUB/fz/9/f0yDBFu78GFK2NwcJDJyUlmZ2fvGxIq/MQi+cVkMuFwOJiYmMDv98tgiXw+z/nz55mZmSGZTBKPx/eckandbpPL5dZ8TKPRMDIyQn9/P16vlyNHjuDxeBgcHGRgYAB4sEqpqirFYpGVlRWuXbvGj3/8YwqFAoVCgccee0w+L5vN8r/+1/9iZmZmy65tuxABQceOHWNgYAC3243FYpGPr/cdrxXr3ul0qNVqLC8vMzs7S6vVot1uSwNvKpVa9f2I14hF40ExClvFIxvoVFVV71cDbCvqe9frdak+R6NRGbk0MTEh/7ZarXQ6HZaWlkgmk5TLZer1+roqkkajwWKx4Ha7cblcOBwO7Ha7/BJSqRT5fJ5isShDGiuVyrZ+KdtRC71bUMWYOBwOrFYrsViMvr4+jh49il6vv995YbfbCQaDuN1utFqtDP3sHo9msyl90yKqTAhHu91mamqK+fmt6YvxqGOlqirpdJobN25QKBTo6+sjEAhI4229XpfaWzgcxul0yliGbqOdiOVwu92cPXsWp9PJ9PQ0i4uLUtsMBoM4HA7g9r1crVbJZrNkMhnS6fQj5ShshocV9hVFUcKqqsYURQkD68ZAqqr6J8CfwMMXBhQhqSaTiRs3blAqlbDb7Tz33HMy2klkrF2+fJnZ2Vny+fy6win2sE6nk0gkQjgcJhgMYrfbabfbZLNZpqam+OSTT6hUKhQKBTlLbydbMVZrvKdUwcWe3WAwMDU1RSgU4tVXX2VoaOiBwu7z+fB4PExNTaHX62k0Gly6dImrV78sKOxwOHj11VcZHBykr6+PgYEBKRiNRoMf/ehH90wQj3BdjzxWCwsLZLNZ/H4/zWZTanRGo5FsNsvMzAyKovDKK69w9OhRAoEAFovlHmHXarWEw2G++93vsrKywo9//GNisRg+n49nnnmGSCRCIBBAVVWq1SrxeJxEIsHS0hJLS0vkcrk9vbL/FPgB8Ed3fv9ky85oDYTRrF6vk81mZUy32+3GbDbLuPl4PC4Ncu12e80B1Ol02O12GZnn9/txOp0oirLKzVcoFGRGUqPR2Nc57mJfCbdXXxGLrdFoWFlZIRaLUSqVZHiwCPnsTpXtjmsQAtFqtahWqzLuQKvV4vV6iUQihEIhAoHAKmH3+Xy43W4ajcaeCEJqNptSlU4kEnI7ZzAYyOfzrKysoCgKy8vLUnMUYdgihFogAnNUVSUUCskxENcsXKCNRoNCoSC1xmKxSKPR2BvCrijKn3PbGOdTFGUJ+DfcFvL/pijKP+F2v7Lf2c6TFBQKBT788EOcTifPPfccZ86cwW63Ew6HqdVqfPLJJ7zzzjtyANfC5XLx8ssvEwgEGB0dZWBgALvdTq1Wo1AocO3aNc6fP086naZYLEr330Gi3W4Tj8fJZDJ0Oh2pKfX39+NwODhx4gSPP/74mhFhVquVkZERdDody8vL5HI5HA4HkUiESCTC1772NR5//HFMJtMqv3Kz2eSFF16g1WqxtLTExx9/vGOGqfUQYbytVov3339fTnYiurJSqaAoCrFYDKfTybFjx3jxxRfxer08+eSTBINBOSGazWYmJiao1WpoNBpOnjyJ1+vl6NGjMikLbkcUfvbZZ8RiMa5evcrMzMyOBWRtxBr/e+s89NoWn8sDqdfrRKNR8vk8zzzzDF6vF6fTSSgUkqmp09PTwL0Glu4vRRinhOEKkJFw6XSaeDwuDXcHTdABma1XLpdZWFiQuf+lUkkW+uh0OmsKu9iflkol0um0DFP2eDzSQNptdRbfQ7PZJBKJMDIyQqvV2vEY/bUQGo8Q+vXI5/PodDra7TbhcJhKpcKxY8fodDrSTSfGpd1uMzExgc1mw2KxEAqFpDYEt2sKiLRgUQNxp9j9Ed8EwngmVHrh1xUqkXDxdMe/22y2VdlJDocDn8+Hoih8/vnnvPvuu/j9fh577DEp2Eajcc+6i7aacrlMNBrFaDRSLpexWq309fWtu9K4XC6eeOIJBgcHOXr0KKVSiVAoxNjYGF6vd1X+PNwW8kwmQ7lc5sqVK3z44YcyfHm/ILaE0WiUjz76CJ/Ph9lsZmlpiYGBAYaHh1dtecS2UITc7pW4+X0l7CJMVQR2iEy3bDZLoVC4x4UhjHB2u52vfOUrfOMb35BW2HK5zCeffMK7777LY489JiuLwO3Vv1qtHpiY6PtRKpUol8sy6lCr1fLEE0+sq9F4vV6ee+45qtWqHOtgMMj4+LgMQOqmXq+zvLxMJpPh4sWLvPnmmzsaSLIViMi/hYUFlpaWpI1oZGSEF198cZUhUpQtd7vd8v+9wr4S9u60VxEJJirFNptNmRQjEPnsLpcLk8lEqVSi0WgQjUYpFotks1nq9bo0wLXbbWmM2q101d2gO5RYVVUKhQKxWAybzSZr7Av0er2sMyBwOBwynly8R7lclmN869YtkskkyWRSJhXtR0SuRq1WI5VKYTKZSKVSFItFjEajTH9eT8BVVZVZkuVyecfDh/eVsOt0OlwuF1arVbpAhEW4XC7j9/s5ceIEcHtgbTYbTz/9NKFQiHw+z4ULF8hms1y6dIlcLkcul5NCLqzUIlddr9fvqVl5p1BVlampKX72s58RiUR4+eWX8fl88nFRAKN7ZRaGrW6mpqa4cOEC0WiUX/ziF8TjcdLp9L4V9G5qtRqXL19mZmYGh8PB6OgoTqeT4eHhVYE5a5HL5bh16xaJRGLHDZT7SthFAI3ZbJbpqELY6/U6ZrNZFkgQwu7z+fD5fBQKBVKpFKlUSlqR7y5nJWLiD9vKfjcikEgUC+lmIwUwVFWlVCoRjUZZXFxkenqaeDy+nae8o4hQ12q1SiqVkobK9Vbq7uy4er0u3bq9lf0+WCwWjh07JqvQTE9PUy6XZQjryMgIZ8+elQkb9XqdpaUlpqamWFxcZG5uTmoB3b5nWK3KHmZUVWV+fp633nqL48eP8+qrrz7U+4gyXfF4fF8Z4zaC2Dq2220uX74MwNjYGOFwWEbKddPpdGTV4rm5OZaXl+UWcifZV8JuMpkYHR0lFArRarVYXFyUyRkGg4GvfOUrvPTSS1LQE4kEly5d4sqVKzK/ej3DUE/Yv0RkbrXb7YcO5SwWiywvL5NOp2UdgYOEKBR58+ZNlpeXOXPmDL/927+95nPb7bZ06S4vL7OyskKxWNxxI+W+EHZhlLNardhsNmw2m6xA02w2ZWEAnU4nBV343UWo7YOilLrr0feE/jbdKb0WiwWj0bimHaNer1OpVKhWq8zNzZHP57l06RKpVIpCobDn8ti3ku703wfdN7vZIAL2ibCLhJVgMEg4HCYQCHDt2jUuXrwofeRutxuDwUCxWKRQKJBMJkkkEjLvvFwuP1DYhXX/bhX/sFKv15mfn5fluO72ocOX1vv5+XmWl5f54Q9/yBdffEG5XKZUKq0qv3wQERb6/RBOvS+E3Wg0ytpydxdLENlrZrNZxs6Xy2VptNPpdJjNZhqNxgMbN26k28xhwGw2Y7FYcDqdaDSaNf3i4iYXxrhEIkE8HmdhYWHLMtv2C939BNZDVCzu7kHQa/90F4qiMDQ0xHPPPYfJZCKfz1MqlfD7/Xzta1/DZrMRDodRFIV3332XRCKBz+djcHAQjUbDSy+9xLPPPsvHH3/Mu+++u2YIbHcF2c2oZQcRRVF47bXX+P73v4/X6+X48eMyJbabdrvNysoK+XyeTz75hL/8y78klUqxuLi4S2e+O5hMJlwul6ygtBYajUbW8BdNOkSC1U5qkHte2AF507VaLWKxGPV6XbY6EoX4q9Uqk5OTfPbZZxw9elT2PJuYmMBut7OyssIHH3ywbvRWdymiwyrocFvYT5w4we/+7u/et2OM6Fu2srLCjRs3ePPNN/dU9Z6dQq/Xy45D663uiqJgNptRVRWr1SrLee10ktWeFXbRv8xmsxGJRGTNOZEiaTKZUBSFbDbL1atXKRaLRKNRqtUqiUSCy5cv43K50Gq1MpX161//Ovl8nunpaUqlklT1u1d24bvfD3uwrUR0vBWtsx6EqPN3GPu8ibh3rVbL4OAgp06dYmxsbN2AGvF8uL1FEh1jdrp70J4VdpPJxGOPPUZ/f7+MUFJVVZZ8FmGu0WiUv/qrv5LdSVutFtPT08zPz8vi/cPDwwwPD/Piiy+yvLzMf//v/52lpSUSiYTs5CKKS3Z3ljlMq7tOpyMSieDxeGSi0P0QarxoEHmYhF301jOZTJw+fZrvfve7+Hw+XC7Xms9XFAWLxSLtIA6HQ+b076TA7zlhFwUSRAunQCCwqryR+F2pVMjn8+RyOVlDXiB8oOVymUwmg81mkyWntFotLpeLarUqCxd05zGLip+HbWXX6XQEAgFZeHGjZZRFd9LDhOhTYLFYcDgcMtV6vcjCboOcuLcrlcqOZ8LtOWF3u90MDQ0RCAR44YUXZDNG0dGlUChQrVa5ePEiV65coVAorBtjXKlU+OSTT7hy5QpjY2PMzc1hMpk4c+YMTzzxBB9//DEajQa/34/FYsFgMMjPOGwdXlwuF9///vd59tlnCYVCeyLffK+i1+vp6+vD7/czMTHBxMQEZrN5Qw05PB4Pp06dIh6Pk81md9TOsZFKNQPcrhkfBFTgT1RV/ePtahRhMpnwer34/X4ikQj9/f2kUikSiYRU36vVKrFYjFu3bslecGsh6pcDMsHF7/czPj6O3W5nbm5OWprFHkxUBT3IgSB3IwpQTExM8NRTT+326ex5ROlyj8cj01k3WoLaZDLh8/loNBqbLlv9qGxk+m4B/1JV1U8VRbEDFxVF+SXwv7ENjSKEUBqNRlkaKJPJyOSVq1evksvlWFhYkG60jazA2WyW6elpstmsTN0MhUJ873vfw+v1yn2U6P92WPbsfr+fkZERBgcH191z9liNTqfD4/EQCoWw2+37JjtyI2WpYkDszt9FRVGuA31sU6MIEQQjVOpSqUQymWR+fp5YLMbbb79NMpncdJRbOp0mk8nIKiI+n4/f+I3f4OWXX5b7+2w2+8ASRQeNcDjMSy+9RCQSkQUXetwfnU6Hz+ejv79/w/aNvcCmNmZ3OsM8AXzMBhtFbLS+t/Bzm81mPB4PTqdTlpwSSQSpVEquuptFxLyL6p4ajUY2ZBQGud2uoLIddeM38Jmycux+uWlhd8ZK1Ii3WCx4PB78fr/sCycQhTuq1ao0xolgLXH/iTyCnTZsbljYFUWxAf8T+BeqqhbuusB1G0VspL63sG4aDAb6+/t56qmnMBqNpNNpotEo58+f54MPPqBWqz2yQaNWqzE1NYXZbGZ8fJxQKCQtq6If/G6xHXXjDyq7MVYWiwWfz0dfXx9PPPGEbArRLQudToeZmRmmpqYIBoOcOXMGi8UiYzdyuRzz8/MkEokd72q7IWFXFEXPbUH/z6qq/vjO4Q03itjQidzJbDObzTidTrRaraxdlk6npYHuUWm325TLZZrNJrlcjkwmI0seV6vVQ2WYg9WhwvtpZd8NRENRq9WK2+3G4/HckwkoVvZ0Or2q+agI1hIZmeVyee+t7MrtK/khcF1V1X/b9dCWNYrQarX4/X68Xi9ms5loNEqj0eDjjz+WudVbrV6L7jGiTLBoerAf+pRtJTabjaGhIUKh0K73D9/riJLZojipqDl3N6KbsGi00W63SSaT5HI5ZmdnmZmZuW8fwu1iIyv7C8A/Ai4rivL5nWP/mi1sFKHRaHC73fT19WEymUgmkxQKBVnnaztyzDudDjdv3uTWrVurjh8GC3w3FotFtr/aiJ/4MGMwGHC5XLhcLmlEvhsRGivy/0WgViaTIRaLsbS0xOLi4q7kEWzEGv8esJ5+tyWNIjqdDoVCgUQiIY0XonzUdheTOGzCfTdGoxGPx3NPFdkHITrJiJTiwxIu262yr7ftsdlsBAKBVW3F9kIewZ4Ik2q1WrL4gWi62Ol0qFarh+Ym2i2cTqds8LCZqLl2u00sFuPmzZvE4/He93QHjUYjGzkKT0elUmFubo5Lly6xsLCwa3ahPSHscLvh3U5nAfX4srf9RlV4EWFYqVRkbfjDFFrcXSm20+nck7Mh1HiDwSArH4s8DtEZZ7fGas8Ie4/9QTKZ5PPPPyeRSPDZZ59x69YtGatw0BHtxkSuhqiEtJ5GlM1muXbtGslkkg8//JALFy7sak2+nrD3ANZvhHn348VikRs3bhCLxaS/+LAg3GetVotms0mz2ZRdiroRYyXUd5HHMTU1tRunLekJ+yEnk8lw9epVPB4PDodjVRVfIfDtdpupqSnm5+dZWFjgs88+I5VK7WgH0r1ApVIhHo/Tbre5cOEC+Xye0dFRJiYmpAtO1ObrdDqy+0s0GqVQKOzy2feE/dATjUb59a9/jdvtZmxsTLpAu8NAW60W7733Hj/96U9JJpPcuHGDarV6oKvGroWof7i8vIyqqgSDQb7zne8wNja2yt/ebDZpNBrEYjE+/PBDlpaWWFlZ2cUzv01P2A85YrUSsdzFYlFW/BHC3mg0WF5eJpFISFfbYTSmqqoqo+Cy2SyKorC8vMzs7Kx0W4oWT2LM8vn8rjRxXAtlJy2DvXjve7ioquqaCeQ7NVaiH55Op8NisaDX62U/PUGn0yEajbKysiLTjnfa1aaq6rqxvDt9X2k0Gmw2G3q9nmAwSCgUWlVsUmRkiog5UXhlp4yY641VT9h3l10X9v3CXhL2vc56Y3V4W5X26HHI6Al7jx6HhJ6w9+hxSNhpa3wKKN/5vV/xsXXnP3Sfx3pj9SX3GyfojVU3647VjhroABRFubCeUWo/sJPn3xurvflZ28FOnH9Pje/R45DQE/YePQ4JuyHsf7ILn7mV7OT598Zqb37WdrDt5/9Ie3ZFUb4J/DGgBf5fVVX/aKtOrEePHlvLQwu7oiha4CbwOrAEnAd+T1XVa1t3ej169NgqHsX19gwwparqDICiKH/B7S4x6wp7L6zxHlKqqvrXeqA3VqvphctunO0Il+0DFrv+X7pzbBWKovyBoigXFEW58AifdVCZ7/6nN1YbpzdWm2fbg2p6XU42Tm+sNk5vrDbPo6zsy8BA1//9d4716NFjD/Iown4eOKIoyoiiKAbgd7ndJaZHjx57kIdW41VVbSmK8s+Bn3Pb9fanqqpe3bIz69Gjx5bSK16xu/SKV2yQnjV+4/SKV/ToccjpCXuPHoeEnrD36HFI6Al7jx6HhF7d+DtotVoURcFkMqHX6zEYDLKccrPZpNPpUC6XKZVK295GercRnXS1Wi1msxmtVovBYECn08l+Z+12m1KpRL1e3/D7ir5oBoMBu90O3G68UK1WZaPE/YIoHa3RaFaVkV6PVqu169fXE3ZAr9djtVoxmUycPHmSSCTC6OgoZ8+eBZDte95//33OnTtHo9Gg2WweWIG32+24XC7cbjdnzpzB7XYzMDBAKBSiWCyysLBAPp/n3LlzXL9+fUPvqSgKfr8fv9/PyMgIX//619FqtfzlX/4lFy9epF6vU6lU9sWYajQazGazrLXf3T1nLdrtNslkkmKxuINneS8HUti7B/5+X4JAp9NhMpmwWq1EIhHGx8c5ffo0r776KgBTU1NkMhkWFxcxGAyywd9+uDE3i6IoGI1GHA4HPp+PI0eOEAwGOXr0KMPDw6TTaZxOJ8lkkgsXNh6WrigKVqsVj8fD4OAgzzzzDHq9no8++giDwbCvusAqioJer8doNGK1WnE6nfe9z1qtFvl8ftVzHnTvbOa5G+XACLtGo8Hn88kOJ4ODg1IV7+7DBfcOpF6vx2KxYDQa5c0dDoelau/z+bBYLPT19dHX10exWCQWi21Khd3rGAwG+vv7sdvtHD9+nMceewybzUY4HMZsNlOtVpmamiKdTsvJr1QqPfB9NRoNRqMRg8HA+Pg4Z86cIRQKUa1WKRQKFAoFyuXyvtCU3G43kUgEq9XK6OgoLpcLj8eDz+dDURR5/nffX61Wi5mZGZLJJIVCgVQqRbVaZWlpadUYGo1GgsEgZrNZalLRaJSPP/6Ycrn8yOd/YIRdq9USDoeJRCKcPHmSV155BZvNhsfjwWQyyeet1YpYo9Gg0+nQarXY7XbMZjOKosi9WDAYpNPpMDw8zPDwMKlUinQ6faCE3Wg0MjExQX9/P6+88gpvvPEGnU6HTCZDrVZjYWGBaDRKOp3mxo0bFAoF8vn8A99Xq9VitVqxWCwcP36cV155BYBSqUShUCCXy+26ertRvF4vZ86cwefz8cILL9DX1ycXhvsJe7PZZHJykng8zuLiIleuXCGdTlMoFFYJu9lsZnR0FK/Xy0svvcTZs2f5+OOPuXbt2uEWdmFA6t5vDw8PMzQ0xMDAAF6vF6vVisPhwGg0rnqt+DK6vxytViuNLe12W/4tnitWKIfDQa1Wu0db2I8oioLFYsHpdOJyuRgcHKS/vx+3242iKNTrdRYXFykUCiwuLhKPx8nlcqRSqQ0b58S2wGKxSFtAuVwmkUiQyWSoVqs7cKWbR/Rd12q1eL1ebDYbo6OjstOt3+/H5XJhtVoxGAxoNJpVmkm38Gs0GpxOp+ztXi6XcTgcLCwsAF8aLt1uN0eOHMHr9RKJRHC73QQCAUZGRjCZTKTTacrl8kMbiPetsFutVqxWK36/n+PHj+PxeHj11Vc5ceKEvIG1Wi06ne6+e3hVVVcJf7FYpF6vYzab79mLeTwejhw5gtFo5IsvvtiZC90mxGQ2MjLCyy+/jN/vl6uVVqsll8sxPz/Pf/pP/4n5+XkymQy5XE52MW232xsSVL1ej8/nw+12MzQ0xJEjR7h69SoffPAB0WiUaDS6A1e7eQwGAw6HA4fDwbe+9S1Onz5NJBJhYmJC2nf0ej16vV5qgELAxT0j/tfpdPT39xMKhThy5AhPPfUU2WwWn8/H3NwcTqcTt9uNx+PhiSeewO12S21IURR+8IMfsLKyws9+9jO++OIL2u32Q7XL3nfCriiKdJHZ7Xa5j/L7/QwPDzMyMrLKHdLpdFbNhHfPiN2PdTodarUa5XL5npkabs/ARqMRo9G4IXfLXkSMn8FgQKvVSkt7IBAgEokQDAYpFovk83kymQzz8/NMTU3do3Ju9HOE5uVwOLDZbPIGTqVSJBIJarXaNl7tw6PRaDCZTFgsFvr7+zl27BiBQIDBwUF0utti0y3YgrX+VxRlVVdcuN09d2BggE6nI/f9breb0dFRnE6nvC/dbjcjIyPSEKjVah/atrEvhF3sn/V6PTabDZPJxHPPPcfjjz+Ox+NhfHwcm81GJBJBq9XSarWo1WrUajVmZmZkj+xisXjPSt5Np9OR/cdPnz7N66+/vupLWl5e5pNPPiGZTG7JHmqnMZlMuFwuLBYLZ86cYWBgQLoY9Xo96XSalZUVbt26xfXr10kkEszPz1MoFDZtn3C5XHi9XsLhMN/85jeJRCIMDAyQz+dJp9PE43FWVlb2rBpvNpvp6+vD7/czNDTE4OAgVqtVTvLdi8da20LBesdMJhOnT59meHhYtsg2mUwYjcZV96XNZmN8fByPx0N/fz9+v59SqSRjPzbDvhB2EeRhMBhwuVzY7XaefvppvvWtb2Gz2QgGg+j1+lUrdLVaJZ/Pc+3aNZaXl0mlUqysrNx3VhQ9tSuVCoqi8NWvflUKu6qqJBIJLl26RKlU2rM36f0wGAxyBXn55Zc5e/as1IgqlQrvvfceS0tLfPjhh7z99ttUq1VyudxDqYwOh0NOJq+88gpDQ0O0Wi1KpRL5fJ5UKkUqldqzK7vJZCIUChEMBolEIkQikXUXibX+796zr3XMaDRy9OjRe15/9+ssFgtDQ0M4nU5CoRButxtVVclms5u+pn0h7AaDAavVitvt5oknnsDn8zE8PIzNZsNsNkuVu1ar0Ww2icViTE1NkcvluHbtGolEgnw+Ty6Xu6+wC7Wz2yK/FnvdRbQeVquVkZER/H4/4XAYj8eDoijE43EKhQKzs7PMz8/LFbder2969RBqq8PhoL+/n3A4jN1ux2g0Eo1GWVpaYmZmhkqlsqdjFUwmE+FwmHA4vCpoZi2Bv/uYMMR1G3m7jb13v26tY3e/v16vZ3BwkNOnTzM9PU0sFtt0bMIDhV1RlD8FfhNIqKp66s4xD/BfgWFgDvgdVVU3P9VsEIfDQSQS4ciRI/yzf/bPGB0dXWXA0Gq1tNttMpkM+Xye9957j7/4i78gl8uRTCapVqu02+0HDo7RaOTs2bMMDg7i9Xr37b58PYLBIG+88QZ9fX2cOnWKvr4+FhcXuXDhAolEgp///OfMzMyQzWbJZrN0Op1NC7vwkgwNDfHCCy8QCoUIhUJYrVYuXbrEX//1X0tLfL1e37PC7na7eeqpp+jv7ycQCAD3BmvdvWdXFIVOp0OlUqFcLsv4DY1Gg8FguO/rxLG71f1uG9Urr7zC8ePH+bu/+zsuXbpEo9HY1DVtZGX/D8D/A/zHrmN/CJxTVfWPFEX5wzv//6tNffImECq8xWKRhqRuxGAVi0Wpri8tLZHP5ykWiw8cFDHzilhwj8cjZ3PhJ221WjImXBj99jrdN4rRaMTr9RIIBPD7/ej1eqlWJxIJVlZWSKfTZDIZuepuFq1Wi81mw2g04na78Xq92O12Wq0WlUqFTCZDPB4nm83u+SAanU6H1WrFZrNJg9xaiAlRRFW2220ZLCQMuXq9XrrxHgYxThaLRdpcNhIZes81beCD3lEUZfiuw98Dvnrn7z8D3mIbhb2b9ayd9Xqdt956i/fff5+FhQVSqRT1en1DN63ZbCYQCOB2u/na177GCy+8gNfrxWAwUKvVuHr1KslkkuvXr5PNZqXraS8j4reNRiPf+MY35Cp75swZ9Hq9DPKYnJzkgw8+oFgsSp/6ZgVdTJRut5tvf/vbjI6OcuLECR5//HFKpRLnzp0jnU7z/vvvMz8/v+HvZa9xtzFO7J3T6TSlUom5uTlKpZKMSejr6+P555/H5XLR39+Px+O5r2Hv7j0+IF2d9Xqd5eVlYrEYiUTioZJqHnbPHlRVNXbn7zgQfMj32TJarRbXr1/nnXfeWWV53wgGgwG3200wGOT48eMyAQagUqmwuLjI3Nwc0Wj0oVe9nUaojlarlSeeeIK/9/f+HiaTSQYFxeNxLly4wOTkJOfPn6dWqz20xiK2UjabjSeffJKnnnqKcDhMX18f8/PzXL9+nenpaaampkilUvs6a/Du865UKnJbcvnyZTKZDFNTU8zPz3Ps2DFpmPT5fA98r7WOtdtt6vU61WqVbDZLIpGgUCjsqLB3n5x6vxpgiqL8AfAHj/o5XZ+37mPCiAdQLBY3vPra7XaOHTtGOBzG5XKteqxerzMzM8OVK1eIxWLbmqa4FWMlAj3sdjsTExO43W76+vqkV6FQKMjMtenpaVZWVqShbLMCKKIOg8Ego6OjhEIh+vr6cDqd1Ot15ubmmJ2dlYa/fD6/ZYK+1ffVJj4X+PI+TCQSfPHFF2SzWaampiiVSthsNs6cOcPo6CgDAwN4PB4sFssD32utY9VqVWpcV69eZXp6moWFhYfSLB9W2FcURQmrqhpTFCUMJNZ74nYX8+/2Y4oAG7j9JWx0QHw+Hy+//LK0HndTqVS4cOGC1Bi2U9i3YqxESG8kEuHVV1+lr6+PEydOYLfbKZfLRKNRUqkUly9f5uOPP6Zer9NoNDYtgMJCrNfrmZiY4Lvf/S6BQIATJ04QCASYm5tjamqK6elpLl68yPz8/JZa33ejScRaRrWZmRl+/vOfUygUWF5ept1u88Ybb/DCCy8QDoc5deoUVqtV7tfXs8CvZ7QrFApcvnyZRCLBr3/9axknv5MRdD8FfgD80Z3fP3nI99kQ7XabRqNBvV6nVCpRLBYxGo3o9Xo5KBqNBpfLRTgcpl6vY7VaqdVqNBqNdQVUZGM5HA5cLhdOpxO9Xg9Ao9GgVqvJyLFyubxp6+duYLFY8Pv9BAIB+SOCQZrNJplMhlQqRbFYpFarPbQAajQa3G43DodD+qO7Y+qz2SzLy8vE43Eqlcq+GLtuhMHtQcErIonKaDTicrlQVRWv14vP58PlcmE0Gu8J2V4r8q77M0WBkGazSTKZlPv0bDYrcxK2JTZeUZQ/57YxzqcoyhLwb7gt5P9NUZR/wu1+Zb+z6U/eBKVSiVgshtFo5OLFi6TTaY4cOcLQ0JB8jslk4qWXXuLo0aNcvHgRRVHIZrPMzs5SKBTueU+NRiOz2E6dOsXExAR+vx+73Y6qqsRiMS5fvszS0hLxeFzuafcyiqJw9OhRvv71rxMMBnn++edlEgdAPB7n7/7u74hGo8zMzFCr1R56pTWZTLz++us89dRTDA0Ncfr0aemzX1xc5Ne//jV/8zd/Q6FQIJ1Ob+Vl7gj1ep1EIoFer6e/vx9Y26gmjHBwO9rNYDBw7NgxRkdH5YLU/dr7GehqtRrRaJRyucz8/DzRaJS5uTnefPNNstmsTCt+WNvKRqzxv7fOQ69t+tMekkajISOvYrEYBoOBUCh0T9aaCCfM5XIEg0E0Gs26iRaKouByuejr65ORSd0re7lcZmlpieXlZUql0r4wysHtNEwxcfX19a2yQVQqFebn51laWlplwFwrDwDWt48IFX54eJgnnngCv99PKBSiXq8zOztLMplkbm6Oq1evPpS6uRdot9vSXy60n7uj2+C2vaevr0/ekxaLhXA4LH3z9+Nu67soclEoFKRNZW5ujsnJyS1JA94XEXRCrclkMpw/f57Z2VmputvtdsLhsNw/KorC8PAwr776Kslkkk6nw8LCgkzuEANsMBgYGxvj+eefJxKJSH+qCKRpNptSfd/rbjaRRioyzAYGBnC5XDKQQxAKhfiN3/gN8vm8LJMkEn9arRaFQkFOrOKxVCpFo9GQamU4HObpp58mEAjw5JNPEolEaDQaXL9+nVwux7lz55ibm+P69et7ftzuRz6f58qVK6RSKalFCpUdvhRUn8/HsWPHZC0EkfizXrz8WnnvmUyGdDpNLpfj8uXLZLNZrl27xtTUFNlsdsu2QPtC2EX0WyqV4p133sFkMsnChX19fXi9XlkkUlRECQaD0iViMplYWlpaFf5pMpk4evQor776KmazGYfDsSroodlsSsv1Xl/VNRoNFosFs9ksLeOi8k43/f39fP/73weQ45DL5VhZWaFSqbC0tEShUCAWi7G0tCTDjcU4dDodRkZG+If/8B/S39/P0NAQPp+Pmzdv8vnnn7O8vMxPfvITJicnZfDRfiWXy/Hpp5/i9/t58cUXabVaq4JrhKCKIKVu7pdSvdaxTCbDjRs3SKVSnD9/nlQqJS3vDxPFuB77QtgFnU6HZrOJoiisrKwwPT1Nu91mdHSUdrstK8OKmnI2m43BwUFarRZms1nWj4PbxrlAICADT8SMWy6XpYFJlEza68KuqqrMcS4WiySTSZlFpdVq5Q0j/O4iTlukuooCH/V6HYvFIouCFAqFVRFhxWJRhhI7HA5p8FtZWWFhYYF4PC4zsvY7Qo0X28dsNovFYlml/cGXQV2wsaw38T2JegDNZpOFhQVmZmbkWIpkrK2+7/aVsHeHrn700UdcuXKF06dPy33S2NgYwWBQhjoajUZ++7d/W/oq5+fn6XQ6co9/5swZnE6nTFhoNpvcunWL5eVlrl27xuTkpBz4vUyn05GZeNevX+eXv/yl1HI0Go10rwUCAU6ePLnqpjWZTHJ/KcpvNZtNms0mtVpNJsWkUimy2Sx9fX0cPXoUo9Eoo/AuXrzIX//1X5PP50kk1vXC7iuEga5er3Pjxg18Ph/9/f2cOHECg8Fwj6Htfhlu3cdE2HC5XGZycpJ0Os3Fixf54IMPqNVqMstwO7IB95Www5dhiplMhkwmg8fjYWVlBb1eTyQSkdlGokpNJBJBVVUMBgN6vX6VsHs8nlXW0larRS6XIx6Py+KApVJpX+w9hdqcz+dZXl6W16soinRBij13o9GQsdqqqmKz2WReALBq8rPb7dTrddxuN5lMZpV1v1QqEY/HiUajLC8vS63oICAmPeHuLRQKsr79Zi3h3RNDo9GgWCzK7VIikWBhYYH5+XlpG9mu6MJ9J+x3E41G+clPfoLP5yOXy3Hq1Cm8Xi/9/f2rAhlcLpe0Ogs11m63oygK1WqVdDpNPp/n7bff5pNPPpF+YuFv3w+oqsri4iLvvvuujG5TFEUmaFitVj799FM5EWi1WhwOh0yMEaWWRA63yWSS/mKDwYDX60Wn01EulymXy7z//vu8//77xOPxfVMhdqOIQh8ul0uOgchgW8vIdr9jqqqSy+VkhV5xf12/fp1UKkU8Hpf5Fts5fvte2EVkkc1mk4a6kZERWQpaYLfbZReSu6uN1Ot1kskkiUSC8+fP86tf/Wrf3rSxWIxYLLbmY903Ybew+3w+jEajLJl97NgxHnvsMXw+H8FgcNXYVSoV0uk06XSaTz/9dF+P1f3oLvThdrvvqXGwEcObOCYi4bLZLJOTk7z99tuyJPfDFKF4WPa9sMOXKvji4iJ2u51SqSRX7oGBAXmjwtoFJ8Xv7p+DSPe1ilWkVqtJN5uqqjIVNp1Oo9frabfbq8ZMGD/NZrM0AopIs4OA0HqCwSCnT5+WrkxRBHIzxjhxrNlsMjs7y9TUFJOTk9LtudNRhQdC2OH26vz+++/z2WefSSNSJBLhH/yDf8Dx48fl89ZKI1wrxfCg02q1UBRFehxETr/QekwmE/V6/Z4tjF6vx+PxALd9zD6fj3K5TC6X29euNkAuEC6XizNnzvCP//E/JhQKyeYjYmu0UWNcdzLLL37xC372s59RLBZJp9Oyms1OcmCEvdPpUCwWqVQqGAwGPB4PRqNxzdlzLaEWLhTxcxgEX2gxQkiFwLfbbWnAE6tUtyAL15woqbzXXZMbQQiy3W7H5/MRCARkzH93zMLD3BuqqlIqlWSdfGHo22kOjLADq6rIdEfUPQhRCUeUDrZardISe1gQgTkGg4EzZ87w/e9/XzZ3BOQqL0ot6XQ6hoeHOXPmDLOzs6TT6X2X7CIQ+3Or1crrr7/Oc889RzgcluW07s5Y26yBTqvVEgwGGRsbI5FI7FrsxoESdrH6iAHuXpnuh6Lc7v4hovBEOd/tdIPsNUSAjcViYWBggLNnz2IymeT1C9+vqqqyf57X62VwcJBCobCv6/XpdDrZFef06dN8/etfl0FZ613XZgx0Go0Gh8NBMBikVqs9VEmpreBACbvA6XRy5MgR2YTvQej1ehwOB6qqcvLkSWq1GktLS1y/fl1GOx1Uoe+uMvPUU0/Jwp5arZZCocDk5CSlUmlV6SlhqBICYTKZdu0GfhTE/tzj8ch4f9FqqTs0djPGuLWO6XQ6RkZGqFarWCwW2Xdgp410B1LYg8Egzz33nKwr9yBE6KzT6eTrX/86R48e5YMPPmB5eVm2g9oPgTUPg1arxWg04vf7+d73vsdTTz1FKBRCq9WSSqX4q7/6KxYWFmR24PDwMP39/dIv312cc78RCASYmJhgeHiYv//3/75MIBLXs5nIuPsdMxgMnD17liNHjuD3+4nFYmQyGWZmZnrC/qgIo9Naeb+isZ6IpRdx8aIKqAgy8Xg8crXfSBnq/YqoBOvxePB6vasMmyLYKJlMYrPZsNvtMq9fbH1EG6n9hBBkq9VKMBiUi4LT6VzV2mutslHi+GY0PUVRZEVY4cozm82riqLuxB5+I8UrBrhdRjoIqMCfqKr6x8oO147fDNlslqtXr5LJZIhEItJVJB575513yOVyPP744xw7dmzVTdvdYmd2dpZEIsGnn37KysrKLl7R1iMiwYaHh2Wa78TEBMFgUObyiz5vs7OzGI1GrFarLJ6gKIpsfikiy/YDYpLS6XQcO3aM3/zN35Rtqrr36GuViLrfsfsZ6DQajWxo8uyzzzI4OEg8HudHP/oRV69e3VC3oq1gIyt7C/iXqqp+qiiKHbioKMovgf+NHawdvxlEHrbBYLgn2KNWqzE/P08ikaC/v19m0QHS9WK322V9etGq+aDRbTgaHR2VHWIsFovMZxfZXt3lkERIrIjCMxgM962rvhcRrkOv18vY2JhsOtmdJ7ER7t663M9oJ7xDomlGNBrl3LlzsjLNTrCRSjUxIHbn76KiKNeBPnaxdvxGWWvwRYZYPp+nUqnQbDbXrNSyH/egm0EY3JxOJ8PDwzLdV8TXf/TRRywsLMgsLJEKK1ZxERnWPQHsB4xGI8eOHcPr9XLkyBE5wYmtyP3KRq117GGNdmv9vd1sakpWbjeLeAL4mD1YO76b9WKY2+02xWJRpq42m81195wHWeBFVqDb7WZ8fByv1yvLHc/NzfGrX/2KVCol/eeiqaZQdYVrUuRk7xfMZjOPPfYY4+PjnDhxQiYBrbUPX0sQ13rOwxjtusOyd0rgNyzsiqLYgP8J/AtVVQt3zVTr1o5XdqG+tygMUKvV7jGsibhn0Yt9amoKl8slrdJi7y6qvrRarR1T43dqrLonwu4w2e5oOZEpJ1xzFosFj8eD3W6Xk2OtVqNUKj1S4cpHuIaHGithaxAuw+5CHnD/Gu7rHRPH1xsDoQWJMW02m+RyOVndd6fCjDck7Iqi6Lkt6P9ZVdUf3zm8odrx6i7U9y6XyywvL6PRaO6J7fZ4PHzzm9+UDSB/8YtfMD4+zne+8x28Xi/BYFB2IP3GN77B/Pw87777Lrdu3dr2896NsbrzWWtqQqKrjEajYWhoiDNnzsh012azSSKRYHp6+qHbET0KDztWOp0Oj8dDKBTCbrffI+x33nvdY4LNGO06nQ6pVErWR0in09IoVyqVdsz9thFrvAL8ELiuquq/7XpoR2vHb4ZWqyVjkNdb2W02G+12W2bKlctleUxEiQWDQSqVyoEz0D0oAag7R0Cv10trsgioEWp8tVqVRR32UxKMMNCJ67hbaB8GIdTdv8XxVqtFsViUpc4SiQTpdFpuI3fKrbuRlf0F4B8BlxVF+fzOsX/NDteO3wyiP9Za/cVFtJgIdNDpdLIvmd1ux2AwSNXVaDSu8rseJMQNJkpQCSObCDUWxRvEtkakeWq1Wllt5ebNm5w/f55sNrtv4hDq9To3b96k2Wyi0+kYHByUeRHd3/N62ZF3q/GiAlC1WmVpaYlyuSwbO4rntFotlpaWZJvqSqVCtVplbm5uVQWc7WYj1vj3gPWmvR2rHb8ZujtqrCXsosjkyZMn8fv9shW0qNsGX6qwQvgPGmJcREBH995R5Kzr9Xr8fj9Go5FQKITD4VhVT31+fp7Lly/v5mVsmkajwdzcHOVymf7+fiqVCqqqrvk9P8hAJ1Zt0XTx5s2bpNNpLly4wJUrV9YU9ge9/3ayvxykG0T0A8/n88zMzMi+1mJlEl+syWSSUVPCX7yeFf+gIdRNYTDqdp95PB4mJiZkRVqj0YjT6aTT6VAoFGSwUT6f3+Wr2DztdptcLgfA/Pw8165dw+FwMDg4iMVikf5wETnZ6XSoVCqyaGe1WpU19kV31Wq1SrFYZGpqimKxKMtwi/HsdDoP3bJpKzmQwl6tVkkmk9Trdf72b/+WL774gieeeIJnn31Wqqd6vV6WG+q2Rh90IReIVVw0hbBYLLKgxcTEBE6nE2BV+apGo8HCwgI//elPicVizM3N7eIVPBzNZlN2xel0OmQyGcLhMK+++iqBQACPx4PT6ZQLRqPRYH5+XhrVFhcXKRaLMvKtWq1SqVSkQIvf3e5IMXHsNgdS2IUaL4QeIBwOk0wmsdvtMlpKpMGuhYiH308BIw9Do9Egn89jMpnktsdsNuP1eqXtQkyApVJJNpWIx+NUq9VdPvvNI+IDAFlJWFEUGQ4tNJ5msymr5SYSCZLJJMlkkmg0Sj6fZ2FhQQr7fhmHAyns3bPylStXMJlM3Lp1i3PnznHkyBH+6T/9p4yMjKz7elW9XQ10cXGRhYUFSqXSDp79znLz5k1+9KMf0dfXxw9+8ANOnjyJTqfD5XKtqiE/OTnJ7Owst27d4vz586TT6R0tlrgdiLrworW06IDrdrtl+69ms0kqlZLxBOKYMLbtpyo9B1LYxcreaDRkg4fp6WkAzp49y+///u/L5663aote5rFYbN+Ukn4YVlZWyOfzDA4O8s1vfpOxsTFsNhsWi0XuWZvNJrFYjC+++ILZ2dl1O+PuN4rFomyYeOvWLRRFuUfYRZbkQahadCCF/X6k02l+9rOfrbKWrve85eXlA7GC3Q8hzLlcjnfeeYdoNIrJZMJkMq3af964cYOZmRmSyeS+LT/1IFT1drXdQqFAq9WSdQz2wn57K1B2cj+6k1Fh66HValfVFVsPYakWN/w2feEXVVV9aq0HdnqshEtSeCTujuMWwR/tdlu2MN5JVFVd13K6lWO1VujsfrPZrDdWh25lF40Ke6ym3W4faNvERulOUDloHLzQsB49eqxJT9h79Dgk9IS9R49DQk/Ye/Q4JPSEvUePQ8JOW+NTQPnO7/2Kj607/6H7PNYbqy+53zhBb6y6WXesdtTPDqAoyoX1fMv7gZ08/95Y7c3P2g524vx7anyPHoeEnrD36HFI2A1h/5Nd+MytZCfPvzdWe/OztoNtP/9H2rMrivJN4I8BLfD/qqr6R1t1Yj169NhaHlrYFUXRAjeB14El4Dzwe6qqXtu60+vRo8dW8Siut2eAKVVVZwAURfkLbreEWlfY90LW2x4jpaqqf60HemO1mp3KejsIrDdWj7Jn7wMWu/5funNsFYqi/IGiKBcURbnwCJ91UJnv/qc3VhunN1abZ9uDanary8l+pDdWG6c3VpvnUVb2ZWCg6//+O8d69OixB3kUYT8PHFEUZURRFAPwu9xuCdWjR489yEOr8aqqthRF+efAz7ntevtTVVWvbtmZ9ejRY0s5dDXo9hh7pgbdXqdnjd8422GN79Gjxz6iJ+w9ehwSDl112R5ro9Pp8Hg8mEwmzGaz/Onr68NkMq16rqIotFototEo2WxWtoQSpaYPanXW/U5P2HsAYDAYGB0dxe/3EwgECAaDhEIhXnvtNQKBwKrnKopCtVrl3LlzXL16lcnJSd5//32q1ep21tjv8YgcSGHXarXodDq0Wq1sw6vT6Va1ZF6LTqdDtVql0WjIdrwHfZXS6/WYTCbsdjuhUIhwOIzP5yMYDBIIBPD5fLjdbvl80UShVqsRDAblyu7z+SiVSqTT6QMv7IqiyIYa3fea0WhEo/lyZ9xut6nVarLrjvi9W+3EDqSwOxwOIpEILpeLZ599lnA4LFer7i/jbur1OufPn2d2dpbp6WkuXLhwYFsdCUKhEKdOnSIQCPCtb32L0dFR2f7JaDRit9tXPV9Mfjqdjscff5yxsTHGx8fx+XwkEgl++ctfsrCwsBuXsmOYzWZOnz6N3+/H5/Ph9/txOp0cPXp01XilUimuXbtGqVQiHo+Tz+dZXl7mxo0bq1o67xQHTtgVRcFkMuHxePD7/Zw8eZKxsTH6+/sZGRm5r7CLzq9arZZSqfTAFlH7HUVRsNls9Pf3E4lEOH78OBMTEyiKsmqc1tJuNBoNgUAAv99Pq9UilUphsViwWq07eQk7htAIFUXBYDAQDAbp7++nr6+PgYEBvF4vzzzzzCotaHl5GZ1ORy6Xw2w2yxbPWq12V1poHRhh1+l0jIyM4Pf7GRsb4+zZs7hcLo4fP47X68Xlcm3oPY4cOYLdbqfT6XD9+nXy+bxsz3tQ0Gq1DAwM4PF4eOyxx3jppZfwer14PJ5Vvc6azSb5fJ5ms0mlUqFer2MwGGR/e5vNhtFolJPDQZocDQYDdrsdvV6Px+PBarXi8/kYGBjAZrNx7NgxvF4vDocDl8uF1Wq9x5Bps9mYmJigWq3S19dHqVRiYGAAg8FALpfj1q1b5HK5HbumAyPser2eEydOcOrUKR5//HG+8Y1vYDab0Wg0cpW63369+z2OHz9Oo9HgwoULJBIJaXg6KOj1esbHx5mYmODJJ5/k9ddfx2q1YjAYVq3ozWaTlZUVyuUyqVSKXC6HzWYjEolgsVjkPlVRFLRaLRqN5oFjvF8wGo0EAgGsVisTExOEQiGOHz/OSy+9hNVqxeFwYDAYVmlBd2uNDoeDkydPyv5xqqpy9epVLBYLsViMTCbTE/aHQVEUrFYrbrcbu92OwWDAYDAAt9XQcrlMsVik0WiQy+VW7ZmsVivBYBCDwYDRaESn02G324lEImg0GhYXF9f72H2F6NRqtVoJh8MMDQ3h9/sxGo3o9Xp5s4re9rlcjtnZWXK5HJlMhnw+j9PpRFVV7HY7LpcLl8slDVH1ep1Op7PLV/nwKIqC2+2Wq/XIyAg2m43h4WF8Ph+hUAi73Y7ZbMZgMKDX61e9dq3302q1q9R1i8WCx+OhWq2uev1OcGCEXavVEg6H5Sx8t0o5NTXFhQsXiMfjvP3226TTafnYqVOn+P3f/31CoZBUbwcGBnjjjTdYWlpidnaWeDy+05e05dhsNkZGRvB6vbz22ms8//zz2Gw2LBbLqlU5k8kQjUaZm5vjz//8z1lYWKBcLlOtVgkEApw6dQq/34/dbicYDFIul1lZWSGZTO5rDUir1fLss8/y3HPPEQwGeeyxx7BarVitVoxGIyaTCZvNtkpb3Cwul4tjx45hsViw2WxbfAX358AIu3CHOJ1OzGbzqplWVVWKxSJLS0ssLi5y+fJlVlZW5ON6vZ5MJoPFYpErvslkwu/3U61WpYaw39HpdFitVpxOJ36/n0gkglarXTUxqqpKrVYjm82STCaZm5tjdnZWrty1Wg23202r1SKfz1Or1ahWq5TLZcrl8j1uN7G6iffu/tlrKIqC1+tldHSUUCjExMQEFotFutYE3X3b17sWYfu4u9+7Xq/Hbrdjs9l23MZxYIRdq9USCAQYGRnBarXeM/POz8/z1ltvkclkKBaLqx6rVCosLi7S6XSIRCIEg0FKpRILCwssLS3tml90q9FoNHJ7I2IPum/Eer1Oq9Xi+vXrnDt3jng8TiKRoFar0Wq1ACiVSty6dYtYLIbFYuHy5cvMz8/zxRdfUCgU5B5Up9Oh1+txOBwcO3YMq9XKysqKtEjvRX+88DAcO3YMh8OByWRaMzaj0+lQKpVoNptkMhnS6fQqgRduS5vNRjgc3jOLxYERdo1Gg8fjob+//57HVFUlGo3y8ccfrym4tVqNeDyORqOhWq0CUC6XiUajxOPxAyXser1eCvvdq1W9XqderzMzM8O77767pieiUqkwNzeHTqejXC5z8eJFstkssViMVqslJwWdTiddoE8++SQ+n49r164xMzNDNpsln8/vOWHvXtmF/WatvXin06FcLstFYnp6WtoqFEXB4XBgs9mka7In7NvEetbg+6mOzWZT+kLFjV2v12V02G4EQGwHzWaTQqGA0Wgkk8mQyWQwGo1YLBbgtoCqqkowGOT48eMkk0kKhQKdTodWq7XK+NbpdKhUKmg0GiqVCu12e9XjOp0Os9mMw+EgHA4TDocB8Hg8xONxKTDFYlFGmYmJYrfpvofWup+azSbxeJx0Os309DQ3btxYJew+nw+Xy4Wqqhw/fnzHzvtBPFDYFUX5U+A3gYSqqqfuHPMA/xUYBuaA31FVNbt9p7m9lMtlZmZmqFQqUsUvFApMT0+zsrJCpVLZ5TPcGsSqnM/nmZycxOfzEQgEGB4eRqfTYbFY6HQ6nDlzBpvNxszMDKlUSgpmt4bT6XRIp9Nks1k6nc49CTAWiwW/38/AwABPP/00o6OjcuWfmpriZz/7GYlEghs3bkjtqVwu78m9/N1Uq1U+/fRTbt68yZUrV/j000+llqLRaBgeHqavr48nn3ySr3zlKzgcjl0+49tsxKT4H4Bv3nXsD4FzqqoeAc7d+X/XaTQaMvhjMzdNq9WiXC5TKBTkHiybzVIoFCiXy3tmxXlUhIusUqlIFb1UKq1albRaLXa7Xaqgdrtd5hfcTavVotFoyPHpDq4xGo1YrVZsNpv88Xg8hEIh+RMMBqVBVfis9wvtdptWqyUnqWKxSDabJZPJSI2wVCpJjajbqNdqtXYlO/CBK7uqqu8oijJ81+HvAV+98/efAW8B/2orT2yzNBoNLl26hNPpZHBwkNOnT294ryRWvHg8zr//9/+eH//4x8RiMW7evCmtzQeBdrtNpVKh0+nIvfbTTz/N0NDtLr96vV7uOXU6HRqNhmeeeYZgMMgXX3zBjRs31nxfrVYrbQAWiwWDwcCRI0c4deoUfX19GI1G2u02Op0Og8HAwMAA3/72t8nlctjtdq5cucLS0hLFYnFf+OktFgsvvPACx48fx+Px0G63yeVyzMzMyACsYrEof2w2GyaTCb1eT6VSIR6Ps7KysuNuyofdswdVVY3d+TsOBLfofB6aVqsl3WoajYYTJ05sWNgbjYb0uy8vH9wCuZ1Oh0ajQafTYW5ujnK5TDAYpF6vr7I8m81mLBYLjUaD0dFR9Hr9fZNbhOFPuJVMJhPBYJDh4WH8fj86nY52u42iKDJv3u12Uy6X5bZC7P/3Gqqq3qNxGI1GxsfHabVaJJNJbt68idlsZmlpiWq1SrPZpFqtUq1WqdVq1Go1OT4iWCmfz++4xvjIBjpVVdX71QBTFOUPgD941M95EBqNBqfTSTAYxOFw3HPjiCi5UqlEoVDYk6r5To1Vp9ORtonZ2Vk+/fRTvF4v4+PjuFwuOXZms5mxsTGcTidLS0vSDVcoFFZZ0sPhMOPj4zIyz2azMTQ0xMjICHa7fZUbS3y+2AI0m02p1m6G7RirTqfDwsICn3zyCU6nk/7+fkwmExaLBaPR2P3Z0pPR39/Ps88+Szwep1qtkkql5HZpeXmZX//617jdbvke8Xic6elp8vk8ZrOZoaEhHA4HTqcTvV4vA5xyuRzFYpFCocDS0tKWZF8+rLCvKIoSVlU1pihKGEis98SdKuav1WoJBoOMjY0RDAZXuZVEGOTY2BiZTIapqak9Kew7NVadTodkMkk6nZYuJhHvbrVaZe6/w+Hg2WefpVqtUigUqFQqZDIZZmZmVqmgp06d4rd+67fwer0y8UjkeYvVvDu4RAiDUHkbjcam97DbMVbtdpsvvvgCgMHBQV588UXcbjeRSGSVsANyjE6ePMnw8DDRaBSDwcDy8jJXr15lamqK69evs7S0JGMOdDqdtCvp9XrC4TB9fX2Mj49z9OhRrFYrkUgEvV7PjRs3mJmZYWpqinQ6vavC/lPgB8Af3fn9k0c+k0dEpLYKNfJu1Uuj0WyogMVa7yvixu9+vTC2CCNMs9ncF9ZkuC3wwsqeTCbRarUkk0mZW+B0OtFoNNLX7PP56O/vx2az0el0Vgl7f38/gUAAt9uN2+3G6XTKx7pdnrVaTaq4wgAqgpz2QqEQVVUplUqsrKxgMplIJpO0221sNhsGgwGtViu3huIeEOPjcrkIhUKoqiqThoQGI+wVYjz1ej1Go5FwOIzL5ZKBXFarFb/fj16vJ5vNUqlUpEtYjN2j2DQ24nr7c24b43yKoiwB/4bbQv7fFEX5J9zuV/Y7D30GW0R3bPzdFUMeBb1eT39/P3a7Hb/fTygUkl90p9MhHo+TSqWkurXffPKJRIJPPvkEl8uFTqdjcHCQp59+mhdeeEFmshmNRp599lnGx8elsHar3WL7ZDAY7sln754Qp6ammJ+fJx6P89lnn8k0T6EC77a21el0mJ+fJ5VKMT8/T6FQwO128+STTzI8PCyDtsRKLdR5kSH3+uuvU61WOX36NHNzcyQSCS5fvkyr1eLYsWOEw2GZrGUymeT/4ker1cqFymw2Mzo6isfj4erVq8RiMeLxOIVC4aGvbyPW+N9b56HXHvpTtwFFUbBYLDJv/e7VW7iF1jq+3vsBUp31eDz09fUxPDwsJ5J2u41Go5GuFa1Wu++EXRiSyuUyU1NT1Go1hoeHpWFKjEN3YMyD6F6hu/fn6XSaxcVF5ubm+PTTT8lmsyQSiXvCl3eTQqFAoVCg2WzicDhwu90Eg0GZLh0IBKSQa7Va+bcQ2Ha7Ld2X8/PzRKNRGo0Gg4ODDA8P43a7CYfDMvdCBDTB6nEzGAy43W7i8Tgul4tyuUwmk3mkazswEXSNRoOPP/5YFrE4c+bMqn1WJBLh2WefZXFxkcXFRSqVCoODg0QiEfkcjUYjjSlWqxWXy4XRaMTn88mJxO12rxL2UCjE0tIS09PTzM/P77vQWhHW6nA4CAQCMo3zUUkkEnIlmp6eplgsMjMzw+LiItlsVq7me7XsV7VaZXFxkVQqRbPZ5Nq1awwMDLCwsIDT6eSxxx7D5/PdkwEn7EOKosgYhXa7LbMpzWazLIohDJbdiO1VKpUik8kwNzcnw7YfNbjrwAh7rVbj7bffZnJyktdff53jx49LYVcUhcHBQV555RVu3LjBO++8QzqdZnx8nGeffVa+h16vZ2xsTNarE26n7hXubkPT8PAwS0tLWK1W3nrrLfL5/M5f/CNgMBjkChYOhxkYGMDlcj1ygEssFuPChQtEo1HOnTvHysqKjIlXVVXuPXd7n74ewi0IMDk5iaIojI6OMjMzQyQSwefz4XA4VtUBgC/j6z0eD6qqcubMGYBVWmX3PdSNqqoyWCcej0sD3fz8PMlk8pHH6sAIu3AniZI/xWIRjUaDyWSSeyFhRBGz8rFjxxgYGFilsgeDQVnAQFQQvZtGoyHTOxcXF5mZmZGJIHsZ4QcXhiadTifHxOVySUObzWa7r7ArikKn06FQKFCr1eRN2Gq1KBaL1Ot1bty4wezsLIlEgmw2K2Pg9/oYdSMmJPG7VCqRSCTQaDREo1Hsdjtut1uW84L1BfluhOFSxD7UajUajQaZTIZarcbNmzflqt5oNLZkUjwwwt5ut4nFYqRSKYaHh5mcnMTv9zM0NITdbsfj8WCz2RgcHOTYsWPU63Xsdvsqg5KiKLJSzd1ZYd3k83neeecd4vE47733HhcvXqRcLu/5Vd3j8fDEE0/IstEul4uhoSEef/xxLBaLLLVkNpvXvXZxM7daLa5evcrMzIxUPYvFIp988gnxeJxsNitdRsVikWazueey3DZLMpmkXC7LxeDWrVs89dRTPPfcc5s2CHeHzS4vL7O4uEgymeT9998nmUyysLBALBajUqlQKpW25PwPjLADMkVTBCOYTCZarZasCCqKJfp8vge+11pZWN03dTQaZXl5mZmZGW7durVdl7RlCNek3+/H7XYzODiIx+NhbGyMkydProo2FOrk3VVmu+l0OmSzWaLRqByrfD7PjRs3pE3koCQQCUS5LlVVSSQSWCwWCoXCZuMD5H1Ur9dlJmIymSQajTI1NUU8HicajZJIrBu+8lAcKGEXlEol5ufnaTQaMu57M6iqSiwWY3JyUlrXVVVlbm6OqakpisWiNDrth/p0ovTU6OgoL774omz+INRQUSdNBLekUikSiQRms5mRkZE1LcaNRoOrV6/y5ptvSmt7vV5neXn5QCUPPYjN2DZExaR0Ok2hUODSpUskk0kWFxeZn5+nWCzKMOatWs27OZDCXi6XicVisnPJw5BKpbhw4YJMglFVlQ8//FDe3OLYXke4JN1uN/39/Zw9e5ZwOCxDWAVi7yhytScnJ+V+vlvY4fZ1N5tNpqam+Oijj2T2134Yj63kYYyYlUqF5eVlEokE586dk1V/lpaWtr1c14ERdnFTGwwGmWgh4o0fRC6XY35+nmq1KhtFzMzMMDk5KV1DqqrKiKr9cFN3R2uNjIwwNjYmO5YYjUbpIxYpryKWW7jIbt26JaPm6vU6DocDq9Uqb3CNRoPf72dkZESq8/t9T/4gXC4X4XAYj8fDxMQEg4ODeL3eTQl9qVRicXGRRCJBMpkkl8vJ6MHtvq8OjLCLCDqv18vExAQTExN4PJ57VqW1mJub44c//CGxWIy5uTnpW+0O4RRlm/ZDCibctrx7vV5sNhtvvPEGb7zxhrxZRYinqqrk83lmZmbIZDK8/fbbsu7e3NwcfX196PV6hoaGOHXqFOPj4/L9DQYDp0+fptPpcOXKFTkRHmTGx8f5zne+QyAQ4KmnniIUCm26cGQsFuPdd99lZWWFa9euye63O7GAHBhhF3XjPR4PLpdLWtrXcp3Bl6poq9Uil8sRjUZZWlqS4ZL7HeF2FGMSiURkkQiNRiMtwcVikWQySSqVIhqNygCOVCqF2WymUChQKpXuCX4RWYaBQACn0yk1hf2g9TwsRqMRr9cr/egul0tqjt2Lwv2iNIVhTvzsZFDRgRF2g8HA448/ztmzZxkZGeHo0aOyx/hadDodbty4wdTUFFevXuX69eskk8ltMYzsBkajUTaB6Ovrw+12y2SMVqvFrVu3SCQSXLlyRQYDLS4uyuw2UVOu2WxKw103olWWx+OhUqnw7rvvylbOB3WFF16KTqcjYxWEt0IsHp1OR7onRfJUN16vlzNnzrC8vCy/g53iwAi76F92+vRp2Vtcr9ev2gvdPcPGYjEuX74sjSQ72YpnuxFqvPCnizxpuG1JTyQSTE1NceXKFd5//31KpdI92xThUru72CTcHu9QKITb7ZYtjURt+YMs7CIP4m5B7i7KKYS9O35eIGI9RLLLTrLvhV2Ee3o8HoLBoKxrptFoqNfrLC0tUSqV7mnZrNFoiEQiPP7447RarR1vxbObtNtt4vE4U1NTxGIxKaCbVcFFaKdY7Q6yCg+3i3kEg0HZMqubRqPBysoKtVoNk8mEwWCQUZvdsQrdTSLW22JuF/te2K1WK0NDQwSDQcbHxxkfH5fJCdVqlQsXLrCwsMDTTz+N3+9fJexHjx6VRqednmV3E5Fu+tFHH8nGlZvN1hMRYKLgpAgUOcg4HA7GxsZkYlQ31WqVqakpcrmc9AQ5nU7sdvsqoTaZTPh8Psrl8o7Xk997Rb82icFgwOv14vP5sFqtUnWv1+uyMEM0GiWTycjKKN3VVA8jYn/5oIII3aro3ZF0qqpSrVbJ5/Oy7dNBX927a+0JY2Sr1aJer1OpVGQw0v3G4+6WUDvJRopXDAD/kdtFJVXgT1RV/eO9Ujve7/fz2muv0dfXR19fH6qqUigUpGX517/+tSxCOTAwgNPpZGBgAKPRSDKZJJlMsry8fGgivjaC0IxEeLHoittNs9nk+vXrsna6KBp5UPfr6yEi4ubm5vjFL35BLBbjm9/8Jn19fffs1+G2ViUKUe70WG1kZW8B/1JV1RPAV4D/XVGUE+yR2vEWi0UWBhBdMUU3F5FQMD09TTQaldlXrVYLVVVlTbVisXjoblK4v2Yj6r+LGnV3+5JFk4iFhQVSqZTsE3eQV/a1xkvkYmQyGebn55mZmSGfz6/Kc+82EgsPx26UMNtIpZoYELvzd1FRlOtAH3ukdrzZbCYcDsuCiXA7JLG7T5uohd7f3y8zu1RVJZfLsbS0JCuCHhZEYtB6zRn0ej0mkwmn08nw8LCsOttNq9Vifn6eS5cuEY1GD6xmJOIJLBaL3Kt3lz0TTSorlQput5tOp0MoFCIQCKzKHhQCn0gkuHjxItFodMezJDdloLvTLOIJ4GP2SO14s9nMwMAAQ0ND8qYVHVij0aiMjRc3rqjx1Wq1ZCWQlZWVA3uzroVI5RV9x9cSdhFPPz4+zvHjx9dUR2dmZjh//vyafviDgggL9vv9sihktxCLvXq5XJZ2o/7+fiKRyKq9udi/x+NxPvzwQ1nMYyfZsLArimID/ifwL1RVLXR/+ferHb8TtdDXUpm6faJ3zuOeEkJ3P2e32eqxEhby7ugu+PIGHhoaQqfT3WONF/XUQqGQLP4hEIa9QqEgX7cb+QI7VWMfkL3sxFh2X6uQA4PBQDgcptVq4XA4VqUHdycZCZV/zzaJUBRFz21B/8+qqv74zuEN1Y7fqVroB4GtHCuxNxR76U6nI0sjGY1GXnjhBY4dOybbXHULuyh1HAgE7lHfRXpvIpEgnU4/cnnjh2Wn7itVVanVapRKJVkBt3tyE8E1gUCAU6dOYTab5aou6HQ6UsBnZma4fv06uVxux+sVbsQarwA/BK6rqvpvux7aE7Xjhfuj2WxK66eYVUWjAhEmutZr7179DgrCvSZ+Wq2WHA+tVitVToPBIB8XiDFzu93SviFoNpuygaFotXzQxq6b9eIJ7hZ2s9ksi3UK21G3RiUmjFKpRLFYpFwu7/i1bGRlfwH4R8BlRVE+v3PsX7NHasen02k++OADFhYWZG1uEZJotVp57rnnGB0dlcE2AlVVSafTzM7OHsg9e6VS4caNG0SjUSKRiOyiOj4+jtFolO2YNBqNbNUsEJOlyWSSOe/iBk8mk3z88cfSAHoYhF3U1ctms5TLZYxGowzC8vl8nDx5UvawE3747te3Wi2i0Sizs7PEYrFds29sxBr/HrCej2bXa8fncjk+++wzVlZW8Pv9hMNhLBYLkUgEu90uG+mJeGSBSO9cWloinU4fOANTrVZjZmYGvV7P8PAwXq+XoaEhGWMgfqxWK4FA4IHvJ5JAstksly5dkl6Mgx41p6oq5XJZtvSuVCqyPjwgu+Dc7/WtVotEIsHMzMyupgLv+3DZZrNJLpfDaDTKvuqtVgun04nRaKRer+Pz+fB6vTLjq1wuSx97JpO5p1HhQaLT6bCyssL169epVCr4/X5ZOddgMMh6+PcrmCjqmAu/ejqdJp/P79ma79uFKBtVrVbvKVa6FuVymZWVFQqFAlNTU0xPT7OysrJrE+S+F/ZyuSwDGUZHRzGZTLjdbkZGRmT8e6fTkb7RcrnM/Pw82WyWmzdvcvPmTZnZdRBpt9tcunSJGzduMDg4yPLysmxW6Ha7GR4e5vHHH78nsePu97h27RoXL17k1q1b3Lx5U06qh4nl5WV+9atf0dfXRzAYfGDh0kQiwZtvvkk8HufnP/85V65ckVb53WDfC7tYqQ0GA+l0mpWVFTQaDaFQSJZm6na5dTodKpWKNJIchtppotKr2WyW5YkVRaFer2M2m2U31/UQaqgo1S1Kdx02arUa2WwWi8VCpVKhXq/fk8baXSK6VCqRTCZJJBLSGr+b7Hthr1QqzM3NEYvFyGaznDt3jmPHjvH888/L+ujCOOX3+2Vjh2g0eqDy1zdCLpfj008/leq70WjEbrfLFsvrIRpYiuIe+63F1VZRqVSkge3q1as0Gg3ZRac7eGZubo6lpSWmpqY4f/48yWTykfu0bQX7XthFw0CAaDQK3K4MK8oxNZtNPB4PBoMBn88nI+eSySSVSuXAr+rdVCoV5ufnd/s09i3C2KvT6VheXpYhx/39/avcbKlUSu7RZ2dnyWQye6IC0r4X9rXIZrNcvXoVq9VKNBqVgu/3+8nn83z22WdkMpkDUWuux84h2n61220+++wzuXp//vnnq5p9zs7OsrS0JNX3vVJHX9nJlW2nIui0Wu2q/tndobKiGUJ3yaVd5KKqqk+t9UAv2nA1qqqum6K3U2PVHbAlGjqKPXs3ooKPiGLsbmS5E6w3VgdyZW+32wfWldZj9+jOudgLK/Vm2feVanr06LExesLeo8choSfsPXocEnrC3qPHIaEn7D16HBJ22hqfAsp3fu9XfGzd+d+veXxvrL7kfuMEvbHqZt2x2lE/O4CiKBfW8y3vB3by/HtjtTc/azvYifPvqfE9ehwSesLeo8chYTeE/U924TO3kp08/95Y7c3P2g62/fx3fM/eo0eP3aGnxvfocUjYUWFXFOWbiqJMKooypSjKrvSG2wyKogwoivKmoijXFEW5qijK/3HnuEdRlF8qinLrzu/1Kw4+3Ofuq3GC3lhtht0aq1UdVLbzB9AC08AoYAAuASd26vMf8pzDwJN3/rYDN4ETwP8P+MM7x/8Q+P8e5nHqjdXeHytVVXd0ZX8GmFJVdUZV1QbwF9xuDrlnUVU1pqrqp3f+LgLdTS3/7M7T/gz4rS382H03TtAbq82wS2O1o8LeByx2/b9059i+YAebWu7rcYLeWG2GnWyW2jPQbYC7m1p2P6be1rl6Lo079MZq4+z0WO2ksC8DA13/9985tqe5X1PLO4+v29TyIdmX4wS9sdoMuzBWOyrs54EjiqKMKIpiAH6X280h9ywbaGoJW9/Uct+NE/TGajPs0ljtnDX+joXxW9y2PE4D/5/dtopu4Hxf5LYq9QXw+Z2fbwFe4BxwC/gV4DnM49Qbq/0xVr0Iuh49Dgk9A12PHoeEnrD36HFI6Al7jx6HhJ6w9+hxSOgJe48eh4SesPfocUjoCXuPHoeEnrD36HFI+P8DSre7ZPllhdgAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 288x288 with 18 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fig = plt.figure(figsize=(4., 4.))\n",
     "grid = ImageGrid(fig, 111,  # similar to subplot(111)\n",
@@ -1272,83 +2114,73 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 117,
-   "id": "2078932a",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAIAAAD9b0jDAAACqklEQVR4nO2SPUhqYRjH33OOCeZbYAcySCoFQYxsEgkcPbW4ODgJUtCQi0NBIAoJjmcRHAzcJPADvzJBkAwRdEhsiAh0KeFkdsBUBMs0vYPhLTGty4XLhf7T+3z9eP68DwA/+idCUVSn00UiEZIk/xqUIIirq6ulpaV8Pj81NfUnCARBGAxGP8Rx3Ov1rq2tAQBcLpdCoRhPGIj5fP7R0dHr62ur1apWq7VabWFhAULo9/tfXl7W19ebzeb5+TmEcGZmZnp6GkJos9ni8fh7CGMAen9/DyGUy+VMJnN2dlYoFBqNxlAo1Gg0mEzm4+Mjj8erVCoURTWbTbVazWazi8XiePuHh4dbW1u9t9FotFgs/ZJMJnO73QAApVJJUdTu7u54XE9isfj29hZCyOFwLi8v5+bm+iUul5tOp+12u9frXV1d/YwwaB8AcH19HQ6Hd3Z25ufnj4+PS6VSL49hmEQiEYlEJycnBoOhWq1+dc2eeDxePB4vl8soivaTJElms9lMJrO4uDh6HB2apSiq1Wrl8/lOpwMAEIvFsViMzWbLZLJCocDhcEZDh9gHAPD5fAzD7u7uCILodrvb29tOp9Pj8bTb7aenp7H3Pxy6ubl5enqaTCYDgUC9XtdoNJlMplfqdDoIMnjdAxpiXygULi8vezyejY0NmqYvLi5ubm5+D6Bou93+NnR/fz+VSu3t7QkEAoIgcrmc0+mcmJh4s8ZgfBuq1+u5XK5UKkUQRKvV0jR9cHCQTqcTiYREIgEAsFiser0+GvpBSqUyl8sFAgGSJCcnJ9+XVCqVz+dbWVk5OzvDcXw058NH4ThO03QymbRarQN9wWDw+fk5HA4/PDyUy+WvronjeCwWM5lMnzUgCOJwOKLR6FeJAACVSmU2mzEM+8bMj/5v/QKdDw1VV/HIUgAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "PILImage mode=RGB size=28x28"
-      ]
-     },
-     "execution_count": 117,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "PILImage.create(\"stars/Star1.png\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b7878c7d",
-   "metadata": {},
-   "source": [
-    "I think this net is overfitted to numbers. But does that make sense? Shouldn't just... features to features create the appropriate cosine distance between star and star?\n",
-    "\n",
-    "Or, maybe it's that the best diagnostic is: \"OK, return the top 3 returns in the top 3 categories.\" So you'd get \"8\"s and their <0.04 distance, and you'd get FPS1 at 0.04, and then you'd get the top (whatever) "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 118,
-   "id": "505af5ed",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(10001, 128)"
-      ]
-     },
-     "execution_count": 118,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "fps = np.array(list(fingerprint_db.values()))\n",
-    "fps.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 119,
-   "id": "d90157da",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def train_and_fingerprint(epochs, learning_rate, files_to_fingerprint) :\n",
-    "    learn.fit_one_cycle(epochs,slice(learning_rate))\n",
-    "    fingerprints = fingerprint_all(files_to_fingerprint)\n",
-    "    \n",
-    "    return (learn, fingerprints)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 120,
+   "execution_count": 34,
    "id": "5a7928da",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T14:05:55.426524Z",
+     "iopub.status.busy": "2022-08-16T14:05:55.425462Z",
+     "iopub.status.idle": "2022-08-16T14:06:15.832314Z",
+     "shell.execute_reply": "2022-08-16T14:06:15.831317Z",
+     "shell.execute_reply.started": "2022-08-16T14:05:55.426500Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[t-SNE] Computing 91 nearest neighbors...\n",
+      "[t-SNE] Indexed 10003 samples in 0.000s...\n",
+      "[t-SNE] Computed neighbors for 10003 samples in 1.824s...\n",
+      "[t-SNE] Computed conditional probabilities for sample 1000 / 10003\n",
+      "[t-SNE] Computed conditional probabilities for sample 2000 / 10003\n",
+      "[t-SNE] Computed conditional probabilities for sample 3000 / 10003\n",
+      "[t-SNE] Computed conditional probabilities for sample 4000 / 10003\n",
+      "[t-SNE] Computed conditional probabilities for sample 5000 / 10003\n",
+      "[t-SNE] Computed conditional probabilities for sample 6000 / 10003\n",
+      "[t-SNE] Computed conditional probabilities for sample 7000 / 10003\n",
+      "[t-SNE] Computed conditional probabilities for sample 8000 / 10003\n",
+      "[t-SNE] Computed conditional probabilities for sample 9000 / 10003\n",
+      "[t-SNE] Computed conditional probabilities for sample 10000 / 10003\n",
+      "[t-SNE] Computed conditional probabilities for sample 10003 / 10003\n",
+      "[t-SNE] Mean sigma: 0.021153\n",
+      "[t-SNE] KL divergence after 250 iterations with early exaggeration: 69.586418\n",
+      "[t-SNE] KL divergence after 1000 iterations: 1.319757\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAegAAAHSCAYAAAAnsVjHAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAB330lEQVR4nO3deXxU1fk/8M+ZJcmQQAYkIQthC1sA2UwBi4DiLiLoV0FrW7QutS5F7Q/FHRUrVqvSzdZqK7Yq4gZitIogiAtoIKwJW8KaBBKWSUiYSWY5vz/u3MnMZPa5M3eZ5/168SJz5+beM0zIM+ec5zyHcc5BCCGEEGXRyd0AQgghhHRGAZoQQghRIArQhBBCiAJRgCaEEEIUiAI0IYQQokAUoAkhhBAFMsjdAG89e/bk/fr1k7sZhBBCSNJs2rTpOOc8x/+4ogJ0v379UF5eLnczCCGEkKRhjB0MdJyGuAkhhBAFogBNCCGEKBAFaEIIIUSBKEATQgghCkQBmhBCCFEgCtCEEEKIAlGAJoQQQhSIAjQhhBCiQBSgCSGEEAWiAE0IIYQoEAVoQgghRIEoQBNCCCEKRAGaEEIIUSAK0IQQQogCUYAmhBBCFEhR+0ETQpKnaeVKNLz0Mhz19dBnZ8PZ2grY7Z7nWZcuyH9yAbKnT5exlYSkLkl60Iyx+xhjOxljOxhj7zDGMhhj/RljGxlj+xhj7zLG0qS4FyEkfk0rV6L+scfhqKsDOIfTYvEJzgDAz5xB3fyH0LRypTyNJCTFxR2gGWOFAH4LoJRzPgKAHsD1AJ4D8BLnfCCAUwBuifdehJD4Na1cibr5D4HbbOFPdjrR8NLLCW8TIaQzqYa4DQBMjDE7gC4A6gFMBfAz9/NLACwA8IpE9yOEBNC0ciXqn/k9uMUCANCbzej1yMMAIAxn19VFfU1Hfb2UTSSERCjuAM05r2WMvQDgEAArgC8AbAJg4Zw73KcdAVAY770IIcE1rVyJuoceBhwOzzGnxYK6B+eD6fXgfkPYkTLk50vVREJIFKQY4u4OYAaA/gAKAGQCuCyK77+dMVbOGCtvbGyMtzmEpKyGl172Cc4eLlfMwRkAsqZMjr1RfuqffBJVw0egamgJqoaPQP2TT0p2bUK0RooksYsA7OecN3LO7QA+BDARgJkxJvbQewOoDfTNnPNXOeelnPPSnJwcCZpDSGpK1FB0y7qvgz7XtHIl9k69EFUlw7B36oUhE8rqn3wSlneWAk6ncMDphOWdpdh35ZVSN5kQTZAiQB8CMIEx1oUxxgBcCKASwFcArnWfMwfACgnuRQgJgmVnJ+S6gQJ/08qV2DPhXNTNe8CTCe6oq0PdAw/iwM03BwzalqXvBry+fV819aQJCYBxzuO/CGNPApgNwAGgAsCtEOaclwLo4T72c855W6jrlJaW8vLy8rjbQ0gqqX/ySSH4SfB/ORDWpQu41Rrz9ZnRiPzfP4O6eQ8EP0mvR8nOHTG2kBB1Y4xt4pyXdjouRYCWCgVoQsKrf/JJWJa9JwwVM5awwCwlvdksrLUOoeD5P3gKpxjy85F7371UJIWkBArQhGiAZx5XaxgDMxg6J7O5P4AYCgooYBPNChagqRY3IQoSLunKsuw9mVqWYJwHzjR3dyAcdXWom/cADtx8c5IbRoh8KEATohAHbr65U9JV/WOP+wZpMQNaZZjZLMl1rN9voIQykjIoQBOiAAduvhnW7zd0Os5tNsWX2mRdugC6EL9KDAbku6uZScHyzlIK0iQlUIAmRGZNK1cGDM4ixZbaZAyAkABW8NwimM6d0OkUQ0EBzNddi/pnfi/prSlIk1RAAZoQGTWtXIm6Bx4MeY4hP98zN60Yen2n+WFr+SaAMRgKClDw/B9QsqsKWVMmw/LOUk9tcClZ3lkaUYEUQtSKsrgJkUnTypWof/iR8GU4TSbAak1OoyTCMjKQffXMpGWcs4wM5D/9FGV5E1WiLG5CFKbhpZcjq5GtsuAMCHPnyVwOxm021M17AFVnj6TeNNEMCtCEyESxc8tqZrejbt4DFKSJJlCAJiSBQu3eRNs4Jo7SM98JiQQFaEISJNjuTWKQzr3vXjCjUcYWapejro62tCSqRwGakAQJVvVLPJ49fTryf/8M9BIV8SAB+H0oIkRNKEATEoWmlSuxa8K5Qu9saAn2TDjXZ77Tu1Rn0KpfXsezp0/H4A3fw3zD9QFPNQ4shqGgQNLXkIqCbXVJiJIZ5G4AIWrRtHIl6h56GHA4PMecFgvq5j2AunkPCNsynjkT0bWqhpYAEKpw5T+5QDjotzOV+Ybrkf/EEx33DrVdYzh6PVhamrBtZCpS0HJSQiJFPWhCItC0ciXq5j/kE5z9RRqc/b+nbt4Dwlx1ooKIToeCRc+C22yJuT4hJCEoQBMSRtPKlah/7PGkb1QhzlV77h8rlwv1TyyAPjtbopapkMkkdwsIiRoNcRPi1rRyJeoef6KjMAhjMF8/Gy3rvpan9+l0omnlSqGgSZz352fOwBlJURQtYgwFT1GSGFEfCtCEwKsmtvcwM+dJrYYVSKc2xSMVA7T7QxaVACVqREPchMBd2EKJiURKbJOacA7Le+9TZTGiStSDJgRUdlPTHA7UzXsApz78EPaDh+Cor4chPx9ZUybj+MpPoW9pBgCcTuuCltvm4sJ7filzgwkRUA+aEFDZzVRg/X4DHHV1AOdw1NXh1DtLYWhpBgPAAHRrP4Oef3sOq//8ptxNJQQABWhCAAhlN0lqYQGOpXEX0t74e9LbQkggFKAJASiJiHj0aD0ldxMIAUABmhCSDCxQf1WZTmZ2l7sJhACgAE0ISQaVZKNzAO033SF3MwgBQAGaEEJ8UBY3UQoK0IS4sS5d5G4CkZmOtv4kCkIBmhC3/CcXAHq93M0gMsq+/DK5m0CIBwVoQtyyp09HwaJnwQL1ovT6wMeJprSs+1ruJhDiQQGaEC/Z06dj6IbvUfD8H2AoKAAYg6GgAAWLnsXQDd8Lx9TAaJS7BapEFeWIklCpT0ICyJ4+PeDa6Nz77kX9Y48rf2/lVNwYQwJUUY4oCQVoQqIgBu2Gl14WelsZGR3bUxJ1MxioohxRFBriJiRK2dOnY9Ca1SipqkRJxWaYb7he7iaRaPkVTmFmMwqe/T1VlCOKQj1oQuKU/8QTsu8bTSLHdQzDKivlboZsymrKsHjzYhxtPYq8zDzMHTsX0wZMk7tZJADqQRMiBVqepR4udVQ1S4SymjIs+G4B6lvrwcFR31qP+evn4+wlZ2Pcf8ehrKZM7iYSLxSgCZGAedZ1CbmuPsWWdjGTKeH3aM/tmvB7KNXizYthcwZOcLQ6rXho/UMUpBWEAjQhEsh/4glhLjrYphA6XdS9bJaRAZcEbVMNgwFITw/+fAwbbvj3lZ3pBmTc86uor6MV9a2hl5FxcCz6YVGSWkPCoQBNiETyn3gCJVWVKHj+Dz5FTfRmMwqeW4SCRc961lZHEqy5zQZusSSuwQoiJmnxpqbgJ0W74QZj0D09F225XcEZ0JbbFYZH78LQ61JzM4xIe8aWNgsWbliY4NaQSDCuoF1mSktLeXl5udzNICThqkqGqWaHJ0no9TDPug4t676Go74ehvx85N53b6es6b1TL4Sjrk6SWxoKCjBozWpJrqUFl7x/SdgetLfZQ2bj0QmPJrBFRMQY28Q5L/U/LkkPmjFmZoy9zxjbxRirYoydyxjrwRhbxRjb6/6bNlklxC0RBTGUWuWMdemCgkXPIv+JJzzL0watWR20EAwLVAXNEOWCE8ZoTbOfaIIzALy3570EtYRESqoh7sUA/sc5HwpgFIAqAPMBrOacDwKw2v2YEAIhEEUddEJgGRmJD0jeQ/N6ffiELr0eJbuqMHTzpojXF2dPn4783z/jkxwnDn9HzGRCwR+eozXNEIa1L3n/Epy95Oyov9fFXZ2GxcXrjVwyEpe8fwkllCVY3EPcjLFsAFsADOBeF2OM7QZwPue8njGWD2At53xIqGvREDdJJU0rV6Ju3gNRf5+hoAC5993rqWbmPVx84OabYf1+Q3QXNBph7NsH9n3VIU8z33A98p94wqf9ocqe+p8fr6qhJUGf05vN6PXIwxSUvZTVlOGxbx+D3RV72VcddMgwZOCM40zA5w3MgIXnLaR11HEKNsQtRYAeDeBVAJUQes+bAMwFUMs5N7vPYQBOiY+DoQBNUs2useeAnwn8yy8ggyFsxatogrTp3Ano9+9/h/4+9/xxoGDbtHKl8EHBe944xPnx2DPhXDgDJM2xLl0wdPMmSe+lBZOWToKlzZLw+2SnZeObG75J+H20LJEBuhTABgATOecbGWOLATQDuMc7IDPGTnHOO81DM8ZuB3A7APTp0+ecgwcPxtUeQtQkml40M5uRH2Uvsf7JJ2FZ9h7gdCYscCZL08qVqH/4EXCvjUCY0Yj83z9DPecAYhnWjtX2OduTdi8tSmSAzgOwgXPez/14EoT55oGgIW5Cwqp/8sngpUIZg/n62aoNqlLz9NhDZIITQTIDdBdDFzx+7uM01B2jYAE67iwVzvlRxthhxtgQzvluABdCGO6uBDAHwCL33yvivRchWpT/xBPoMnYs6p/5vWfdM82pBhZsG1DSWXZaNpraQ6wrl9AZxxk8tP4hAKAgLSFJ1kG756FfA5AGoAbAzRAyxJcB6APgIIBZnPOToa5DPWhCCJFGWU0Z5q9P7uIZmo+OTcJ60ADAOd8CoNPFIfSmCSGEpIBk9dhTBZX6JIQQjRF3rSLqRgGaEEI0JtSuVUQ9pCtlRAghJCkWbliI9/a8Bxd3Qcd0uG7wdT51s4+2HpWlXeZ0syz31SoK0IQQoiK3fX4bNhztKCjj4i68u/tdrKxeCavDCpPBBN5po83kmD+OKjpLiQI0IYSoRFlNmU9w9iaW4wxWlpOoD81BE0KISizevFjuJoQ0f/18TFo6iTbRkAgFaEIIUQm55pajYWmz4LFvH6MgLQEK0IQQohJ5mXlyNyEidpdd8b19NaAATQghKjG592S5mxAxNfT2lY6SxDRm3du7sPObOnAXwHTA8PMKMOVnQ33OWfHSZhzZbfE87j3EjBn3jU1ySwkh0SirKcOKferZ0oAxhrKaMqrNHQcK0Bqy7u1d2PF1x7683AXPYzFI+wdnADiy24IVL20OG6T3bDyK71dUo+VkG7J6pOPcGcUYPF4dQ26EqJ3aio+4uMtTzYyCdGwoQGuId3D2Py4GaP/gLDqy24IlD38bNPj6B/+Wk21Y9e9K1FdbfHroFMQJkU5ZTRkWb16Mo61HZVvbHA+b04bFmxdTgI4RBWiV8w6Iofz1jjVgYTIOxGv4B989G4+GDP4APOetfrMKLif3XGf1m1UAQEGakCiJ9bTV1GsOhOaiY0cBWsX2bDyKL9+sBHdGdj53RXf9HV/XIb/YjO9XVIc9DwB2rK+D/4d8l5Nj7du7MXh8XkTz44QQgdqGtINRS+a5ElGAVrGvl+2OODjHKpLeORB8eB0A7G1OvHLXV56eNRB4fpwQ0kErPc+5Y+fK3QTVomVWKtbWmuDoDHjmkuPlHZy97VgfPLATksq00POcPWQ2zT/HgQI0CSuSHnTMuJCARgjxNXfsXGToM+RuRkzyM/OxaNIinx22SPRoiFvFMjINsLU65G5G3MS5bkokI6SD2PN8duOzaGpvkrk10fni2i/kboImUA9axXr2zpK7CZIJl4hGSCqaNmAavrnhG2SnZcvdlKgs3LBQ7iZoAvWgVSbSZVVq03KyDX+9Yw3SM/WYPGsI9aYJcSurKQNjTO5mROW9Pe/R8LYEqAetIns2HsVXb+3SXHD21tbqxKp/V+Kvd6yhuWmS8spqyvDoN4/C0maRuylRcUW7ppMERAFaRb5fUQ1He+r84O/4uo6CNElpz258Fg6uvjwTXbiqSCQi9K+oEns2HtV0zzmYnd/QMiySutSWHCa6bvB1cjdBE2gOWuH2bDyKNf+pgtOhvjq8UqCRMpKqymrK5G5CTIq7FdP8s0SoB61gezYexZdLUjc4i95e8L3cTSAkqcQ63Gq0//R+uZugGRSgFez7FdXgrtQOzgBw6qiV5qJJyli4YSHmr5+v2jrclCAmHQrQCpaKc87BhKr1TYhaLNywEKPeHIWzl5yNUW+O6rReeOGGhXh397sytU4alCAmHZqDVrCsHukUpAlRuLKaMiz6YVGnpVD5mfmYO3aupyKYf/B1cZfnsThn+96e95LT6ASiBDHpMM6VM4RaWlrKy8vL5W6GYohz0DTMLbjr71N9CrVkZBrAwdHW6kRWj3ScO6OYCpyQpCqrKcNj3z4Gu8se8rzstOygGdk6psPWX24FAJy95GzJ25gsOqbDdYOvowSxGDDGNnHOS/2PUw9awcRgs/bt3bC3JX7nKqXz37LSuw55y8k2fPWWME9NQZoky+LNi8MGZyD0cinvOVsd06luDteoM+LpiU/TrlUJQJMFCjd4fB5uXzwFd/19Ki6+eRiYXu4WJQ7TAYa04CUNg21ZKXK0u6imN0kqKfZs9p6zVdvwsDndTME5gagHrTIGgx52pzZ709wFDJ2QH1dCGM3Zk2TKy8xDfWt9XNfwDsrec9Eu7lJkj3rRpEUUkJOE5qBVQqzDrfVSn4Y0HQAOR3vsP5dZPdLRb8RZ2LvpGNpahQ8zGZkGTJo1mIa/iaQinYMWMTAwxjzBN9ScbVlNGRZvXhz3BwCpbZ+zXe4maA7NQatcqtThluI1tpxs69QLt7U6sOqNSgA0R02kI/YkA2VxB8LBse2X28KeJxYqUeJa6Evev8QnO50kDs1BqwQN3UqAA18v2y13K4jGTBswDeuvX4/tc7Zj0aRFMOlNQc/Nz8wPe72ymjI8/M3DigzOAFDfWo8F3y1QbSlSNaEetErQmmhpiEPehCTCtAHTMG3AtIA94Ax9BuaOnYvbPr8NG45u8Bw3MiMc3IG8zDxM7j0ZK/atUNy8sz+b04bFmxdTLzrBqAetEufOKHbPzxJClG7agGlY8NMFyM/MBwNDfmY+Fvx0Af659Z8+wRkA7NwODo761nq8u/tdxfac/UmRwU5Cox60SojzpmKRDhIbY3p069TWvb0LO7+pA3cJy8CGn1eAKT8bGvQ4ISKxNy0qqylDdbN2lgHmZeZ5EtmOth5FXmYezU1LjAK0igwen4fB4/Pw1zvWyN0U1dJF8RO/7u1dPslm3CXUBN+5vg7eix/E4wAoSJOgFm9eLHcTJNW3a1/MXz/f81icmwZAQVoiFKBVZs9GGlaKR1urE3+9Y42nNCgQ/ahEsJWJO76ug+XYGcy4b6wUTSUao6Uh4eJuxZ2G6gGam5aaZJOajDE9Y6yCMfaJ+3F/xthGxtg+xti7jLE0qe6VqvZsPIov36yUuxma0HKyDaveqMSXb1ZKOmVwZLcFK17aLNn1iHbkZWpjed+EvAkhh+rrW+s77dJFYiNl1tFcAFVej58D8BLnfCCAUwBukfBeKenrZbvBKQlZOhwJ+fc8stsi/UUV4sS3/4X1uRLwBWZYnyvBiW//G/9Fty0DXhoBLDADz/UX/iwwC8e2LYv/+goxd+xcZOgz5G5G3AL1nP29u/tdCtISkKSSGGOsN4AlAJ4BcD+A6QAaAeRxzh2MsXMBLOCcXxrqOlRJLDSae1YfLVUwO/Htf5G9+ncwuDqyjDkAru8C3YzFwMhZ0V902zJg5W8Bu7Xzcxmjga6XAgYzkNUVGDceGDQ41uYrQllNGR795lE4uCP8ySrnvUsXCS3RlcReBvAAgK7ux2cBsHDu+Sk8AqBQonulpHVv75K7CSQGtlYHVv27EvXVFvUlkG1bBqy8F7C3AgB6APDfyoQBYM4zwIe3AYc2AFe+GN09Vj8VPDhnXwPo3DNjLS3A1+uEr1UcpCsaKlIiOAPCLl0jl4yk7O44xD3EzRi7EkAD53xTjN9/O2OsnDFW3tjYGG9zNGvnN7FvIEHkt+PrOnUl+G1bBnx4uyc4A52DcyflrwOf3B/dfZqOBD7e9dKO4CxyOIAfNkZ3fYV5b897cjchqcT13VR5LDZSzEFPBHAVY+wAgKUApgJYDMDMGBN76L0B1Ab6Zs75q5zzUs55aU5OjgTN0SaFFxYiEVDVVpifPQhhADtK5a/7zhtvW+aeU84W/jzX3/f57N6Br6M3Bz7e0hJ9mxSirKZM8RXCEkXM7ibRiTtAc84f4pz35pz3A3A9gDWc8xsBfAXgWvdpcwCsiPdeqYxRETHVU1WBGevJ2L/3sweFv7ctA5bf6Xst60lgxV0dQfrCxxGwb+60BL52Vlbs7ZLRbZ/f5rNmOBVpaZlZsiTy1/6DAO5njO2DMCf9egLvpXnDzyuQuwkkTlk90uVuQnJYTwoBePVTQKBtGJ3twnPiOYF66qc/B1ztvsdc7UKimMos3LAwosxnrdPKMrNkkrRQCed8LYC17q9rAIyT8vqpTEww2rG+LqaRRyI/sTCKKph6xNeLXnGXEIiDaTosJJYFY9si/N31UmG422kRgvagubG3SSapNu8czOTek+VugupQJTEVmfKzoZjys6G03EqlVLXU6vLnhOHpQD3gSIQKzpGybekI1CqWqvPO/r4+8rXcTVAdmtnUKNr5SllUl0MwchYw829yt0ITdKp78xOjvrVe7iaoDv3kaFBWj3RccONQ9QUFiRjSwi4ISjpV5hCMnAXoFVahN9plXApw3eDr5G4CUSka4lahjEwDbK1Bih0wYa5THE5d9e/Uqt0tboLx5ZuViiiLqoqtKMVkrabDANML9U+zi4AeA6QZqpbSpn9HXwxFJgs3LMSy3cvAKWmExIgCtApNmjUYq9+sgsvp+x+f6YGLfjnME5wHj8/D2rd3w96mgEiVJC0n2xTxoWTEZIUHZdG2Zb4JXeKnmqbDwh+l4S6hzbGUFU2ihRsW4t3d78rdDEVh4UvdED8UoFVIDMDiNolirzFQEtL5PxsSMJiTxDGkMXUEZ0BYs6y0XnI4H94eW1nRJKLM7c60sFFIslGAVqnB4/Miygr2D+ZaxHTKqbRmSNPhghtVEpyB+JZSyYYD5f8C+kxQbE+aMrc7szlt4U8iPihApwDvYL7ipc2a2g7RkKaDo13aX4b6NAZne/QjDumZekyeNURdy6lUiwvz5goN0KQzKlQSvRTN801dM+4bi95DzD7Heg8xdzqmZMZ0PYCObPX0TL2k17/jTxfg4puHISOz4/OrPkxmeEamAbf+cYr6grOaU/2DbbRBFCdDn4G5Y9VXZEZu1INOQTPuG4s9G49i/bI9sLU6cGS3BemZelx88zBVDIWLSW+JTAgLNIWw7u1d2PF1gF3FmJC4p0pqHooNttGGAuRn5gdd92tkRth5jAVgVIiBYcFPF9B2kzFQ8cdnEqs9G49i1b8rfZZqtbU68eWbleg34iwwaTukqhKqQznlZ0MxYnKBz94OhjSGi28apr6esyi7SO4WxO7Cx+VuQVBzx84NmhSVSsEZELacpOAcG+pBp6DVb1YFPM6dwIEdJzB8YkHgnmIKCNehFMutqp732mcwqLLAu4Lnn8WAtHjzYqqgRWJGPegUFGrJVcvJNhzYcSKJrVEWcX5b07YtA5bf4bXO2evnQc1z0gozbcA0fHHtF3I3g6gY/W8kPrJ6pCt+DjqR7G1OrHhps9zNSIxty4CXRgi7SLkCFK/RpwEGlWyJaeohdwtIhGYPmS13E1SLAjTxce6M4tTZtziII7st2LNRxZvLi4F4gVn4e9sy4c/K34auDuZsB+zWpDUzZjqjsNuWSpjTzXI3ISmy07Jh0ps8jxkYZg+ZjUcnPCpjq9SN5qBTUO8h5oBrobvnmTzJTl+9tUvy9cVq8v2KanUmfvmX7mw6LDxOy1JH8A0nu0hIDlPw/LO/+ePm47FvH4M91q07VaK5vRnb5myTuxmaQj3oFBRsLfTPFpwLQFhilMq7YQFQ7zB/oNKdznaVVgzzk10E3LdDVcFZZGDa7wtRIRLpaf+nhgQ0476xIZ+PpCet0zNwcEXsGiU11Q7zayEQB6IzKnpZVTCpsmmGgRmoEEkCpHAfiYQj9qTFYJWeqfdU18rqkY4Lf1mCzGyVBrIQDGk6nDujWO5mEG/pXVXXcy6rKUuJ4Jydlo2F5y2ktc4JQD1oElK4TTliquTFgBGTCnBgxwnZh5LFrHVxw41QO4Mp3pKr5G5B4lhPAk92D7xQPS0TuPJlxQXwZzc+K3cTOpGqiplRZ8TTE5+moJxgFKBJXKJdluW9ocQUAEse/la2IJ3VIx1zfj9RlntLbslVwP51crcisYJVkWlvFbagBBQTpMtqytDU3iR3M3wwMEmCszndjPnj5lNwTgIK0CQu584ojjjje8Tkgk5VuOQKzpoZxvbP2k5ZXEiQU0iAXrx5sdxN6ITHUC1Ox3RwcRfyM/Mxd+xcCspJRgGaxCXS/aa755kClsgM1wOPdevHUDIyDZg0a7A6h7G9bVvm7jmqsExnIigoQe5oq/rW0TMISZ86psN1g6+j9csKQAGaxM17nnrPxqP48s1Kn8zu3kPMQbPGz51RHHQeW5wPjnqeO0hpaWO6Huf/TEP7NX/2IDQTnHVpgEs7owB5mXmqqsFd3K0Yy69eLncziB8K0ERS4ZLKAp1fX23ptDmHOAQ9eHxeRAFaE0le0VJQjzFueiMADsRTzENB5T8n954sawZ3dlo2GGOwtFkiOp+CszJRgCaym/Kzobjxdxej9ugR3yf+3PncHlm98NSNb3seG9J0uODGoakRkKOmol2q7K1AVj7QEmOvU5+mqPKfXx/5WrZ7Z6dl45sbvsHIJSMjOj8/Mz/BLSKxonXQRBFqjx4B5zzon7VvVeGvv1mNky3HPN+T1SM9tYNz2B6jSoKzKNbgzHTAjL8qJkEMkHcOWswej7SyFxUYUS7GuXL+E5eWlvLy8nK5m0FkwBiD98+i2WwGAFgslpDnpbRty4SdqVLdNf9UVHAGgEvev0TWOejtc7ajrKYMD69/GC4EX2FBm1koA2NsE+e81P849aAJUSuFBSXZKPDfYe7YuTDqjLLdv6ymDNMGTMPvJ/0eabq0Ts/nZ+Zj0aRFFJwVjuagiaKIPeempiafx/49aUIAKCoxzJu4XnjRD4siTtSS0uLNizFtwDTPH6JO1IMmRM2yi+RugbwUlBjmb9qAaVh//XrMHjI76feub61HWU1Z0u9LpEUBmiiKxWKBxWJBdnY2srOzPY9JEBc+DhhNcrdCHqW3KHJ429+jEx6VJUgv+G4BBWmVowBNiJqNnAWM+hnA9HK3RHqltwgJYJ0+gDDhuStflKVZEdm2DHhpBLDADLw0Ao92GYztc7Zj0aRFSWuCzWlTZMlREjmagyaKRL3mCG1bBmx9G5rblNs/AK9+Cmg6AmT3FkYNlNxz3rYMWPlbwG4VHjcdFh4DmDZyFpbvXY4NRzckpSlqLDlKOlCAJkTNVj/VEQi0wtTDNziPnKXsgOwv0HtitwrHR87CzEEzsenYJkl2lgon0rXQRJkoQBNF6Nu3LxhjEZ1HvDQdCX+O2ig48SsiQd6TMsdJPPXWeJxxnElaU6gIibpRgCaKcODAAbmboE6m7hqryZ2urt5yINm9hWFtL2WZXfBYTg/YkxicZw+ZTUusVI6SxAhRq23LAJtF7lZIiAEz/iJ3I+IXILN+cY/usEcwQhSt7LRszB4yG9lp2Z5j5nQzFSHRCOpBE6JWq58StvDSDI2UcBVHALwS244aAgfnnxgn4uqMG9BDdxZOuk7gI9s7+NH+bUS3MelN+OaGbwCAgrFGxd2DZowVMca+YoxVMsZ2Msbmuo/3YIytYoztdf/dPf7mEkI8tDj//OFtwCf3y92K+I2cBdy3A1hgAe7bgbwAO0b9xDgRv+hyO87S54AxHc7S5+AXXW7HT4wTw17eqDPiiZ8+kYCGEyWRYojbAeB3nPNhACYAuIsxNgzAfACrOeeDAKx2PyaESCW7t9wtSIzy14Xhew0JVJv76owbkM4yfI6lswxcnXFDyGvlZ+bj6YlP0/xyCoh7iJtzXg+g3v31acZYFYBCADMAnO8+bQmAtQAejPd+hBC3Cx8Hlt8BuDS2BhoAPntQ/cliXsRg+tD6h8DdQ/k9dGcFPDfQ8fzMfMwdO5eCcoqRNEmMMdYPwBgAGwH0cgdvADgKoJeU9yIk5Y2cBYy9Se5WJIaWMtPdpg2YhmcnPet5fNJ1IuB5/sdnD5mNL679goJzCpIsQDPGsgB8AOBeznmz93Nc2MA3YAYIY+x2xlg5Y6y8sbFRquYQon1iFTGiGtMGTPPU5f7I9g7auM3n+TZuw0e2dwAADIz2a05xkmRxM8aMEILzW5zzD92HjzHG8jnn9YyxfAANgb6Xc/4qgFcBoLS0VCNpnIQkgRariIkUuo2kFB6d8CjG5I7BQ+sfAs6gUxb3Xt1ObJ+zXe5mEgWIO0AzofzT6wCqOOfe1es/BjAHwCL33yvivRchxIsWs7hFaq8mFoY4XP3Yt4/hx9Mdy6qMOiOenvC0XM0iCiPFEPdEAL8AMJUxtsX95woIgflixtheABe5HxNCpKLELO7sImEHqnioZBvJeE0bMA1PT3wa+Zn5YGCUnU06YcL0sDKUlpby8vJyuZtBiLJtWyZkOQdMpNIBkKt4CQOueVUIrgvMiKnwSP8pwJyPpW4YIYrGGNvEOS/1P06lPglRk23LgA9/HSQ46yFfcAZ8AnLpr6L/9p5DKTgT4oUCNCFq8tmDCB6EFbAeevVTwt9XvigMVSOK+tN3b0xIkwhRKwrQhCjdtmXAc/2BBdnKXx/snbh25YtCqctI5qT7T0lYkwhRKwrQhCjZtmXAiruUH5hFgRLXRs4SkseCoXlnQgKiAE2Ikq1+CnC2y92KyF34ePDjflswwmgSetcUnAkJiAI0IUr1yf1A02G5WxE5U4/gy6NGzgKm/8ndk2bC39P/lBLLqQiJFe0HTYgSfXK/sKuTWhhN4YuLjJxFAZmQKFAPmhAl2vSG3C2IDvWGCZEcBWhClIgrYMlUpJiegjMhCUBD3IQoxbZlQlKYXDW2dWmAK4aEtHNukrwphBAK0IQog7icSs6M7ViCc/8pwnpnQojkKECT2O3dA3z7LdDm3tM2PR2YeB4waLC87VKjzx5U13KqtEzgypdpaJuQBKIATWKzdw+wZrXvsbY24Ks1wtcUpKOjhkIkTAdwl7BE6sLHKTgTkmAUoEl4e/cAP2wEWlqArCxg3PjOwVnEudCrpgCtLUzfkbjWdBhY+VvhawrShCQMBehE0cLw7/p1QGWl77GWluDBWdRmE16/ml4rCc0/q9xuFYblKUATkjAUoKXi3ctMTwfa24XepKitzTew+fdIYwlmgXq28QbF9euAqirftsfih40UoCO1bVnH8LGaWE8KbacgTUhCUICWwt49wtyrGNTa2oKfu24twBjgcAiPW1qAr9cJX++qAurqOs4tKACmzwh+T++A792zjTUwBuoxx6qlRZrraNm2ZUIvVA3zz8GsfooCNInZlpom7G+w+Rxj6NhZnAHol5uB0QOyk900RaAAHY9YApozQAEKh8M3wIvq6oCVKwIH6XXrAl//qzWhA3SgXjfgOxwvhaws6a6lRduWCfO4dqvcLYmPXGu2ieoFCs5AR3AWvxbPScUgTQE6VlL2NoHgQ8p1dYGDqtMR/Dr/eEXopXPuO/Tt39MXe93iuVLq00fa62nN6qeiC846I9CjGDi+K3FtikWg7SUJicCBAME5mP0NNpzVNQ1FOaag5xxutGLn4RZY210wpekwvCgr5PlqQAE6VlVVybuX/1C2uJQpFO8gLA6hf/tN4EAsdXAGgD17gLx8mocOJpqepzETmP6yMJSstE00gm0vSYgf7wCqY7495UiUVzejvLoZPbsaMGn4WZ2uXbG/GU53Goe13YXy6macON2u6p4344n45Ryj0tJSXl5eLnczIvOPV+RuQXSyspI/LxyoF08EL42IbitJMYnMe7mTEixokrsFRAX8A2i8/IP0/zY3wtoe/OKmNB3yzGk4amlXZA+bMbaJc17qf5x60LFKxLBwIsmRtBWoF09BWjDokuh6wmKGt5KCc+ktcreAyMh/SDlUANx5uEWy4AwAx0/7TvGFCs7i897z3WIPu7y6GYByk9EoQPuLdOlSSYm0c9Ba53DQ0ivRtmVAxX/kbkUcGFD6K6rBnaION1qx9UAz7F6fFQMFwM01QvAryjGFDaDxMqXp4rqHmIx2oMHmGXo36oFR/brJ2sumAO1t7x6hp+e9BGrNauFPVpaQ+HToUEfwLijwXRZFQqOlV4LVT6mr7rbIaNLWvs/1FcCeTwD7Gd/jGWag+BIgf0zwcwwmYMh04RwN21LT5BO0vJdAhePiwCavXmoi5ZnTAmaER8v7tdmd8Oll95ehh00B2tsPGzuCs7+WFt8ec0sL0NqanHZpBS29EqhlaRLTCYHIfkbI1tZS/e36CqDyg8BTBjYLUPURYDkI1JUHPsdhBXa+L3yt0SAdaBlUtJN6iZoE7Nm1I3QdbrTi0HEJl4gGIcdyLwrQ3qLt4alpDloJxDXXqS67d3QJYnI5azBw90a5W5EY1V+Ens932YHaHxA6xLiE62g0QEezDCqZstKZT4KY1PPboexvsFGAlsXePepL/FKTggKafwaAJVepIzgDyltzLSWbJYKTIvhdENF11EnO34RGvTBE7h94Aw0zJ3p+W04UoIGOuWcKzon11n+krRuuNkuuAvYHqQBHkosZAW6P/zoZ5vivQTqxO4UgrTcwtDt4yGVR8SaIKRkFaCD03DORhncynXexlVQK0hSck6e+QphHdnkFYWYEhl0tzC1LEZwBIZlMg9bvPCF3E2B3AgwcpcWhM6mHF2UlJRFNDqkboKXatYnEhnMhO/6HjanZm1aDnkPlbkFs6iuAne+h0yAttwM7l0l7Lw3NP3uva1YKDmDrgeaQAfrE6eSuiPh44zGMGZCc5VfaDtDBNoZYty54LWuSXFTERJl6DlVvglj1F0jaDGrVcqBkZnLulUBSV/qSkj1ILl+g9djJ4ORAxf6ONd6JpEvo1eUkbscoZmZ7r2mm4KwsYhETres/Re4WhGc0Adf8U73BGUhu4lbtD8m7VwIlMxNaCuIHimQHZ5HTJfybJZp2A7T3BhNE+VpagDf+JXyw0qo5Hys7SGcXaaMQSVITt7QxRaakYW1/aQbW6ZgSPlAk499MmwF65Qq5W0Bi0dYmJI9pPUgrcYOJ7CLgvh3qD85A8hO36iuSe78EMKUpNxR0M+k7HVPCB4pk/Jtpcw6aym+qF+dUszvZjCZtbRuZP0bI1K5N0jB91UeqSBbzLtvpvzlEZrpylyqdON15SlLupVV6nZA9nmjaDNBEMRozcnAoawDa9OlId7ahT0sNcmyNIb+Ht5xGwz//iLphvTFm4uwktTSFaWFY25+5L3Bsm1CSM9FcdsUni/mX7RQ3hwCE0pWBgqBScAAfbTgGQBjuHtm3K4YXZWFzTTNcMswwMABj+lMWd2y0PDyqMo0ZOajuNgQunTBE1WbIQHW3IQAQMkgzMPRydUHOjhM4YHkT/ab9MintTYhP7gc2vSGUlWQ6gBkAl4I2ysgu0l5wDrQGOtFqNwofChTakw5WtvOAu3SlWmbS2x0cm6qbcU5xN+h1gEuGJDGOxGdvi5Q78RCrVMgGVolDWQM8wVnk0ulxKGtARN+vA0PfIypOHvvkfmHPZ7HmM3cpKzjrjNoa2gY61kAnMziLqr9I/j0jFCwAqyUwe+MAth08LVsGdzLn67XXg6YtDRWjTZ8e8XEODobO2ZoMTEgeU+Na6fJ/yd2C4Ew9gMuf007vOdi2kMmk4LrcwbaJZBCWLKmNWP4zkfPQpcXdOq0NT9bcs0h7ATori4K0QqQ729BmyAh43F+g4OxDXCutpgCttP5J6S3AlS/K3QrpyTGkHYiC63L3y80IuF9yZjpTbZnM4UVZCSuu0j83wzOMLVZXC1UPPFESHqAZY5cBWAxAD+A1zvmihN5w3HhaA60QfVpqfOagAUDncqJPS03Q7wmZVEYfvGKn1eAMCEPLcgdnQNF1ucVsbe8s7sx0hpY2hX2IjMKJ0+0JCc5Z6czz71WUY0pqQPaX0ADNGNMD+CuAiwEcAfAjY+xjznllwm46aDAFaIUQA2ukWdxhk8qykje0pCnZRdoNzvUVChlaZopNEBONHpDts1XjcndmtFoFGhEINpQfjZY2ji01TUnd9zmYRPegxwHYxzmvAQDG2FIAMwAkLkATRcmxNYZdViUKlVSW4zjVUUudRE5ra5wBZcw3+zPlyN2CqKm37xycVK9pf4MNZ3VNk7X3DCQ+i7sQgPfu9EfcxwjpJGRS2eQpKpt/BpCWKe/9tVK601t9BVD5gbKCMwBYGzRRUYx0SEat7XBkTxJjjN0O4HYA6NOnT9Dzmpub0dDQALs9grmm0nGAU6Yc/BgZ7e3IPXQQ3ZrVmbAhhaBJZbwdGDRchhbFSZ8OoFWee4ulO7Wm+ouOZWtKs3OZ4oe5SeSUUFkt0QG6FkCR1+Pe7mMenPNXAbwKAKWlpQFHKJqbm3Hs2DEUFhbCZDKBsTAZvwBgsQB2Ba05DYFzDqvdjtr0DGDv7pQN0kGTynp3DtqqYD0lz321OKwtUsR8cwjrfg9MeVjuVkRE7nKZSmfsXAI86RI9xP0jgEGMsf6MsTQA1wP4ONqLNDQ0oLCwEF26dIksOAOA2QyEW7qjEIwxdElLQ2F+Hhr69JW7ObLJsTWiuHk30h02gHOkO2zoaa3HDwfs+Hb5TpS9tw2frd8vdzMjl907efdi7t8mWhzWFlUtl7sF4dlPq2aoO5nredUo4liTQAntQXPOHYyxuwF8DmGZ1b845zujvY7dbofJJO9kfTKYjEbYjWlyN0NW3kllDRk52NNtCLq7e9Td0wxoa2zFZ+v34/JJ/eVsZmQufBz48LbE36f/FGGXLK1Ty97L1V+oYqi7KMek2jXQydDukD+NLuE1yzjnn3LOB3POiznnz8R6ndg+zcj/DxwNJXxiUwzGsCtrIHR+Wd3peh1cR0/L1KgojZwlrD+WUs+hvo9TJTgDUM3/Z6UPw3uRomylTqO/tpSwBafsSWKE+Pj1bzxf6pcHHmzJVsLkUKTE9cflr0tzvbtTuda8FKtck0DBFcX85ZnTAq4njgZXwVsSrWSX9AxG/o8ICcI5R8XRM7hz5T6ULN6E/n/8ESWLN+Gulfuwpb4FXMKfqpOnTuHqOTchs18/9B17Dt7+4APJrp3KLEGq4TfJVSU/Vle+CFzzT7lboX6F4+RuQXg6o6Irivk7aok/kVYL8bm0uJunx2xK0yVtO8lwNNmDtjtduH/ZFnxZeQxtDpdnz1Crw4XP9p7CmpomXDTQjBcv6w+jPv7PKHfNn4+0NCOO7diJLTt2YNqNN2LU8OEYPnRo+G8mHYYN83moy+uKtsZWpHu9R21OF3R5XZPdsviNnAV89iBgPRn7NUw9pGuPGpXMBFqPA5ZquVsSWIZZCM4qmH8WJSOLW+njHmkGJntJz2A014PmnOP+ZVuwqvIYrHZXpw29XVwI1Kv2ncL9/9vv1ZOObSKltbUVH3xShqfnz0dWVibOmzAeV116Kf7z3nvxvZBUM2wYMGmKz6HLJ/WHLScTp9odcHGOU+0O2HIy1ZEgFsjlzwk9rFjo04TvT3WltwLDZc5Q13slchpMQnsuehY470FVBedk7WKl5OAMACP7KvcDv+Z60FsOW/BlZQNs9tCfDG0Oji/3WbD1aCtG53cFunYVNmPg0X2i3FNTA4PBgMHFxZ5jo4YPx7rvv4up/SlFpwPOvyBkhTDVBuNAxKVPq58Cmo4ATBe66AbTCT+P2UVCRrgWl07FwnJQ3vsbuwAXPClvGySw7aBKki0T7MTpdkX2ngENBujX1u9HmyOyOco2pwuvbTqGv9xQAGS4i2GcPo1On/mMaUGLnrS0tqKb3yYO2d264nSLTBWklGzqhcKWkS0twsYX48arr3xnvEbO6gi025YBK+4CnH4/WzojMPNvFJD9VS13L7WSuU+moiztUKReRqRj6DRiqQZKqbsdiOYC9JpdDRH/kLg4sLqmqSM4i3+3tgIuJ6DTA5mZwnGbDTjdec1gVmYmmv22QWw+3YKuWTLXYVYaxoRgnGoBORQxAHvPTZt6CEPZFJx9VS0HahWUwV61XJgTJx4urvz55mAq9gu/25UWpDUXoG1RZvja/HvbGRkdgdr/uN0O2HznbQYPGACHw4G9NTUYNGAAAGDrzp0YPmRIVO3QvJISuVugTN49aiJU4ar+QuilGrsIa3gcyZkrjYr4YUHFQdqoB6ReEKHG4AwAThewqVp5QVpzSWIZUa6RzTBEcX7XrkDXbkLPGgB0emSau+OaaVfg8eeeQ2trK77d+ANW/O9/+MV110XVjpilZwB6CT9nMSasRY61aIre79+TsYAJYIR0Ul8B7Hy/YwjZfkaZwVmklspmQYzq103uJigKB7C5pjlpyXOR0FwPeurQXHy2oz6iYW4dAy4syY3uBgF62H/769/wq1tvRe7w4Tirew+88qc/Yfiw4cIweaIVDwAqJdxeW8xqLykJfF2zWZhDdjh8jzMmfA8FYhKr3SsBqGnzBrX2FwVU6rMzFxeS55TSi9ZcgL51Un+s2dUAawRjN+kGPW6dNCC6G9hsneaoexQUYPmnn3Y+L1DCmZSzNHoDcOiQNNfy9o9X3NfXd2zbSQGYJIo4rK3k3nJA6q9xqdcJw7ukgxJqcIs0F6BHF5lx0bBcrKo8FnKpVYZRh4uG5WJU7+zIL+4fdF1O92N0nrcOlnAGBEw2ixpjwJQpwJrV8V8rGKczoqVQhITlPbfsXdCjvgKo+ghwRbDPe9JE+CFaDZXNQjjcaKXgHMT/NjfC2u6CKU2H4UVZsvWoNTcHzRjDi7NG4+JhvWAy6jsVctcxwGTU4+JhvfDirNHRbVDR2orO/3G5+ziEAH7iBNDYIPwRA3HXbsBZZ3UMj3ftJqxxjcbUC4WlSYDw9wVThaCZleB6sS6XsDSKkFiJQVicW7ZZhMdi0FZUcIYQeCMpKFP7A/DlQ8A3z6lmi0lvOw+3hD8pRYkV1qztLmyqlm9eWnM9aAAw6nX40/VjsPVIE/75dQ3W7GqAzeFEhkGPC0tycdukARhVZI7+wsHmlF3O4EPagXrZ/vPYQZZweWRlBV+iNG58YnvRgDDnTEg0vHvMgbjsoZ+XU8lMwNwX2LkszInu/+viBw5AVZXEklHmUws4gK0HmmXpRWsyQANCT3p0kRl/vXGsdBfV6QMHaZ0+SO9a5O5lB1q+BfgVSfFjMAhBOJD166RNEAsm0b10oi2RDluLw91KCtLiTlTRVisTP3CoKECb0nQUpCNkdwpTAskO0poN0AmRmRmgl8zcx8PMK3sH9gCJZp5edX29EBBDVduKNTB7J31FSqcL/gGBkECiGbZWUnAGOnaiimUJldJeSxjDi7IoizsKchQzoQAdjVCVxsRjwYhrpwMmmjV3BHibLXQJzEiDc7Agv3cP8PW6zsukgqEEMRItlQUqH7tXur+IIZNXRftAA7TMKlpOlzBvTwFayYJVGktL61RlzIeYwd3SgrD/+cU55UCBsaoqombixl8EPi5e89tvgLa20NeYeiEFZxI9pQ1bR8Nhdc8nx7AcUkX7QMeif24G9jfY5G6GrKztLmypacLoAVGs/omD5rK4ZWGzCX9CaW0Ves6R7pYVLHOaR/BLI1xm+qDBwE2/6rT/so+CAgrOJDZnqbzMrcsOsBj6Liqaf45Fqgdn0f4GG7bUNCXlXhSgpRAyQczN5Qzdw/YXLHM6kmVhkda9njRF6CX7lwodNgyYPiOyaxDirb4CqN8sdyvix+1A4XhooRhJKP1zgySupigdA9IM4d/zZH1Y0ewQN+ccp1oc2FvfimOWNjhdQtWcXuZ0DCrIRPdMQ3RroANxJ3v95Z+v4o2l72J7VRVuuPpqvPHnP8X/AoJlTgcrwSmKtu417TBFpBBuWZXaGEzCcquSmcJa50jOVyFxqJZ6x4J0ow6Xjc3xFCqRmyYDtMvFsam6GfWnbD6VcpwuoO5kG45Z2pDfPQPnFHeDzr+SSaROn/b0iAt65eHR++7F51+thTXcUHekgmVOi8HXO0jr9cCU8ynQkuSrrwB2Le+8p7XaOazCa8sfE9mc+pDpyWhVQlCQ7mBtd+GTH49FtMvXqooGXDwmyr0coqS5AM154ODszekC6k/ZsKkaKB3YLfqetM3mM1x9zZXTAADlW7fiSF19rE3vEC45a9IUqolN5FdfAVR+APAkbAojh53L3MVKtD3MDSgjSDMA/XIzcNrqwPHTEa4ySYBIt+BsaeMJXxutuTnoUy2OkMFZJAbpU60x/CAEKigSNyaUAO3alXrCRB2qv9BucPYRQWKmZ3mWeiUrMzkYDuDQcXX14hNdLlVzAXpvfWvEBeCdLmBfXWt0Nwi4Q5UUvGp6E6IGWplvloI4JK5ykSRIJZLTBVl7z9FK9Dy15gL0MUuYtb1+jkZ5flSZ2NFKxv7RhEhFZYU5Ek6sx61iStpqUQ1MaYkNoZoL0NFun6ao7dbEamOEqEHGWXK3IPmMXYI/p7RduaKUrLW9WsEglEtNJM0FaH2Uryja8wNxOByw2WxwOp1wOp2w2WxwRFpK04N1VBsjRA0sNXK3ILn0acCUx+RuRcIcoCzuqJxT3C3hZT81F6B7mdOjOj8vyvOR0fkNWfjiSzD16YtFf/oz/vv++zD16YuFL74U/Bo6vXAdsces0wvJYcF2uyJEkVJsOLRrkfuLYPO06s72TrF3My5GfXI2zdDcMqtB+ZmewiTh6HXAwIIoe61duwp/e81FL3hgHhY8MC/ya5yVgkODRINiqFetZpZq4NuXEPQ1F45LanOkFs27qdcpbHowyUb165aU+2iuB909y4D87hlhh671OiC/ewa6Z8bwGUUM0oSkMpUHpJhYGwIfLxwvVB1TsX5RlP3snmnwJEipe9wgeqVJGNoWaa4HzRjDOcXdsKkaQddDi8H5nOIYipQA4TfGCNlAzX0mIgEsr6jF85/vRp3FigKzCfMuHYKZYwoDHgcQ8FzFM/cFaoNs6pJSmOqDM9CxDvpAgw0coXvUJ047MHNCL2ypaUqpCmTJDM4AwHgkuyMlSWlpKS8vL+90vKqqCiWRbgDhxjnHqVYH9tb51uLOE2txZxlja6TN1rF3cyy6dgs51xzLayWJEyzQ+nt0+Xa8vfEQXFH+d9IxBPyedIMOz/3fSOUG6qrlFJy9XfSs3C1IiI82HAv6XP/cDE8wTxVXT+iVkOsyxjZxzkv9j2uuBy1ijKFHlhHjB5ulvXCwXaYiwigRTCWWV9Riwcc7YbF2LJ2ptVgx7/2tAOATOB9dvh3/3XAopvsEC+htDhfufXcL7n13CwqV1quur6Dg7EO7g7yhetGp1HMGEr/mORDNBuiEsNki3885EJq7VoxQPePlFbV46MPtsAYoymt3cty/TAicyRLsg4Fsqr+QuwXKouG5+H65GSkXiIHOI1t6XeLXPAdCAToasZbi1OmFNc7Ue1aE5RW1mPfeVtjd/wNrLVbcv2wLHvpwG6z28B/Aoh3GloLdyfHkyp3KCNCpWuJz+CzAchCo/QEQZ2kLx2li/jkYJWyiIYexA7ph5+EWWNtdMKXpMLwoK6lzzyIK0NGIthRnhol6zQq04OOdnuAscnFEFJzldOqMQipVRbL9otYUjhe2nswfo+mAHMjoAdkpFaBNaToU5ZhkCcj+KEBHQ6ePPEgb0yg4yyDY0HWsSVwkgOJLhLrTKi9tGZEMs/B688fI3RKSJHIMZQdDAToamZmRZXBTz1kWyytqcf+yLZ4gXGux4t53t+CvX+3F3gb17xRmVMoKPTFYVX8h9KQNJsDl0GbAPu9BuVugCP1TZC46WRXCIqXdAM05ULsJ+O5PwN4vALsNMGYAgy4FfvpboHAsEO0a6IwMIYvbK1Gsra0Ndz74IL78ej1OWiwoLi7Gs88+i8svv1ziF0TCefjDbQF7yGoJziajDt0yDDh2uj3g83YXcOM/v8dbt52b5JYFIA73equv6AjaWlFfQb1npM5cdLIqhEUqrs/kjLHnGWO7GGPbGGMfMcbMXs89xBjbxxjbzRi7NO6WRsNpBz64FVgyHahaCditALjwd9XHwJIrheedMXziz8qC97IKh8OBooJCrPvsMzQ1NWHhwoWYNWsWDhw4INWrIRE6o/A55HCsdheOnW5HlxBd5W+rT+LR5dsxcdEa9J9fhomL1mB5RW0SWxlC/hjt9TgpY91j9IBsWZYaJZOSes9A/D3oVQAe4pw7GGPPAXgIwIOMsWEArgcwHEABgC8ZY4M554nf8Jhz4KM7gN1l7sDs/7wLsJ8BdpUJ5/3fa9H1pMVM7NZWwOVEZtduWPD0057jV155Jfr3749NmzahX79+8b8eEpT/fLNWhPug4b3mWsxABxSwBEvsQWuJlkYDJDC8KAsV+5s1WYe7Z1flDSjH1SLOuff/xg0ArnV/PQPAUs55G4D9jLF9AMYB+D6e+0WkdhOw+9PAwdmbwyqcV7sZ6H1OdPfIyAi6ZOrYsWPYs2cPhg8fHt01SUQeXb4db208BP8CeLWWMO+3hrm4MLwva4CurwB2vg9AY7+5M8xyt0BRxB7m1gPNCFAmQLWy0hkmDVfeJkZSjlf8CsBn7q8LARz2eu6I+1gnjLHbGWPljLHyxsbG+Fvx3Z8BR4TzJA4b8P1f4r+nm91ux4033og5c+Zg6NChkl2XCMSKXVJXpzUZdfj5hD7QqbgglOzD+7tXQnPBGQAylPdLW25FOSZc+ZNeKC3upvohbz0T6mtfPCZX7qYEFPZflzH2JWNsR4A/M7zOeQSAA8Bb0TaAc/4q57yUc16ak5MT7bd3tvfzyKt9cRew53/x3xOAy+XCL37xC6SlpeEvf5Eu6GvR8oramOZQ39l4OPxJUZpY3ANVT1+Or3Y10hKseDg0OoJhqRbqjpNOinJMuGysBL+zZaTXM8XNO3sLO8TNOb8o1POMsZsAXAngQt6x80YtgCKv03q7jyWePcosQwl+sXDOccstt+DYsWP49NNPYTTGuBFHCvAvo1lrseKhD7cDgGe3pydX7vQpytG9ixFPTB8Op8Rd54nFPTwZ0XUqHyKPZVO2uNVXCD1nrQZnUe0PKVecJFKHG+V/7+PZlbzdoexP5XHNQTPGLgPwAIApnPMzXk99DOBtxtiLEJLEBgH4IZ57RcyYEX7+2Zsh/k9Pv/nNb1BVVYUvv/wSJpNyP43J5dHl2/HOxsNBA6zV7sSCj3d2CsyiU2fsnlrUUvq2+iT6zS9DodkEcxejcip1xeDG8X2Se0OtzjkHpOxf4nLaeTiezYOkoeV3J94JhL8A6ApgFWNsC2Ps7wDAOd8JYBmASgD/A3BXUjK4AWGdc6R7LjMdMPiyuG538OBB/OMf/8CWLVuQl5eHrKwsZGVl4a23oh7t1yRx3jhc79ditYcMkHZn4v4b1lqsqg7OP5/QBwtnnp3cm1Z/gdQIzm71FXK3QJGs7er+GTDq5W5BaPFmcQ8M8dwzAJ6J5/ox+ek97sIkZ8Kfa8gAzr07rtv17dsXStpTW2kSMW9MfCU9OAOpt/yo+gsqWBKAKU2n2iDNoLzCJP6Ut/ArXoXnAEOuENY5h5obM5iE8wrHJq9tKcB/bbLU88ZEIVJtw4xUeq1RGF6Uhc01zapMsDynuJuiE8QAaZdZKQNjwNV/B4ZOA4xdOg93M51wfOg04TxZsmu06dHl23Hvu1tQa7GCI7XXJmte8SXQ4q+P4Oj3RCBFOSaMHdANaQZ1/fuIO1YpnfZ60ACgNwoVwmo3d9TidliFXvPgy4Cf3i30tIlkllfU+lS4IhonDvfuXCZvO5JGhV3EJBG3ZjzcaMWm6uaI/6XkGh7X65S1Y1Uo2gzQgNAz7n0OMGuJ3C1JCY98tF3uJqSkQjlLnOaPASwHgdqN8rUhWaiiWFhijzTSIC1HcDal6TC8KEsVvWdAywGaJFVru4bq/qmEUc8w79Ih8jaiZCbQelwo6KFlxZfI3QJVEANfeXUE2/LKQG2FVShAk6CWV9Riwcc7YbEKS5Ay0/Qw6nVostpRYDZ5gsPzn++Ws5kpSSzeIvsGGQBQeiuw7unIVk6oUeF4yuCOQlGOCSdOtytua0o1liWlAE0CEtcvexN6yR0VwO59d0vyG0aQmaaH5Ywd897b0uk9KHR/cEpa4BZ3sNJycKYqYlEbPSAbZ3VNw87DLbC2u8LON189oRcON1oTtlOWjqln3tkbBWjSCSV8KZs4nRBofwz/0qkJVV8BVH0EuNRb5CWshu0UoGMkJo+JPvnxWMAdsMRiITsPtyQkOOsZMGaA8pdUBaK+Pj9JOBqyVjer3Zmc97D6C20HZ0C7IwMyGNWvW6fFat7FQhKVNHbV+F6qDM6AlnvQnAPNh4GD64Hju4VfJDoj0HMo0HcS0K23ZGugf/7zn2P16tVobW1FXl4eHnjgAdx6662SXFsOat84giRpDToV7yBREIOk97C3d0Z1IpZd9c/NkPR6yabNAO1yCuszG6sAlwOeNYwuO9CwAzi+C8gpAYbPAnTxF2N96KGH8PrrryM9PR27du3C+eefjzFjxuCcc9S51lrtG0dEw6gDwFhCa30ny/mHN+Gmys+QY7Wg0WTG6sITuPCeXybuhqlQTUyCzXRIB/9hb2/Di7Ikn4MePSBbuovJQHtD3Jx7BWc7OhcY4MLxxirhPAlKUQ4fPhzp6ekAAMYYGGOorlbnspPlFbVoSpHgDAjzuA6NBOe5W95HL6sFOgC9rBb0+PsLWP3nNxN301RYetRrpNwtSBlFOSaM6d95GDxWSt8IIxLaC9DNh72CcwhikG4+Islt77zzTnTp0gVDhw5Ffn4+rrjiCkmum0zLK2rxu2VbU2mPIgDaqBF1U+VnyHD6/sxnOO1Ie+Pvibtp/hghy1nLTlA+RjIV5ZhwTnE36COMTF2/W4Xi383GkJsuQPHvZqPrd6s8zzENlHHWXoA++I17WDsCLgdwaL0kt/3b3/6G06dPY/369bjmmms8PWq1WF5Ri3nvb6XNLVQqx2oJeLxH66nE3rhkpjBVZOyS2PvIRetD+Aok9qTD6frdKuS/8QKMJ46BgcN44hjy33jBE6TbHer/Xaa9AH18FyLvE3GgcZdkt9br9TjvvPNw5MgRvPLKK5JdNxmeXLlTE/OwqarRZA54/GRm98TfPH8MMOUx4KJnhWCtpbKYWnotKlKUYwo7RJ37wWvQtbf5HNO1tyH3g9cAqLMwiT/1vwJ/0S77iLS3HQWHw6G6OehUSQrTqjeGXQ6b3uhzzKY3ov2mO5LbkPwxwHkPaiOw6YypMc+uUIGWZXkznGgIeVyNhUn8aS9A64zhz/E5P75E9oaGBixduhQtLS1wOp34/PPP8c477+DCCy+M67qERGNt0TlYPPpaHDOZ4QJwzGTGyTv+X2KzuEPRQmAruZpKfMpInI8OFqQdZ+UGPV6qgr2eI6G9ZVY9hwpLqSIa5mZAztC4bscYwyuvvII77rgDLpcLffv2xcsvv4yrrroqrusmm9lk9NTcJuq0tugcrC0SlvYVmk349p6p8jUmf4z6t6Kk4Cw7McgGWn7V8H+3Iv+NF3yGuV1p6ci68x5NBGdAiwG673nCPHQkQ906A9BnUly3y8nJwbp16+K6hhIsuGo41dbWCKNOAbtcqZ1Wk95UKGiBkwk/R00vE1pf+TP0xxvg7JmLzN/cgwE3/p/MLZaO9gJ0tyKhCEm4pVY6o3Bet97Ja5uCzRxTiAfe34p2ShRTNQbg+etGKWOXqwD2HMrD9zsGouVMBrK62HDuiH0Y3Oeo3M3qzKD++UstCVbgZMCN/wdoKCD7094cNGNCJmlOiXs+OkD1VzE4D58lWblPLfjDtaPkbgKJ00uzRysnOJuLfR7uOZSHrzYNQ8sZEwCGljMmfLVpGPYcypOnfaFYG4Dy1+RuBUlx2gvQgFC+c8T1wDm3AbkjOgK1zgj0GiEcP/sGScp8asnMMYUwm6JMsksCPX2IiojJqFNOcAaEfaK9fL9jIBxO3/9zDqce67fEMxyfwJ8Ni7pWYhDt0d4Qt4gxILsIGPkzuVuiKkqci54woDu+rT4pdzMUzahjePYaBZal9KrX3XIm8MYFtnYj9hzKi36oO8MMnDUEqN3Y+bnC8UIVMCo0QlRMmz1oErOZYwoxsbhH0OcH5WYmss8SEAXn0ArNJuXOOxdf4ln6mNXFFuQkhu93DIzuuuIa5ZKZ7nKj4k8lEx6XzPS5t4/C8dovUUo0Qbs9aBKzt247F48u3453Nh6Gk3PoGcMN44uwcObZAISyoM9/vjs5WxqSoExGPZ695mxlBmaRuFSp+gucO2IfVv0wAoGGpYP1rn0xAFzoORdf0nHtkpnCnxD3hs3S+fsAoPYHBF2S6TeHTkiyMa6g2sulpaW8vLy80/GqqiqUlJTI0KLkU9NrnbhojeKCtJ4xODkXf5VrVqHZhHmXDlF2cA7gtblfoq2t88BdVhcr5lzxTehvvujZBLUKQkKY95yzubjTHDohicIY28Q5L/U/Tj1oErN5lw7Bfe9uUUwgFHuUWu/dv6ykTO0oTf7ZCHz130o4vFZAGvROnDtiX+hvTPS+zBSMiQLRHDSJ2cwxhbhxQp+kz0kHIw731mk4OCsuUztKg8fn4YKfD0NWj3QAHFldrLjgnEoM7nPMPaQc6FcSA4ZMT3JLCZGfZnvQnHNsP74db+x8A+uPrEebsw3p+nRM7j0ZNw2/CSN6jpB8v9C9e/fi7LPPxrXXXov//ve/kl5bqRbOPBulfXvgyZU7A264YdQB9jg3mJ5Y3AObDzXBaneGPE8MXAVmk2Z70IrM1I7S4PF5GDw+yNrn+gpg90rA4X7/jF2AwVdS2U2SkjQZoO0uOx5Z/wi+OvwV2p3tcEGIEDanDV8e/BLra9fj/N7n45lJz8AY7eYaIdx11134yU9+Itn11GLmmELMHFPoSR6rs1hR4DVHuryi1ieAm4w6ZBj1OHXGHnau+MCiaQCExLT7lm1BJCkT8y4dgoc+3B42oKtN9y5GVfeeI5I/hoIxIW6aC9Ccc09wtjk7L+twwQWrw4qvDn+FR9Y/gucmPydJT3rp0qUwm8346U9/in37wsynaZQYqCM9DgiB93fLtsIZIPIWmjvmHcXvD7ZG23tpWLhzlSjcZiV6HcMT04cnsUWEELlpbg56+/HtWHtkbcDg7M3mtGHtkbXYcXxH3Pdsbm7G448/jhdffDHua6WamWMK8cdZo2Dy253dZNR32vBh5phCvDx7NIx+P7UTi3vgrdvO7XSuWphNRiy4ajiMusAfFDPT9PijUtc5E0ISRnM96CU7l6DN0Rb+RABtjjYsqVyCF6a8ENc9H3vsMdxyyy3o3Zs23oiFGHgCDY8HOldrgUocin/+ulER/RsQQlKD5gL010e+9sw5h+OCC18f+Tqu+23ZsgVffvklKioq4rpOqtNi4I1Um8OFee9vxfPXjsK382Xcw5kQoiiaC9Btzsh6zyKbI/RQeDhr167FgQMH0KdPHwBAS0sLnE4nKisrsXnz5riuTVKH3cnx/Oe7U/ZDCiGkM83NQafr06M6P8MQSYnB4G6//XZUV1djy5Yt2LJlC+644w5MmzYNn3/+eVzXJfFL1M5cL88enZDrann9NiEkepoL0JN7T4Yuwpelgw6Te0+O635dunRBXl6e509WVhYyMjKQk5MT13VJ/AIlXukYgiZjReLnE/pg5phC/HxCn3ib10mBOcHVsgghqqK5AD1n+BykGyLrRafp0zBn2BxJ779gwYKUKVKidDPHFOL560ah0GwCg7Bs68VZozF7XFFM1/v5hD6eDUMWzjwbL88eDZN/Snkc/LPWCSGpTXNz0Gf3PBvn9z4/6DpoUYY+AxcUXYARPUcksXUk2QIlnz3/+e6or1NoNnmCc6Bre+/w5V98xWwyYnhB15DbZoo9c0IIEUkSoBljvwPwAoAczvlxJlT+WAzgCgBnANzEOU9KxhRjDM9MegaPrH8Ea4+sRZujzSerWwcd0vRpuKDoAjwz6RnJy30S5Ytlrjdc7zaSLPRHl2/Hfzcc6nTcu2dOCCGiuAM0Y6wIwCUAvH/zXA5gkPvPeACvuP9OCqPOiOcmP4cdx3cItbhr18PmsCHDkOFTi5ukpmhrdUvVuxXrltNaZ0JIJKToQb8E4AEAK7yOzQDwJhc2m97AGDMzxvI55/US3C8ijDGcnXM2/nj+H5N1S6IS8y4dgnnvb4XdGb6wt9S921Re700IiU5cGS6MsRkAajnnW/2eKgRw2OvxEfcxQmQ3c0whnr92FLp3Cb0MK03PaOiZECKbsD1oxtiXAALtDfcIgIchDG/HjDF2O4DbAXiKfRCSaP4JXr97byucro4etV7H8IdrR8nVPEIICR+gOecXBTrOGDsbQH8AW92JVr0BbGaMjQNQC8B7LUtv97FA138VwKsAUFpaGsFmgoRIK5pa4IQQkiwxz0FzzrcDyBUfM8YOACh1Z3F/DOBuxthSCMlhTcmcfyYkWjQ3TAhRmkStg/4UwhKrfRCWWd2coPsQQgghmiRZgOac9/P6mgO4S6prx4Jzjob2emxr+hGHrDVwcAcMzIA+pmKMyv4JctLyJFsDff7552PDhg0wGIR/zsLCQuzeHX0xDEIIIUSkuUpiAODkTnx1/FMcPFMNJ3eAu+s6ObgD+8/swSFrDfp2KcYFPa+Anukluedf/vIX3HrrrZJcixBCCNFcLW7OOb46/ikOnNkHB7d7grPneXA4uB0HzuzDV8c/hdDZJ4QQQpRFcwG6ob3e03MOxckdOHimGo3tRyW570MPPYSePXti4sSJWLt2rSTXJIQQkro0F6C3NZWHDc4iJ3dga9OPcd/zueeeQ01NDWpra3H77bdj+vTpqK6ujvu6hBBCUpfmAvQha3WnYe1gODgOWWvivuf48ePRtWtXpKenY86cOZg4cSI+/fTTuK9LCCEkdWkuQDsi7D13nG+XvA2MMZrbJoQQEhfNBWgDiy4x3cBC12MOx2Kx4PPPP4fNZoPD4cBbb72Fr7/+Gpdddllc1yWEEJLaNLfMqo+pGPvP7IlomJuBoY9pQFz3s9vtePTRR7Fr1y7o9XoMHToUy5cvx+DBg+O6LiGEkNSmuQA9MrvUXZgk/NC1nukxKvsncd0vJycHP/4Yf6IZIYRIbf3Bt1HlOgIOgAEo0fXGpL4/k7tZJEKaC9C5afno26UYB87sC5nNrWcG9O0yEDlpgTbqIoQQae1tqcQPp9ajxdmMLH03jOs+CQACHvv2xGq0cRsAIF1nwsQeUzEoa1hU91t/8G1Uuo4A7oqJHBAeH3ybgrRKaC5AM8ZwQc8rAlYSA4RhbT3To2+Xgbig5xWSlfskhJBg9rZU4usTn3uSWFuczVh7/H/gcHl+P7U4m7HmeFmn721zWbHmeBnWHC9DOssAGEObywoGBg7uCez+AbzKKzh7MIZK1xFUH/oL2lxWn6eCXYfIR3MBGhCGri/seSUa249iq6cWtx0GZkQf0wCMyv4JctPz5W4mIURh1h9fhaqWreDgYGAoyRqFST0vjvo6/r1lu6u90woTF5xRX7eN2yD2N7wD+9cnPgcAn+AaKgvHPziL1/nq+KedrkPko8kADQg96dz0fFyce5XcTSGEKJh3MPXGwVHZsgV7WnfCwe0R9zD3tlQKZYS9AmiiObgDP5xaH1lgDTFqyMHx7YnVFKAVQrMBmhBCQtnbUukz1xuMmHAqDkGLw9D+AXtvSyW+PbkmYO80GcQPAuIoQKhAHEq4fw+SPBSgCSEpx39OOBZiwP725BoUdxniGRqX0z8OPC/r/Ym0KEATQlLOD6fWxxWcvbW5rKhs2SLJtZQgXWeSuwnETXOVxAghJJxkzAurlcNlx96WSrmbQUA9aEKIhgRaaxwo4SlL342CdBBOOLDmeBk2n/oes4tukbs5KU2zPWjOOaxbt+LI3Huxa/QYVJUMw67RY3Dk3vtg3bZN8s0sli5dipKSEmRmZqK4uBjr16+X9PqEkMD2tlTircP/wD8OPI81x8s8gVdcfhSoNziu+6So6/anGovzJFbWvyt3M1KaJn9Cud2OuvnzcXrNV+BtbYDLJRy32XD6iy/Qsm4duk69AAWLFoEZ49ssAwBWrVqFBx98EO+++y7GjRuH+vr6uK9JCAnfI/Zf0uTPwR2ezGvv7xevEWh5FelQ13ZI7iakNM0FaM65EJxXrwG3BVgu4HKBW604vXoN6ubPR8ELL8RdTeyJJ57A448/jgkTJgAACgsL47oeISRw9S0x2IpFRKpbd0WcOe1f0MM7UO9tqQxYxYsQOWkuQNu2bRN6zoGCsxdus+H0mq9g274dppEjY76f0+lEeXk5rrrqKgwcOBA2mw0zZ87E888/D5OJsiEJCSVY5a5wPWOxiEi0/At6ePfQ01kGrQEmiqK5OegT/35DGNaOAG9rw4l//zuu+x07dgx2ux3vv/8+1q9fjy1btqCiogILFy6M67qEaN3646tQ2bLFE4TFoPvu4dex5nhZwtYUi0PaYg9dfEzBObB3D78udxNSluYCdMvatZ4557BcLrSsXRfX/cRe8j333IP8/Hz07NkT999/Pz799NO4rkuI1lW1bA143OI8mdD7Zum7AZB2LbSWWZwnKUjLRHMBOtLes+f8MEPh4XTv3h29e/f2mcemHbIICU+uqlvilo6UHBa5RH9oIoFpbg6apadHFXRZRkbc97z55pvx5z//GZdddhmMRiNeeuklXHnllXFfV2vKaspwYqsNxWyocIAB2Wd1wYjz+svbMCILcbvEZBPnn2ktdHTWH18V085eJHaaC9BZ55+P0198Edkwt06HrPOnxH3Pxx57DMePH8fgwYORkZGBWbNm4ZFHHon7umrXeNiCQ1UNaLMKe3KbeT+Yme8IQ9OJM/huhdc6VQb06mNG8egCGVpMEsUnGUtnAjiXrQf91uF/YFz3SRjXfVLc9bhTiZiUR0E6eZjUBTviUVpaysvLyzsdr6qqQklJSUTXsG7dioM33QxuDb+jDDNloO+SJXFlcUstmteqZI2HLdhXUR9XQRiDUY/+Z/dCTpG507X3VtT5bHjb7SwT9cQVSoqNKaRmYAZMPutSAAiZLU58MTDc3u//yd0MzWGMbeKcl/of11wPOmPkSHSdekHwddBuLCMDXadORcbZZyexddrh3TsGA8CBdJMBfUpykVNkxv7tx+Ku1uawO7GvQij60nziDI4dsgTdhb75hBU7vtlPQVphwi2XkouDOxTZLqWjf6/k0lyAZoyhYNGigJXEAAA6HVh6GrpOnSpUEqOErqg1Hragems9XE73f1b3X21WB/ZursPezXWS3YtzHvH1mk9YfT44eH9gIMkn9pyV+ktdqe1SMgb6fZlMmgvQAMCMRhS88AJs27fjxL/+jZZ168BtNrCMDGSdPwVn/epXMFHPOWaHqho6grPCeAfzNqsD1VuFHjgF6eSjZUzaU5I1Su4mpBRNBmhA6EmbRo5E75dfkrspmtNmVc8vXZeTY2+F0KunHnVyUYa0+jh3dgdfVwg0pwHd2sGm1EI//JRPlTeSPJoN0CRx0k0GVQVp/yH4YwdP0Vx1EtAyJnVx7uwO/llfwKEXDjSng3/WF0adCb+6/EZ5G5eiNFeohCQB10m+XWcyNZ+wonqLdPPkJLBuBrPcTSBR4OsKO4KzyKGH9ase8jSIUA+aRGfPxqM4fcqKNJM+/MkKduygBZaGFkomS6D6tsNyN4FEozktuuMk4agHTaLy/YpqGDMU8GMjQTKpOEwvJpM1HrbEf1HiQVnSKtOtPeDhDLO6P4yrmQJ+0xI1aTnZBrvNKXczAA706muW7HIuJ8ehqgbJrkdoSY7asCm1gMH3/7bOCEy6eqhMLSLaHeLmHGhoALZtAQ4dAhwOwGAA+vQFRo0CcnIBidZAZ2Vl+Ty2Wq2488478ec//1mS6yvJoHN7wJihB+fcZw25/+NkOHbQIun1wiW+NR62oGZ7PZx2oWcYrNIZEZRkjYppz2YiD/3wU3ACPlncF/7fGAwenyd301KWNgO00wl8tQY4eED4WkxocjiA/TXAoYNA337ABVMBffzDNy0tLT5f5+Xl4brrrov7ukqz45v9yDIHno/SSsGXHd/sR6++3X2KnZhzs3Ci7jQcdt/ehcPuxN7NdWg+cYZqhwcwqefFqLMeop2QVEQ//BQw/BQAYFjWaAzuScFZTtob4uZcCM4HDggB2T/bmHPh+IEDwnkSZyN/8MEHyM3NxaRJkyS9rhI0nwhf31ztmk9YsXdznc/89LGDlk7B2duxgxaavw5idtEtGJY1moa7VYZBR2ueFSDuHjRj7B4AdwFwAijjnD/gPv4QgFvcx3/LOf883ntFpKHB3XMOs07X6RDOa2wAcntJdvslS5bgl7/8pWZ6lCQyezfX4VBVg082OJUdFUzqebHnl/1bh/9Ba6NVgCOC3QBJwsUVoBljFwCYAWAU57yNMZbrPj4MwPUAhgMoAPAlY2ww5zzx2UXbtgrD2pFwOoGtW4GLL5Hk1gcPHsS6devw+uuvS3I9oi5tVgf2VtRh//ZjnXrcYpGUVB8Opy0eCYlcvEPcvwGwiHPeBgCcczENdgaApZzzNs75fgD7AIyL816ROXQw8mFrzoXzJfKf//wH5513Hvr312iVKhoUCI8j7HB4KhdJGZQ1DJPPuhRZ+m4A4PmbENJZvAF6MIBJjLGNjLF1jLGfuI8XAvCuUnDEfawTxtjtjLFyxlh5Y2NjnM2BML+cyPNDePPNNzFnzhzJrqc0g8akbs9PSqk+Zz0oaxhuLPo1ft1vHm4s+jUFaQUaljVa7iYQRBCgGWNfMsZ2BPgzA8IQeQ8AEwDMA7CMRTn5yjl/lXNeyjkvzcnJielF+DBEOWof7flBfPfdd6itrdVk9rYop8iMQWMLkG7SZvJ/Mu3dXIdNX+xJ6UAtGtd9EnSgYhjxSteZMCxrtOcDT6jEvHSdCb/uNy9gIB6WNZoSxBQi7G9azvlFwZ5jjP0GwIdcKMz8A2PMBaAngFoARV6n9nYfS7w+fYWlVJEMczMmnC+BJUuW4JprrkHXrl0luZ5S5RSZkVNkxg+f7g45lEvCo807BIOyhgEAvj25Bm0u7a8UkFo6y8BNfe/pdHxvSyW+Ov5pp4puDAwTe0wF4JvAR5Qn3q7QcgAXAPiKMTYYQBqA4wA+BvA2Y+xFCEligwD8EOe9IjNylDCvHMnQtV4vFC2RwD/+8Q9JrqMWZxV0lbxQSKpqPmHFdysqPY/1RoYBZ+enVMb3oKxhGJQ1jLK8Y9DGbQGPez74nFjtOSddZ8LEHlM9zxFlizdA/wvAvxhjOwC0A5jj7k3vZIwtA1AJwAHgrqRkcANAbq5QhOTAgdBLrfQG4byc3KQ0S0saD1vQeKRJ7mZoltMu7GENIKWCNEBZ3rHa21IZMOiKH3yIOsWVJMY5b+ec/5xzPoJzPpZzvsbruWc458Wc8yGc88/ib2qEGBMqhPXrJ8wv+0+JMyYc79dPOI/WK0ftUFUDXE7aCCGhOFKyNrh/lne6zoR0lpH0dqitsMq3J1bL3QSSANrM9tHrgQsvEoqQbN3aMeTtqcU9Wuhpk5iEq1lNpJGq/87Ben2vHnghaTtkqW0nrmDD3ETdtBmgAaFnnNtLsiIkpEO6yZCywSOZKFveVzSbb6SzDApaRPW0V4ubJFyfklzo9PIMAer0DBmZRlnunWzm3KzwJ6WQST0vjryud4pNXaXrTHI3gSQAfUQnURMTl8Q608nSq68ZxaML0HjYgr2btV+Ny9Ig7JJGNb07eC8LWn98VdAedZvLimFZo1Niu0sd9J5lU0RbKECTmIjroQH4LBFKpGMHLeh2VpeUSZ5qszo6/duKa6f3bakHd3GfgJ1qgXxSz4uxp3UnHNze6bksfTdM6nkx8jIK8cOp9WhxNiNL3w19TANwyFqjqaVc5/e8jDK1NYoCNFGVZPfalYq7hCSmNqsD1VvrcXh3I2ytHYFKPA5oe6nW5LMu6bQsy8AMGNdd2O411DKjvS2VWHO8LCntTJQsfTcKzhpGc9AkaVwujuOHz0Cni/3Hrs3qANOl1vxiOC4n9wnO3se1PtoQaPONyWddGlHQGpQ1TNVzt94fRIg2abYHzTnHsQPN2LLqEA7uOAFHuwuGNB36juiJMRf3QW6/rpLt2XzgwAHceeed+P7775Geno5rr70WL7/8MgwS1flWuoxMY+AA4XJ5/o2ddheOVJ7GqXobTtW1Yc7vJ3rOi3aIXOw9kvBSYbQhnmIcE3tMDdgDH5w5IuKhcAaG/PQi1LUd6vSciWXCyltjalsoWfpuGNd9EvWeNU6TEcTpdGH1vyuxf9txOO0uT1luR7sLNRUNOLjjOPqP7IkLbx4GvT7+QYQ777wTubm5qK+vh8ViwcUXX4y//e1v+O1vfxv3tdVg7EWDsPnLvT5BOiPTiO/fPxzw/JaTbclqWsqjpVqhiQHOe57aO/CFSkQTpbF01LcF/lm38lYMyxqNPa07JKuORptZpA7N/e/lnAvBeetxOOyuAM8LgXr/1uNY/e9KXHzL8Lh70vv378fdd9+NjIwM5OXl4bLLLsPOnTvjuqbajL1oUKdj29c0BAzGWT3SfQ8wQGV1IVSDlmqFF6oHLgbCUEE63HrrQ9YaTD7rUs+HAH96GDGl5yVBnxcxMJRkjaLgnEI0F6CPHWjG/m2Bg7M3h92F/duOo+HAafTqH99+tPfeey+WLl2K888/H6dOncJnn32Gp59+Oq5rasG5M4rx1Vu74GjveC8MaTqcO6PY57xefcy08UaCiJnvWk4US7RJPS8OGaCz9N3Q6jwdtPpYi7M54mH4QLtP6aCnTO0UpbkksS2rDsMZJjiLnHYXtnzZed4oWpMnT8bOnTvRrVs39O7dG6WlpZg5c2bc11W7wePzcMGNQz095qwe6bjgxqEYPD7P57zi0QVyNC9l1Gyvl7sJqmfW9wj63Ljuk1CSFXxXPDGBLZxBWcNwQc8rfGqPp+tMFJxTmOZ60Ad3HI9oK2hAGO4+sP14XPdzuVy47LLLcPvtt+O7775DS0sLfvWrX+HBBx/EH/7wh7iurQWDx+d5AnLjYQv2VtTh+IqTPucke55Up2dgOmHXqFTgtHNPIl5GpjHgdAQJbXbRLXj38OuwODt+dhl0uKDn5Z7escV+slOiWLSZ1rT7FPGmuQDtPZwa0fkR9raDOXnyJA4dOoS7774b6enpSE9Px80334xHH32UArSXUNW/kpFpLFYh85esIitKYWu1Y/OXeylIx2B20S0hn5+ePxt7WyqDJpwREi3NBWhDmi6qIG0wxjfK37NnT/Tv3x+vvPIK/t//+39oaWnBkiVLMHLkyLiuqzVyr8dtPNJEc7FugZbEEWlQD5hISXNz0H1H9Iy4Tj5jQL+ze8Z9zw8//BD/+9//kJOTg4EDB8JoNOKll16K+7paIvd63FQo2kEI0RbN9aBHX1yEgzuOR9SL1ht1GH1Rn/jvOXo01q5dG/d1tEwJW1QGur/eyFJmLpoQoi6a60H36tcN/Uf2DDt0bTDq0H9kT+T265qklqW2PiW5cjchYDLagLPzEcnuhVrTeNgidxMIIWFoLkAzxnDhzcPQf1RPGNJ0nYa7GRPmqfuPEiqJSVXuk4SWU2TGoLHyLafS6VnADwk5RWYMGlOQchW3qrfWU5AmROE0+VtJr9fh4luGo+HAaVSsOiQMedtdMBh16Hd2T4y+uA969YuvOAmJnrhFZeNhC6q31sPlTM7QcritF8XjyWyT3MQ5eUqaI0S5NBmgAaEn3at/N1x2+wi5m0L8eO8lLZJ8uRMDBo0piDgAHapqSJngLJI7J4AQEppmAzRRl6iSyJhQHtTa0obmE9aAp0QTnAHpg5V3MRQlJ6KJH4wMRj36n92LetSEKAgFaKIIfUpysa+iHjxIGbhghUaqt9T51PFmOmDg6OiCMyB9lrnLyQGn8LXTzsEYQ26fbMXWHHfYndhXIZQEpSBNiDJQgCaKIAaF/duPwWF3eo7rjQwDzs4PGjSKRxdIUsu7T0lu0EpnUuCc40Td6YRdXwqcc+zffowCNCEKQQGaKEaguWktcdidilgPHorD7kTjYYum3wdC1EJzy6wIiUUkVcbSTYa4l4opYT14OFRxjRBl0GyA5pzj9Mkz2P3DYWz4pArfrajEhk+qsPvHwzh9yhp0rjMWVVVVmDp1KrKzszFw4EB89NFHkl2bJEckvVpxqVY8a6ZziszodpYp5u9PBiX38AlJJZoM0C4Xx55Ntdj53UGcqD/tWT7jcgrzgDu/PYA9m2rhcsUfpB0OB2bMmIErr7wSJ0+exKuvvoqf//zn2LNnT9zXJskTSdAVh337lORCp4+9wM2I8/qjV19zRwUzBkVVM9MbFdQYQlKY5gI05xx7N9fi1NHTQde1upwcp46ext7NtXH3pHft2oW6ujrcd9990Ov1mDp1KiZOnIj//Oc/cV2XJFefktzQVeW8nsopMqN4VL4nqKebDEKvOExc8/4QUDy6AD+9ahh+OmMYfnrVMAwaU9Dp/owxWYIl096vBUJUSXNJYi2nrCGDs0gM0i0WG7p2l3bIkXOOHTt2SHpNklhi73jflnrwACMrvfqYO50fLJEqUKW0YKVG/e9/qKoBbVaHp/oZkPwKZ95Z9IQQ+Wjuo3Jd9YmIf5m5nBx1+47Hdb8hQ4YgNzcXzz//POx2O7744gusW7cOZ86cieu6JPlyisw4d3pJp+HnYGuwQ13Hv4ddPCr4UjHv7zvnksH46YxhOOeSwZ7z5ahw9t2KSny3ohLVWxK39IwQEprmetCnjrUk9Hx/RqMRy5cvxz333IPnnnsOpaWlmDVrFtLT0+O6LpGPFGurpVgy1njY4ikeIhexsIoUa80JIdHRXA862t6GFL2TkSNHYt26dThx4gQ+//xz1NTUYNy4cXFfl6S2Q1UNkq42iNWxQxa5m0BIStJcgI42uzaebFzRtm3bYLPZcObMGbzwwguor6/HTTfdFPd1SWpTzHIn+T8jEJKSNDfE3b1XVlQlFbv3yor7nv/5z3/w2muvwW63Y9KkSVi1ahUNcZOYNB62dCp3qgTfragMu20nIURamgvQBcVn4dSxloiGrnV6hoKBPeO+5/PPP4/nn38+7uuQ1CbOOSthWDuQNqsDeyuEpDEK0oQknuaGuLO6m9A9r2vYoWudnqF7XldkmTOS1DJCQlPKnHNIHKjZLm/iGiGpQnMBmjGGQWMLQwZpMTgPGlsYujgFIUmkmDnnMJS6tzUhWqO5IW4A0OkYBp9TiBaLDXX7jnuGvHV6hu69slAwsKfkxUkIiZfSd7oihCRXXAGaMTYawN8BZABwALiTc/4DE7qliwFcAeAMgJs455vjbGu0bUPX7iYM+UlRMm9LSMzMuVmedcdKR1tSEpJ48Q5x/wHAk5zz0QAedz8GgMsBDHL/uR3AK3HehxDNszTEVzQnmWhLSkISL94AzQF0c3+dDUCsCzgDwJtcsAGAmTGWH+e9CNE0NQ1vq6mthKhVvHPQ9wL4nDH2AoRg/1P38UIAh73OO+I+RumfhAShpjnoePbEJoREJmwPmjH2JWNsR4A/MwD8BsB9nPMiAPcBeD3aBjDGbmeMlTPGyhsbG6N/BYRoRNgtL/1IUQUvVubc+Av8EEJCC/sxmHN+UbDnGGNvApjrfvgegNfcX9cC8M7O6u0+Fuj6rwJ4FQBKS0tp/QZJWWLSlXclMaYD9Ho9HHZnwEpe362olKGl6povJ0St4h2nqgMwBcBaAFMB7HUf/xjA3YyxpQDGA2jinCd1eJtzjqP79qB85YeoqSiHw94OgzENA8b+BKXTr0Ze8WDJ1kD/5S9/wRtvvIHt27fjhhtuwBtvvOF5bvXq1bjrrrtw6NAhjB8/Hm+88Qb69u0ryX2J9kSzC1bjYUtC2xKKWobiCVGzeAP0bQAWM8YMAGwQMrYB4FMIS6z2QVhmdXOc94mK0+HA//76IvZt2ghne7unOpOjvQ17N36LmoofMfCc8bjsrvuhN8Q/l1ZQUIBHH30Un3/+OaxWq+f48ePHcc011+C1117D9OnT8dhjj2H27NnYsGFD3PckRM5MapqDJiTx4vpfxjn/BsA5AY5zAHfFc+1Ycc6F4Fy+EY72toDPO9rasK98A/731xdxxW/nxd2TvuaaawAA5eXlOHLkiOf4hx9+iOHDh+O6664DACxYsAA9e/bErl27MHTo0LjuSYhcvVidnqFPSa4s9yYklWiu1OfRfXuwb1Pg4OzN0d6OfZs24mj1noS1ZefOnRg1apTncWZmJoqLi7Fz586E3ZOkDjl6sekmA4pH5VOREkKSQHPjVOWffARne3tE5zrb21H+yXJMv/fBhLSlpaUFOTk5Pseys7Nx+nTk22ESEkyfklxUb62PaOe2ePTqa0bx6IKE3oMQ0pnmAnTN5h8j3hGIc46azT8krC1ZWVlobm72Odbc3IyuXbsm7J4kdYi92Jrt9SE3sNDpGdIyDLC12gM+36uvcB3/MqOMMQwcQ71lQuSiuSFuhz2y3rPn/Ah727EYPnw4tm7d6nnc2tqK6upqDB8+PGH3JKklp8iM8VeUYNDYAuiNnXMpxCHpsRcN8gRib2LvuHh0AQaNLfAMm6ebDBScCZGZ5nrQBmNa2Plnn/PT0uK+p8PhgMPhgNPphNPphM1mg8FgwNVXX4158+bhgw8+wLRp0/DUU09h5MiRlCBGJBfJ8iwxEMdzDUJI8miuBz1g7E8izspmjGHA2HFx33PhwoUwmUxYtGgR/vvf/8JkMmHhwoXIycnBBx98gEceeQTdu3fHxo0bsXTp0rjvRwghRPs014MuvfJq1FT8CEdb+F60Pi0NpVfOjPueCxYswIIFCwI+d9FFF2HXrl1x34MQQkhq0VwPOm/gYAw8Z3zYoWtDWhoGnjMeecWDk9QyQgghJHKaC9CMMVx21/0YWDoBhvT0TsPdjDEY0tMxsHQCLrvrfsnKfRJCCCFS0twQNwDoDQZc8dt5OFq9B+UrPxKGvNvbYUhLw4Cx4/CTK69G3kDqORNCCFEuTQZoQOgp5w8cgun3zZe7KYQQQkjUVDPEHWnxETVLhddICCEkMqoI0Eaj0WeXKK2yWq0wGo1yN4MQQogCqCJA5+bmora2FmfOnNFkL5NzjjNnzqC2tha5ubRLECGEEJXMQXfr1g0AUFdXB7s9cD1htTMajejVq5fntRJCCEltqgjQgBCkKXgRQghJFaoY4iaEEEJSDQVoQgghRIEoQBNCCCEKRAGaEEIIUSCmpGVLjLFGAAflbkcUegI4LncjkiwVXzNArzvV0OtOLXK/7r6c8xz/g4oK0GrDGCvnnJfK3Y5kSsXXDNDrlrsdyUavO7Uo9XXTEDchhBCiQBSgCSGEEAWiAB2fV+VugAxS8TUD9LpTDb3u1KLI101z0IQQQogCUQ+aEEIIUSAK0FFijL3LGNvi/nOAMbbFfbwfY8zq9dzfZW6qpBhjCxhjtV6v7wqv5x5ijO1jjO1mjF0qZzulxhh7njG2izG2jTH2EWPM7D6u6fcbABhjl7nf032MsflytydRGGNFjLGvGGOVjLGdjLG57uNBf+a1wv07bLv79ZW7j/VgjK1ijO11/91d7nZKhTE2xOv93MIYa2aM3avU95qGuOPAGPsjgCbO+VOMsX4APuGcj5C5WQnBGFsAoIVz/oLf8WEA3gEwDkABgC8BDOacO5PeyARgjF0CYA3n3MEYew4AOOcPpsD7rQewB8DFAI4A+BHADZzzSlkblgCMsXwA+ZzzzYyxrgA2AZgJYBYC/MxrCWPsAIBSzvlxr2N/AHCSc77I/cGsO+f8QbnamCjun/FaAOMB3AwFvtfUg44RY4xB+A/8jtxtkdkMAEs5522c8/0A9kEI1prAOf+Cc+5wP9wAoLec7UmicQD2cc5rOOftAJZCeK81h3Nezznf7P76NIAqAIXytkpWMwAscX+9BMKHFS26EEA151yxxbEoQMduEoBjnPO9Xsf6M8YqGGPrGGOT5GpYAt3tHur9l9ewVyGAw17nHIF2f7n9CsBnXo+1/H6n0vvq4R4ZGQNgo/tQoJ95LeEAvmCMbWKM3e4+1otzXu/++iiAXvI0LeGuh28HS3HvNQXoABhjXzLGdgT4492DuAG+b249gD6c8zEA7gfwNmNMVRtYh3ndrwAoBjAawmv9o5xtlVIk7zdj7BEADgBvuQ+p/v0mvhhjWQA+AHAv57wZGv6Z93Ie53wsgMsB3MUYm+z9JBfmQDU3D8oYSwNwFYD33IcU+V4b5G6AEnHOLwr1PGPMAOAaAOd4fU8bgDb315sYY9UABgMoT2BTJRXudYsYY/8E8In7YS2AIq+ne7uPqUYE7/dNAK4EcKH7F5Ym3u8wVP++RoMxZoQQnN/inH8IAJzzY17Pe//MawbnvNb9dwNj7CMIUxvHGGP5nPN69/x8g6yNTIzLAWwW32OlvtfUg47NRQB2cc6PiAcYYznupAMwxgYAGASgRqb2Sc79H1V0NYAd7q8/BnA9YyydMdYfwuv+IdntSxTG2GUAHgBwFef8jNdxTb/fEJLCBjHG+rt7G9dDeK81x51P8jqAKs75i17Hg/3MawJjLNOdFAfGWCaASyC8xo8BzHGfNgfACnlamFA+I6BKfa+pBx0b/7kLAJgM4CnGmB2AC8AdnPOTSW9Z4vyBMTYawnDXAQC/BgDO+U7G2DIAlRCGgO/SSga3218ApANYJfwexwbO+R3Q+Pvtzlq/G8DnAPQA/sU53ylzsxJlIoBfANjO3MsmATwM4IZAP/Ma0gvAR+6fawOAtznn/2OM/QhgGWPsFgi7C86SsY2Sc38YuRi+72fA329yo2VWhBBCiALREDchhBCiQBSgCSGEEAWiAE0IIYQoEAVoQgghRIEoQBNCCCEKRAGaEEIIUSAK0IQQQogCUYAmhBBCFOj/A1UgoBIlfNCkAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 576x576 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style>#sk-container-id-1 {color: black;background-color: white;}#sk-container-id-1 pre{padding: 0;}#sk-container-id-1 div.sk-toggleable {background-color: white;}#sk-container-id-1 label.sk-toggleable__label {cursor: pointer;display: block;width: 100%;margin-bottom: 0;padding: 0.3em;box-sizing: border-box;text-align: center;}#sk-container-id-1 label.sk-toggleable__label-arrow:before {content: \"▸\";float: left;margin-right: 0.25em;color: #696969;}#sk-container-id-1 label.sk-toggleable__label-arrow:hover:before {color: black;}#sk-container-id-1 div.sk-estimator:hover label.sk-toggleable__label-arrow:before {color: black;}#sk-container-id-1 div.sk-toggleable__content {max-height: 0;max-width: 0;overflow: hidden;text-align: left;background-color: #f0f8ff;}#sk-container-id-1 div.sk-toggleable__content pre {margin: 0.2em;color: black;border-radius: 0.25em;background-color: #f0f8ff;}#sk-container-id-1 input.sk-toggleable__control:checked~div.sk-toggleable__content {max-height: 200px;max-width: 100%;overflow: auto;}#sk-container-id-1 input.sk-toggleable__control:checked~label.sk-toggleable__label-arrow:before {content: \"▾\";}#sk-container-id-1 div.sk-estimator input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-1 div.sk-label input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-1 input.sk-hidden--visually {border: 0;clip: rect(1px 1px 1px 1px);clip: rect(1px, 1px, 1px, 1px);height: 1px;margin: -1px;overflow: hidden;padding: 0;position: absolute;width: 1px;}#sk-container-id-1 div.sk-estimator {font-family: monospace;background-color: #f0f8ff;border: 1px dotted black;border-radius: 0.25em;box-sizing: border-box;margin-bottom: 0.5em;}#sk-container-id-1 div.sk-estimator:hover {background-color: #d4ebff;}#sk-container-id-1 div.sk-parallel-item::after {content: \"\";width: 100%;border-bottom: 1px solid gray;flex-grow: 1;}#sk-container-id-1 div.sk-label:hover label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-1 div.sk-serial::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: 0;}#sk-container-id-1 div.sk-serial {display: flex;flex-direction: column;align-items: center;background-color: white;padding-right: 0.2em;padding-left: 0.2em;position: relative;}#sk-container-id-1 div.sk-item {position: relative;z-index: 1;}#sk-container-id-1 div.sk-parallel {display: flex;align-items: stretch;justify-content: center;background-color: white;position: relative;}#sk-container-id-1 div.sk-item::before, #sk-container-id-1 div.sk-parallel-item::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: -1;}#sk-container-id-1 div.sk-parallel-item {display: flex;flex-direction: column;z-index: 1;position: relative;background-color: white;}#sk-container-id-1 div.sk-parallel-item:first-child::after {align-self: flex-end;width: 50%;}#sk-container-id-1 div.sk-parallel-item:last-child::after {align-self: flex-start;width: 50%;}#sk-container-id-1 div.sk-parallel-item:only-child::after {width: 0;}#sk-container-id-1 div.sk-dashed-wrapped {border: 1px dashed gray;margin: 0 0.4em 0.5em 0.4em;box-sizing: border-box;padding-bottom: 0.4em;background-color: white;}#sk-container-id-1 div.sk-label label {font-family: monospace;font-weight: bold;display: inline-block;line-height: 1.2em;}#sk-container-id-1 div.sk-label-container {text-align: center;}#sk-container-id-1 div.sk-container {/* jupyter's `normalize.less` sets `[hidden] { display: none; }` but bootstrap.min.css set `[hidden] { display: none !important; }` so we also need the `!important` here to be able to override the default hidden behavior on the sphinx rendered scikit-learn.org. See: https://github.com/scikit-learn/scikit-learn/issues/21755 */display: inline-block !important;position: relative;}#sk-container-id-1 div.sk-text-repr-fallback {display: none;}</style><div id=\"sk-container-id-1\" class=\"sk-top-container\"><div class=\"sk-text-repr-fallback\"><pre>TSNE(init=&#x27;random&#x27;, learning_rate=&#x27;auto&#x27;, random_state=42, verbose=1)</pre><b>In a Jupyter environment, please rerun this cell to show the HTML representation or trust the notebook. <br />On GitHub, the HTML representation is unable to render, please try loading this page with nbviewer.org.</b></div><div class=\"sk-container\" hidden><div class=\"sk-item\"><div class=\"sk-estimator sk-toggleable\"><input class=\"sk-toggleable__control sk-hidden--visually\" id=\"sk-estimator-id-1\" type=\"checkbox\" checked><label for=\"sk-estimator-id-1\" class=\"sk-toggleable__label sk-toggleable__label-arrow\">TSNE</label><div class=\"sk-toggleable__content\"><pre>TSNE(init=&#x27;random&#x27;, learning_rate=&#x27;auto&#x27;, random_state=42, verbose=1)</pre></div></div></div></div></div>"
+      ],
+      "text/plain": [
+       "TSNE(init='random', learning_rate='auto', random_state=42, verbose=1)"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "def visualize(fingerprints_db, fingerprints_to_highlight = [], indices_to_highlight = []):\n",
     "    l = list(fingerprint_db.values())\n",
     "    fps = np.array(l + fingerprints_to_highlight)\n",
-    "    tsne = TSNE(2, random_state = 42, verbose = 1)    \n",
+    "    tsne = TSNE(2, init='random', learning_rate='auto', random_state = 42, verbose = 1)    \n",
     "    tsne_proj = tsne.fit_transform(fps)\n",
     "    \n",
     "    cmap = cm.get_cmap('tab20')\n",
@@ -1375,34 +2207,78 @@
     "    \n",
     "    plt.savefig(model_name)\n",
     "    plt.show()\n",
-    "    return tsne"
+    "    return tsne\n",
+    "\n",
+    "fps = np.array(list(fingerprint_db.values()))\n",
+    "visualize(fps, fingerprints_to_highlight = [fps1, fps2])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 121,
+   "execution_count": 166,
    "id": "c5dc96ad",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%capture \n",
-    "# Use %%capture to suppress fingerprint_all output, which produces a blank line for each file for some reason\n",
-    "(_, fps) = train_and_fingerprint(0, .0005, fnames)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 122,
-   "id": "7d031282",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-08-16T13:51:43.003094Z",
+     "iopub.status.busy": "2022-08-16T13:51:43.002914Z",
+     "iopub.status.idle": "2022-08-16T13:55:03.583794Z",
+     "shell.execute_reply": "2022-08-16T13:55:03.582194Z",
+     "shell.execute_reply.started": "2022-08-16T13:51:43.003076Z"
+    },
+    "tags": []
+   },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<style>\n",
+       "    /* Turns off some styling */\n",
+       "    progress {\n",
+       "        /* gets rid of default border in Firefox and Opera. */\n",
+       "        border: none;\n",
+       "        /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
+       "        background-size: auto;\n",
+       "    }\n",
+       "    progress:not([value]), progress:not([value])::-webkit-progress-bar {\n",
+       "        background: repeating-linear-gradient(45deg, #7e7e7e, #7e7e7e 10px, #5c5c5c 10px, #5c5c5c 20px);\n",
+       "    }\n",
+       "    .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
+       "        background: #F44336;\n",
+       "    }\n",
+       "</style>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <div>\n",
+       "      <progress value='10000' class='' max='10000' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+       "      100.00% [10000/10000 02:59&lt;00:00]\n",
+       "    </div>\n",
+       "    "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "[t-SNE] Computing 91 nearest neighbors...\n",
-      "[t-SNE] Indexed 10003 samples in 0.001s...\n",
-      "[t-SNE] Computed neighbors for 10003 samples in 1.091s...\n",
+      "[t-SNE] Indexed 10003 samples in 0.000s...\n",
+      "[t-SNE] Computed neighbors for 10003 samples in 1.830s...\n",
       "[t-SNE] Computed conditional probabilities for sample 1000 / 10003\n",
       "[t-SNE] Computed conditional probabilities for sample 2000 / 10003\n",
       "[t-SNE] Computed conditional probabilities for sample 3000 / 10003\n",
@@ -1414,14 +2290,14 @@
       "[t-SNE] Computed conditional probabilities for sample 9000 / 10003\n",
       "[t-SNE] Computed conditional probabilities for sample 10000 / 10003\n",
       "[t-SNE] Computed conditional probabilities for sample 10003 / 10003\n",
-      "[t-SNE] Mean sigma: 0.045221\n",
-      "[t-SNE] KL divergence after 250 iterations with early exaggeration: 71.065636\n",
-      "[t-SNE] KL divergence after 1000 iterations: 1.563685\n"
+      "[t-SNE] Mean sigma: 0.021153\n",
+      "[t-SNE] KL divergence after 250 iterations with early exaggeration: 69.586418\n",
+      "[t-SNE] KL divergence after 1000 iterations: 1.319757\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAegAAAHSCAYAAAAnsVjHAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAB15klEQVR4nO3deXxU1dkH8N+ZJcmQEAZIAgkkBMKWIJsioIgiiFoVQd+KWtuitVqrtmpb9w1btVpasW9brVpfl0pVpIoiVGQnokCBhC2BhLCFJGQBJmHCzGSW8/5xZyaTZPa5M3eZ5/v5+CG5M7n33Jjkueec5zyHcc5BCCGEEHnRSN0AQgghhPREAZoQQgiRIQrQhBBCiAxRgCaEEEJkiAI0IYQQIkMUoAkhhBAZ0kndAF9ZWVm8sLBQ6mYQQgghCbNz584Wznl29+OyCtCFhYXYsWOH1M0ghBBCEoYxdszfcRriJoQQQmSIAjQhhBAiQxSgCSGEEBmiAE0IIYTIkKySxAJxuVxoaWmByWSC0+mUujlxodVqYTQakZWVBY2GnpsIISTZKSJAnzhxAowxFBYWQq/XgzEmdZNExTmH3W5HY2MjTpw4gYKCAqmbRAghRGKK6Kq1t7dj0KBBSElJUV1wBgDGGFJSUjBo0CC0t7dL3RxCCCEyoIgADSAphn2T4R4JIYSEhyICIYQQIkMUoAkhhBAZUm2A5pyj7PgZ3LtkJ4qf/gpDH1uJ4qe/wn1LdqG81gTOuWjXOn36NG644Qakp6djyJAh+Ne//iXauQkhhCQnRWRxR8rudOFXS8uxtqIJNocTLncsttid+M++Bqw/0IQrSnLwyvwJ0Gtjf0a57777kJKSgsbGRpSXl+Paa6/F+PHjMWbMmJjPTQghJDmprgfNOcevlpZjTUUjLPbO4Ozh4kKgXlPRiF8tLY+5J93e3o5///vf+N3vfoeMjAxccskluP766/HPf/4zpvMSQghJbqoL0OW1JqytaILV7gr6PqvdhbUVTdh9ojWm61VVVUGr1WLkyJHeY+PHj8f+/ftjOi8hhJDkproA/Y/SI7A5wqs2ZnM48Y/SwzFdz2w2o0+fPl2O9enTB2fPno3pvIQQQpKb6uag1x9o6jGsHYiLA+sqm2K6XkZGBtra2roca2trQ+/evWM6LyEAUH64FUebrOAAGIDCnDRMGNb5QFjbbMH+WjMsHS4YUjQYk5+B/GyDZO0lhIhHdT1oqz2yWt3WMHvbgYwcORIOhwPV1dXeY7t376YEMRKz0v2ncMQdnAGAAzjSZEX5YWFaprbZgrIjbbB0CNM5lg4Xyo60obbZIk2DCSGiUl0POk2vhSWCIJ2m08Z0vfT0dNx444145pln8I9//APl5eX4/PPP8e2338Z0XpLcyg+3ouWsw+9rR5qsONJk9fua0wXsrBFGdKgnTYiyqS5Azxydg//sawhrmFvDgFnFOTFf87XXXsNPfvIT5OTkoH///nj99depB00iVn64NWDgjQQHUHaEgjQhSqe6AP3T6UOx/kBTWL3oVJ0WP50+LOZr9uvXD8uXL4/5PCR5iRWcPZwuYEdNG3a4e9O+89eh5rUJIfKgugA9Id+IK0pysKaiMehSqzS9BleU5GD8YPrDRKRV22wRNTj745m/7n4dz3EAFKQJkRnVJYkxxvDK/AmYXTIABr0Wmm67U2oYYNBrMbtkAF6ZP0GV21cS5ahttnjnjKV0NM4PCISQyKmuBw0Aeq0G/3vLROw+0Yq3Nh/G+gNNsDqcSNNpMas4B3dNH4bx+Uapm0kI9teaIV5V+OjJoQ2EkK5UGaABoSc9Id+Iv912vtRNIaQH3/XLckDjSITIj2oDNCFyVdtswa7DbWEX1EmEwpw0qZtACOmGAjQhCVTbbPFmVsvFUMriJkSWKEATkiCeyl9ywABcUJRJ66QJkTHVZXETIlf7a81wymPKmYIzIQpAAZqQBJFLQpheSxXGCFEC1QZozjlOn7VjW5UJX2xvxGdbG/HF9kZsqzLhtNkOzsXL0PnrX/+KSZMmITU1Fbfffrto5yXqYkiRx69bn140s0WIEqjyN9Xl4thZ04aGM9YuQ4pOF1B/2oZGkw25fdNwQVEmNN0rmUQhLy8PTz31FFavXg2LhXYSIv6Nyc9A2ZE2yYe5W846UNtsoV40ITInj0d6EXHuPzj7crqAhjNW7KxpE6UnfeONN2LevHno379/zOci6uaSxyg39teapW4CISQE1QXoM2ZH0ODs4QnSZ9r9b+lHiJg8y6vksvRZLvPhhJDAVBegqxvawx5CdLqAQ/Xt8W0QSWq1zRZ8tas54Wuf9VphfXMgcpkPJ4QEpro56EaTLaL3n4zw/YSEy7PuOZFzzpP8LJ/qvoOVViPMhxNC5E11ATrSP4ZSJ+wQdfCtrW1I0SA9VYOWs4mdPhmak9YjOE8Y1gf9e6d0aduY/AxKECNEAVQXoLWayIKuVoSRPofDAYfDAafTCafTCavVCp1OB51Odd9e4kf3nrKlwyXJHG/daRv69xayswNtxtHhoCdSQpRCdRNRA4ypEb1/YITv9+f555+HwWDASy+9hA8++AAGgwHPP/98zOclyrCjRvqlUwDQ4eDYdbgN5Ydbsetwm9+HBKdLaG9tMy0HJETuVBegR+Smh90r1mqA4XnpMV9z4cKF4Jx3+W/hwoUxn5fI36r/NkrdhC5cXJhzDrVTllxqghNCAlNdgO6boUNu37SQQVqrAXL7pqFvOg1Dk+iU7j8Fm1PqVkTH6QL1ogmROdUFaMYYLijKDBqkPcH5gqJMMEZb1ZPIlR9uTXgSmNioWAkh8hZz95ExNgrAxz6HhgF4BoARwF0Amt3Hn+Ccr4r1euHQaBgmDc/EmfZeqK5vR6PJBqdLCMwDjakYkZeOvhn6RDSFqNTRbkuXlMjS4cLyrY3gELafLKR9oQmRlZgDNOf8IIAJAMAY0wKoA/AZgDsALOac/zHWa0SDMYZ+GXpMGWmU4vJE5eRSESxW3Odfz3ppCtKEyIPYQ9yzANRwzo+JfF5CZEWtEyNqGBkgRC3EDtC3APjQ5/P7GWN7GGP/xxjr6+8LGGN3M8Z2MMZ2NDc3+3sLIbJTGKSMptwFe7hQy8gAIWogWoBmjKUAuB7AJ+5DrwMogjD83QDgT/6+jnP+Jud8Eud8UnZ2tljNISSuJgzrg6E5aYrsSQcLwkq8H0LUSswe9PcA7OKcNwIA57yRc+7knLsAvAVgsojXIkRyE4b1wbypA4JuSqE0Sh4ZIERtxAzQt8JneJsxluvz2g0A9ol4LUJkofxwa4/NKJSIQajlTQlihMiHKFU6GGO9AMwG8DOfw39gjE2AMKJ2tNtr8cc5ULcT+PZ/geqvAbsV0KcBI64CLv4lMOh8QKQ10DabDffeey/Wrl2L06dPY/jw4XjxxRfxve99T5TzE/kKN6lKrwXGF2YmfNvJFB3DuCG9g173hqkDvB933/SDNtYgRDqiBGjO+TkA/bsd+5EY546K0w58dg9wcBXgsALcXZPYbgEqvxAC9qhrgBv+DmhjXw/tcDiQn5+PTZs2oaCgAKtWrcL8+fOxd+9eFBYWxnx+Il/hJlXZnUB+tgF7jp1FhyNxqVgdDo49x84GfU+gjTUsHS5vSVAK0oQknuoqiYFzd3BeCdjPdQZn7+su4fiBlcL7eOx/LNPT07Fw4UIUFhZCo9Hguuuuw9ChQ7Fz586Yz03kLZIxmJU7muBwJj5POtgDgVYj1OUOtPuW0wXspM01CJGE+gJ03U6h52wP8QfFYRHeV7dL9CY0NjaiqqoKY8aMEf3cRF769w5/EKrDwUNuYpFoTlfo7Vk5hCBOQZqQxFJfgP72L8KwdjgcVuC7v4p6ebvdjttuuw0LFizA6NGjRT03kZfaZovi63GHy+mi2t2EJJr6AnT16p7D2oFwF1D1lWiXdrlc+NGPfoSUlBT89a/iBn4iP8kWsAINgxNC4kN9ey3aI1zy4hBn2I5zjjvvvBONjY1YtWoV9HrajEPtki1gGVLU9zxPiJyp7zdOH2GhBZ042ak///nPUVlZiRUrVsBgoIzXZJBsAWtMfobUTSAkqajvL8yIqwAW5m0xDTDy6pgveezYMbzxxhsoLy/HwIEDkZGRgYyMDCxZsiTmcxP5SraARUutCEks9Q1xX/wLd2GSc6Hfq0sDLro/5ksOGTIEXITlWkRZPAFr1+E22WVniy3ZRgsIkQP1BehBFwhFSA6sDD6/rDMI7xt0fuLaRlQnP9vQpWf52dZGCVsTP8k2WkCIHKjvsZgxoULY6GsBfa+ew91MIxwffa3wPpHKfRICqHM3qKE5aTS8TYgE1BegAaF85//8A1jwJVB8vTtQM+HfknnA7V8C339blDKfhPhS425QJ00dVKSEEAmob4jbgzFg8AXA/PekbglRsfLDrTjaZAWH0HsuzElDVm+dqgqYUE1uQqShzh40IQng2WrSkx/GARxpsqK3QaeqPaIBoZLYjpo2fPnfRupNE5Ig6u1BExJngbaaPNJkldVctIZBtCxzu1PYPAOg3jQh8UY9aEKiFCzmyWnVlU7LRO3RcyRfmVNCpEABmpAoxbOXrBXx5B0OjuMtEZbADSHZypwSIgUa4iYkCgc27MKVR/bAYLfAojdg/8AxONGvIObz6rXA+MJM7HAPI4sl1JaSkZLTED4haqXeAM050FYLHCsFWg4CLjug0QNZo4Eh04HMwaKugf7hD3+IdevWob29HQMHDsQjjzyCn/70p6KdP6DqKmDLFsDm7iGlpgLTLgFGjIz/tZPUgQ27MLx6B3TcCQDoZbdg4okyAAg7SDP4HwZnjCli+FhOQ/iEqJU6A7TLCexfCjRXAi4HvH9OXHagaR/QcgDILgbGzAc0WlEu+fjjj+Ptt99GamoqDhw4gBkzZmDixIm44IILRDm/X9VVwMYNgMune2SzAevXAZs3AZdeRoE6DgqO7PEGZw8dd2LMyf1BA/TQnDRMGNYHQOCKYx0ODiWEPyr9SUj8qS9Ac+4TnO3+3iAcb64U3nfeLaL0pMeMGeP9mDEGxhhqamriE6Crq4At3wjBOBCHQwjU69cJ91dcDEy/TPy2JCGD3f8yo0DHPc5aOtdGG1I0ip3H1Wqo9CchiaC+x+C22iDB2YcnSLedEO3S9957L3r16oXRo0cjNzcX11xzjWjn9qquAjasDx6cu+McqKgASjeJ354kxHXOiI57tJx14LOtjfhqVzPSU5X7qzdxaCYtsSIkAdTXgz72jXtYOwwuB3C8FBj7A1Eu/dprr+Evf/kLvvvuO2zcuBGpqaminBfVVcCmTYAzxupUFRXCfwCQlwfMmRt725IQ63cGaO4HcJ8gy1zC8TBYOlyK7T0bUjRBg3NtswX7a82wdLhgSNFgTH4GBXNCoqTcx/hAWg4g/Dk8DjQfEPXyWq0Wl1xyCU6cOIHXX3899hOWbhKGqWMNzt3V1wMrPhf3nEnCkqkFsk8DOnd+g84BZJ8WjqsYA+B0ce8oQPeKYrXNFpQdafM+fFg6XNhR04bPtlL1MUKiob4edKih7R7vj0/NZIfDgZqamthOUl3V2eONh/r6+J1bxap7XYIxfA10vTu/fw7osD/lCglbFV96rbBUS0hi81+fe3+tOeByrh1UfYyQiKmvB62JcIcqTezPKE1NTfjoo49gNpvhdDqxevVqfPjhh5g5c2ZsJ96+Lea2EfH1G34hdqddgXOsNziAc6w3dqddAf2gCdCq7DdKrwVumDoAOq2mR7lQpwvYfbQNX+1qxmdbG0MO2++oaUP54dY4tpYQdVFfDzprtLCUKqxhbgZkj475kowxvP7667jnnnvgcrkwZMgQvPrqq5g7N8Y5XrP818MmI6EXOBmba0t6zLX2752CPcfOenuaSudwCkPXgYKv3QnYI6iCcsRdv9yz3IwQEpj6AvSQS4R56HCGujU6oGB6zJfMzs7Gpk1xyJDOyKAgLVP52Qa/w7We477JUkrGAdGrmh1tslKAJiQMKhuQA5CZLxQhCTXUrdEL78scnJh2RWPyFECnvmeoZJCfbcDV52fjhqkDpG6K7KhjbIGQ+FPfX3/GhAph/iqJCW8Qes6eSmIilvsUnacK2Ib1wlpmokhKLkoSDzL+jUsKy8vqsGj1QdSbLMgzGnD56Gx8uvMEztmFn1HGgNumFOD5eWMlbilRX4AGhPKd590iFCE5Vuoe8na4A/NoYVi7T77UrQyPJ0ivXxfXyxQWFuLYsWNxvYYaDRkyBEePHg36njH5GSg70ib6hhVKVSji1pfEv+5B+OGrRmHexEFYXlaHhz/ZDbs746/OZMEHW493+VrO4T1GQVpajMuoZzZp0iS+Y8eOHscrKytRXFwsQYsSL+C9rvg8rsui2D33gv/9NeET2nAjbIwxhPM71L2AR7L2qDNSGWZPzJG6Gaq1vKwOC7/YD5MlwuWmfmgZQ83vr8Hysjo8smw3OpydP+fTivphyV0XxXwNImCM7eScT+p+XJ09aDWaM1coWhLPddEeNhtmXHsdAGDjs08Lc+EUrGPSPams/HCrN6M5WWgYKDjH0fKyOjz+6V5Y7MFLzobLyTkKH1vp97UtNacx5YU12PbkbFGuRfyjAK0k0y8DKisTOx9tNgvD65s2Ai4b4NICThNgXgOMmQhc90ri2qIi/XunJFWA1jDg/GGZUjdDtZaX1eHBj8sTes3Gsx14avleGgaPIwrQStOnD2Ayxe30M/60GACwqbq6y+cbf/0QAJ2Q4aPrC/S5CTgB4M2/AJdfRT3sCClhz2cxDclOoypiIvKdY9ZrWZfh50T6cFstBeg4Ut8yK7VrlUklJsaE/7hO2JO6ukrqFilKss1BnzR1SN0E1fAMZdeZLOCAZMEZEIbBn1q+V7Lrqx31oJUmzsPbQk+5e885BJdLKEtKveiwJVuiWDLda7wtWn1QtHlmMVDGd/yotgfNOcee5j341cZf4cIPLsS498bhwg8uxK83/hp7m/eGlXkbqerqaqSlpeGHP/yh6Of2CnfddqLXd1PFs4iMyc9QXd3uYAwpSXSzcVZvkt/OYB9uq5W6Caqkyh603WXHk6VPYkPtBnQ4O+CC8PRudVqx9thalNaVYsbgGXhh+gvQR7q5RhD33XcfLrzwQtHO51dxcehMbp0OuPQyIbHLGd2Tdlg9Z18ZGVFdJ1n57gCl9t6lViM8kBBx5BkNqJNZkHbKaLmumqguQHPOvcHZ6uyZJeuCCxaHBRtqN+DJ0ifx8qUvg4nQ2/zoo49gNBpx8cUX49ChQzGfL6Dplwn/erK5GQNyc4G2NqEXm5HRdVmUvwInjIk7VK7RCNcUU+mmrvdYXNx57yrhr563Z0/l7kVNtAyQcKoxYgyd9fucLuDU2Q5KEovS8rI6PLdiP86cE9Y2G/TyG43Qyrkio4KpLkDvbdmLjSc2+g3OvqxOKzae2Ih9LfswNju2uZO2tjY888wzWLduHd5+++2YzhWW6ZeFF6w8QXr7tq7Bu/uxgoLo25KaBkybJu78c/f13px3fq6iIF1+uBVHm6zgEAJaYU6adxMJ36Imnt6nkqqRdX+WoF2sorO8rA4PL9sNu8/TmcUuvx+CW6copDKjwqguQL+3/z3YHLaw3mtz2PBexXv442V/jOmaTz/9NO68807k58vwh3TESP/B03OsugrYsiXy8/7s57G1K5jKysDHVRKguxcq4egaxDy9Td8KZHotoNUxxW5lSbtYRW7R6oNdgrPcaBnDrVPyKUEsTlQXoDef2Oydcw7FBRc2n9gc0/XKy8uxdu1alJWVxXQeSVRXCUukXBE+kaemxqc9HoGG31U0zxWoSMkRnyBW22zBzpo2b29USNzlGJqTpsgiJ+r5v5c4ckwI8xhkNGDLYzOlboaqqS5A25zh9Z49rI7Y/tBt3LgRR48eRYF7mNhsNsPpdKKiogK7du2K6dxxt31bxMGZcwBWG5x/fx3Hcoag6MZrxG9XoDnyJJvn2n20zW9QO9JkhV7rCdjKkVz/98Lz1PK9+HBbLZyc++2NyjEhzON0uw3Ly+owb+IgqZuiWvLLNohRqjay3l2aLradde6++27U1NSgvLwc5eXluOeee3Dttddi9erVMZ037qqroloa5alPomPAsKZjqPl0lfhtC7QxSpJsmOIRLAA7FBacAdrFqrvb3voOH2w97s2AdnKOD7Ye9xb+uO2t72QbnAFhLvzhZbuxvKxO6qaoluoC9KWDL4UmzNvSQINLB18a0/V69eqFgQMHev/LyMhAWloasrOzYzpvXFVXCXtMx4gxYEhTHLaoHJgLaLVdj5WUqGb+WQxKHC4+aepAbbN8A06iLC+rw4TnvsaWmtN+X/9g63EUPrYy4OtyYndyPLdiv9TNUC3VDXEvGLMApXWlsDhC/yFI0aZgQckCUa+/cOFCUc8XF9u3iTafqwWAN17vurzLk3hmc08fRLJ9ZXWV/6VhNYeFwK2SamWB5pGH+vQyUxScEOaPpcOFXYfbAEDVS666b/nYt5cez84Z43c/ZjXwLP8i4lNdgB6bNRYzBs8IuA7aI02bhsvzL8d5WeclsHUyEOXQtq/mtGwczxgGmzYVqU4bCsyHkW1uFgKrp2fu+wBgs3Ue9wTY7vtb5+UJW2pu2uj/ojYrsHlT13MomCcRLNAyKwAYN6R3lyQxNXBxYM+xszh1tiPovSuVvwB85pwdDy/bDQBY+MV+VQVnD8+2lHoN4HB1jvAY9Br8/sZxNE8dJdUFaMYYXpj+Ap4sfRIbT2yEzWHrktWtgQYp2hRcnn85Xpj+gihFShRDhP2km9OyUZM5Ci6NMARt06WhJnMUACDb2hw8A3vDeiGI+0sCq68XgnawymcOh6pqfk8Y1idoUMrPNuBo0zm0nHUksFXx1+HgQZeYKdmi1Qf9BmC7kyd8O0gpdF+ibbG78Cv3fVOQjpzq5qABQK/R4+VLX8bbV76NK4ZcAYPOAAYGg86A2YWz8c7V7+APl/1B1DKfslddFX1wThWGXTmA4xnDvMHZw6XR4njGsNDn8QTlQEHct0cdSBLV/C4/3BpxcE7RKfeB86gCl451J+dlUVJxQXhwIZETpQfNGDsK4CwAJwAH53wSY6wfgI8BFAI4CmA+5/yMGNcLs00Ymz0Wf5rxp0RdUt6iKUYCCPPHt98BAGBL/glbgCz5QMdFF+812BKqbbZg1+E2hDsC6jtHrdcC4wszAQA7atri1cS4UsPAr5yXRUmJHlyiI2YP+nLO+QTO+ST3548BWMc5HwFgnftzIhVbFL0TxoTkLo/JU5AaYJ15oOPiU24PMZjaZgt21IQfnA0pGlw7KQc3TB2AG6YOwHUXDkB+tgGnzip332U1/J99+KpR0GvUcCfi4hDmqW976zupm6Io8RzingvgPffH7wGYF8drEbFptcDlM4X53tJNwJt/B9avQ4H5MDSurvPEGpcTBebDiWlXNA8aCrC/NrKh+0C7Qyl5mJhDGNZXsnkTB+HmyTIs+SsTW2pOY/YrG6VuhmKIFaA5gK8ZYzsZY3e7jw3gnDcAgPvfHH9fyBi7mzG2gzG2o7m5WaTmkB4iHRp2OoGTDZ2JZe5542xrM4raDiLVYQU4R6rDiqK2g0KCWCKocFvL0v2nItpycmhOWsBlSkofJj7SZFV8kN5wgP6OBVPd1I7Cx1Zi2kvrqchJCGJlcU/jnNczxnIArGGMHQj3CznnbwJ4EwAmTZqk9L8v8lS6SVjqFKkASWXZ1ubEBWRf8djWUmKl+09FlAg2NCcN/Xun4KtdzbB0uLzbOhpSNBhoTIlbOxNJ6ZtqhDvfqmEIe0pDjepMFjz+qVA1jTK8/ROlB805r3f/2wTgMwCTATQyxnIBwP1vkxjXIhESYWmVbIwerZolVh7hBucUHcOkokz0752CHTVt3h635++7pcOlyA00/FF6zMozhleExaDXhrWPsl4jBHM1stidlOEdRMw9aMZYOgAN5/ys++MrAfwWwBcAFgB4yf3v57FeKxKcczR1NGBP639x3HIYDu6AjulQYCjC+D4XIjtloKhroGfMmIGtW7dCpxO+pYMGDcLBgxL/4MWytEqOKiqSrtynlgETh2V6h7S/2NYocYviT+mx6OGrRuHxT/fCEmI3k/aO4K97ygW4OINLRTu5dUcZ3oGJMcQ9AMBn7mCnA/AvzvlXjLH/AljKGLsTwHEAN4lwrbA4uRMbWlbh2LkaOLkD3P1M7uAOHDlXheOWwxjSqwiXZ10DLdOGOFv4/vrXv+KnP/2paOeLiUj1tqMSaDcqMVRXqa4XHcgNUwf0OCbjrYFFwwGs3NGEcUN6K7IkqGe4dtHqg6g3WaIeEfD8CjlVHJyB8EccklHMAZpzfhjAeD/HTwGYFev5o2gPNrSswtFzh+DkPYcPOTgc3I6j5w5hQ8sqzMq6Tp3VxLZ8I93+yVqtcO1gVcGipaJKYgCQ1Vvnd5g7q7fqivz1oNcCqToGs63nz2mHgyu6bve8iYO8tbeToYJYtAx6LR6+apTUzZAt1VUSa+po8Pacg3FyB46dq0Fzx0nRrv34448jKysL06ZNw8aNG0U7b1SiSQoTi8MRn+AMqK6S2PQx/XsE46zeOkwf0z/ic2k1QEaqch427U74Dc4eLh758jO5ofnVwAYZDfj9jWMpQSwI1T2m72ndETI4ezi5A7tb/4vZOdfHfN2XX34ZJSUlSElJwUcffYQ5c+agvLwcRUVFMZ87LGpKBgtGhcusIgnGgXbB0mqAgiz/rylZJMvP5IjmV/3TahgevmoUBecQVBegj1tqvHPOoXBwHLeIU2BjypTO5T8LFizAhx9+iFWrVuEXv/iFKOcPKlmCM6C6ZVaRCrQLVv/eKdip0BKfoXy2tTHqUYVEu+2t77rs45yq08DmUPZDRjw4XRyPLNtNAToE1QVoR5i95873x2cvU8YYeKLmgCsrE3MdqZWUqGr+OVr+dsH6alez4pcnBdNy1oHS/adkHaS7B2cAsDlcSb/eOZAOJ8dtb32HJXddJHVTZEt1c9A6Ftkzh47FvqOVyWTC6tWrYbVa4XA4sGTJEmzevBlXXXVVzOcOi8qzPKHTATNndV1iVV0FLPkn8Mbrwr/VVdK1TwaUPhQcDrlvu9k9OHu4uDDfyiD0qEmnLTWn8dTyvVI3Q7ZU99NSYCgCC3MlJQNDgSGMbRJDsNvteOqpp5CdnY2srCz85S9/wfLlyzFqVIKyE9WYhe5RUgLceVfXnnN1FbB5U2fCmNksfJ7EQdqQorpfZVXZ8thM3Da1gIa7/fhwW63UTZAt1Q1xj+szyV2YJPTQtZZpMb7PhTFfMzs7G//9739jPk9Q1VXCEiOzWUiUmjylM2gVF6tzDjojQ+g1l24ShvE5Fx5GNFrA2a035XB0LsHq/v7iYtUXOBmTn4GdNW2qHuaWs1A1pZ9avhdLth5PUGuURe3rvGOhugCdk5KLIb2KAq6D9tAyHYb0Go7slIEJbF2UqquAjRsAl/vp22wG1q8T/vMwGgGTSYrWxY/Z3DMBjvOewTnU+ysqhO/NnLlxba6UPGuFy460wanSTpqc14Y/t2J/0Nc/oOAcUDjlTpOV6sbFGGO4POsaFPYaDh3T9xjuZmDQMR0Kew3H5VnXKKNIyZYtncE5EJMJyMsDUtMS0qSESE2NbGQgIyNwwlx9veqHwPOzDbh+cs/qY1IypGhECaxyyOJeXlaHaS+tx1A/OzGdORefZNNkcOsU2p4zEPk+ksZAy7SYlXUdmjtOYre3FrcdOqZHgWEYxve5EDmpuVI3M3zh7oFcXx/fdiRaJMVWGBOG/X1HFbrbtImywBNsoDElpj2qJxVlyqKS2PKyOjy8bDfs7lqrdSYLHl62W+JWKZuWMdw6JR/PzxsrdVNkS5UBGhB60jmpuaIUISEKkJIqBN8N6wNntQcaGidxE0vhFLkEZwB48rO93uDsYXdyKuMZBQbgyEvXSt0MRVDdELeqVFcB/3hL6lYog80qLLkKReXD3Goil+C8vKwu5M5TJHy0OUb4KEDLVXWVMFxLvb7IhMoI3bBe9UFaq4C0ilBSdPK5CaqnHTkGwGjQQ9/th5E2x4gMBWi52r5N6haoE+eq/95eP2WA3yA9NEcZCYQMwLghvaVuhhfV047ckZeuRfmzV2LR98d7i7TQ5hiRU+0ctOKpbNemoOK5f7Q/SfC9vX6K/2xuuW+mkaJjstsHOs9oQF0SBGkNA8CBWFfpGQ2d1Rk9226S6FCAlquMjKQIJNDpgEvdRUS2fJOYbTJVuCOWnATa4xoQtsN0cgZLhwuGFA3G5GfIKhj78/BVo5IiGUyMeuF6DcPC68fEfiICQMVD3JxzWHbvxokHHsSBCRNRWVyCAxMm4sSDD8GyZ09cNrL46KOPUFxcjPT0dBQVFaG0tDSyE1itQLtZSHayJ8nc88iRQvb1iJHAtEuEgB1PnuVYJC4MKRpMH9Pf73D60Jw0zJ6Yg6vPz8YNUwfg6vOzZR+cAaEX2LdX7DX71U7LGBbdNJ56zCJSZQ+a2+2of+wxnF2/Adxm8xb54FYrzn79NcybNqH3zMuR99JLYHpxfvHWrFmDRx99FB9//DEmT56MhoaGyE5gtQJnz3Y+xoa79jkUnU4ogylXVVXA8ePCaEEihrovn5nUa6H1WsAex4TkMfnC6IS/HbeU7Nk5Y/D4p3thiec3T+FcnFNwFpnqetCccyE4r1sPbrH0rMDlcoFbLDi7bj3qH3tMtJ70s88+i2eeeQZTp06FRqPBoEGDMGhQBD+s7e1APCopy73OrcPROZSfiLZu+Ub1WdzBjC/MjPkcgfKrs3rrFNEjjsa8iYPwPxcoK/jMqN2Jd1c/j5XLf4N3Vz+PGbU743o9DqDQT5U1Ej3VBWjrnj1Cz9kavAfKrVacXb8B1r2xb3XmdDqxY8cONDc3Y/jw4Rg8eDDuv/9+WCwRJJa44vRk7nSqe7erSNlsSbHUKpD8bENM2dyGFA0uKMrE0Jw0b6BmEIavpS7FGW+f7jwhdRPCNqN2Jx4oX4YBFhM0AAZYTHigfFncgzQgVFl7/NO9FKRFoLoAfeqdd4Vh7TBwmw2n3nkn5ms2NjbCbrdj2bJlKC0tRXl5OcrKyvD888/HfG5RcA5otVK3Qj6SYKlVMBOG9cGkokzou/1IBHuMy+qt6zJvPGFYH8ybOgA3TB2AeVMHqGo4O5BzduXsQnJ7xX+Q5uxaHzzNacftFf/BiJx0IWM7jix2J60fF4Hq5qDNGzeG3ljCw+WCeeOmmK9pMAjDer/4xS+QmyvU+P7Vr36F559/Hi+88ELgL7RaheFdnoBffKdT2FtZjdtSRiMZMuSDyM82+B2OLj/ciqNNVnAIAbswJy0pgm8gy8vqsGj1QcWthc62mAIer25qT0gblPY9kyPVBehwe8/e94cYCg9H3759MXjw4Mh2xvIkhSVyB1+lBGetVnigiCdaauWX2pK7YrG8rE6xiWHNBiMG+AnSzQZjwtpAJT1jp7ohbpaaGtn708SprnTHHXfgL3/5C5qamnDmzBm8+uqruO666wJ/QbySwtQg3sGZllqRMCxafVCRwRkA3i35HqzaritUrFo93i35XkKuzwAq6SkC1fWgM2bMwNmvvw5vmFujQcaMy0S57tNPP42WlhaMHDkSaWlpmD9/Pp588snAXxCvpDASnFYHXHZZUi+1IuFR8hDtxvwLAAhz0dkWE5oNRrxb8j3v8Xi7bWoBLbkSgeoCdP87bod50yZhiVUILDUF/e+4Q5Tr6vV6vPbaa3jttdcCv8lqFXrOFJwTLzUNmDaNAjMJm7GXHmfO2UO/UaY25l+QsIDsy2jQ0x7PIlFdgE4bNw69Z14urIMOMr/M0tLQe+ZMpI1N0A+SFHPOapeaBnTYgq+fzsgQhrMpMJMI2RQ6vC0lBlCpTxGpbw6aMeS99BJ6z5oJZjAAmm63qNGAGdLQe9ZMoZJYotYI05yzuHQ6oUccLDj/7OfAbT+i4EyioqRlVXJBQ9viUl2ABgCm1yPvj3/EkPfeRe8rrxQCNWNgBgN6X3Ulhrz/Pgb96U+ilfkMCw1rx2bmrM7M64wMYYONESMDZ2NTljYhCTWtqB8NbYtMdUPcHowxGMaNw+BXF0vdFIFGS0E6WiUlnRtqdDd5CrB5U9d64zodZWmTmBkNepgsyp2DThQtY7h1Sj4F5zhQZQ9altLTEbxWE+mBMSE4Tw+SaT9ipNCb9te7JiQGC68fA328S24p3A+nFqDm99dQcI4T1fagZSctTUgUs3dI3RLluPue8N4XqHdNSAw8c6kPLS2X/Z4zUvlg63EAoAAdJ9SDTpSzZyk4E6Iw8yYOwuL5E6AN0JMOdDyZfLitVuomqBYF6ESxKrfogWTeeB14952k3XmKyMO8iYOgCbACI9DxZOKk4YW4oSFuJdNoulZMY0z++z9HymYF1q8T/tPpaH6ZSCLQiiu7S0iSSuYgpaXtbONGvQGac6CpCdhTDhw/LmT56nRAwRBg/HggO0e0fZIzui3psVgsuPfee/GXv/xFlPP7xVjPcqacRxek8/LEa1c8ORxCoAYoSBPZmDqsL7bUnJa6GZK5dUq+1E1QLXUGaKcT2LAeOHZU+NgTsBwO4Mhh4PgxYEghcPlMUfZJNvtsXdje3o4BAwbgpptu6vqmNEOQYW6GiIuYBArCnAsPIr7LjkIxGiO7ttQ2b6IATRIq0HMvA/Dd4eQNzrT2Ob7UF6A5F4Lz0aOA00+Q4lwIXkePCu+bdYVoPWkAWLZsGXJycjB9+vSuL/TuLfzbJUizzuORlAFNTQP0Ov97GntKW27fJryemiYMEwejlG0oPSJ5+CBEBLdNKcCulj34QccWjPloO1Kb23Gmdx+8NeIaSepdRyPSwbVQQ/ev3jyBqobFmfoCdFOTu+cc4o+40yG8r7kJyBkg2uXfe+89/PjHP/ZfQrR3786A7E97GBupMyaUuAQCF+jovuyodJPygjAhMjJmeCvGN5ei+I1voLUJBYf6tbXiod3LAEARQTrSma+a31+D5WV1ePiT3bC7Or9Yr2FYdNN4Cs4JoL4s7j27w99P2OkEdu8W7dLHjx/Hpk2bsGDBgsi/OC0N6N9fCOAzZwnbInan0wnD8p4AHG6BjumX+Z9npuQOQsJSz3Zi+D93eIOzR4rDjtsr/iNRq8KnYZElcxkNQhnkeRMHYdFN4zHIaAADMMhooOCcQOrrQR8/Fv6jIufC+0Xy/vvv45JLLsHQoUNjO1G4hTciKdAxZ66wXMkz9A3IN+O7pAQ4cCDwnt4lJYltD0l66b06kNrsf4Qr22JKbGOi4OIAC3MKTa9hXXakmjdxEAVkiaivBx3p/KSI85nvv/9+dL3nRBkxEigokLoVoVVUAKNHC/Pn3YUq/UlIHLSfS4EtO93va80GY2IbE6Vg4dnTt6YesryorwcdaQazTpxvwbfffou6urqe2dtyU1kpdQvCU1VFa56JbOTxC3DoR5Uo/us3XYa5O3R6vFvyPb9f07eXHmfOyXuzDQYgz2jAw1eNoqAsQ+oL0AVDhKVU4QzfMia8XwTvvfcebrzxRvQOlgSWaL5D2p7sbrkOa3fncAhtpwBNZOCaI2dw6J090NiccGkYmIvD0q8v/m/Uddg4YLzfrzHJPDgDwJGXrpW6CSQI9QXoceOFeeVwetFarVC0RARvvPGGKOcRTXVV1yxvs7mzyIdS+FtGRkiCta5YgRNPPo1eHTYAAHNxWLV6vDH8GuTMnQO29bjf4eM8owGF/Q2yLWJCFcDkT31z0Dk5QhESf1nQvrQ64X3ZOYloVeJt36b89cLdKrQRkexZCiw+D1hoFP7ds1TqFsla0+JXoXEHZ480px0/2LsSGw4047apBT02kjXotXj4qlFYctdFmFbUr8trI3LSYdDHXiApVlQBTP7U14NmTFiK5K+SmOd1rbazkphanyKV3vv0rOkm4tqzFFjxS8DuLpjTWgt8epfw36Q7getekbZ9MuRoaPB7PNtiQr3JgufnjcWkIf2waPVB1JssPeZ0l9x1UY+vXV5W1+X97TYHTJbEDYn/cGoBVQBTAPUFaEAIwLOuEIqQ7N7dOeTtrcU9Qehpq1lGhnKDtGe+nOafxbfut53Bubsdbwv/UpDuQpebC0d9fY/jzQYj8owGAJEvRer+/uVldXjw4/KY2xoOqgCmHDEHaMZYPoD3AQwE4ALwJuf8z4yxhQDuAtDsfusTnPNVsV4vgoYJFcJmX5mwS8rK5Ck9K43JkVYLXDaDgnGitIbYu3fnuxSgu8l56EGcePLpLsPcVq0e/xp7LR6+apQo15g3cRCe/Gwv2jvCLLIUpRQto+CsIGL0oB0Afs0538UY6w1gJ2Nsjfu1xZzzP4pwDRIpT8DzLUwiN7SmOXZ7lgL/eRSwuBORDP2A770MjJsPfPkrIeDyCP7oR/LeJNFnzhwAwLGX/whdSxOaDEZ8MWkurrn3R6IGuxduGItfLS2HK8BCi2lF/bD96BnYndGtxNAw4A/fFycpliRGzAGac94AoMH98VnGWCUAekSTA99KY9VVwry8VMustFpApxc27qAhbHHsWQosvxdw+cxdWk4Dy+8Byj4AjmyK/JxM23nudb8FWk8AfQYDs54Rgn44bYrm62Suz5w5GOcO1CUAZsThGp5g370nnZ6ixQs3jMW8iYOwvKwOz63Y711fbTTocd34XGw40Ix6kwXGXnpwDrRa7Ohj0IMxYbkXrXVWJlHnoBljhQAmAtgGYBqA+xljPwawA0Iv+4yY1yMRONkgTXD+2c8Tf0216N47TkkHtKmA5YwQ/DrauwZnD5czuuAMABfcLvS8PfPRQGci2fGtQMHUwAH4y18BO/4P3ppVrbVCQhqgiiCdCKHmsqnsZnIRLUAzxjIA/BvAg5zzNsbY6wB+B+G39XcA/gTgJ36+7m4AdwNAgRLKUCqVFBXE/G3QQcLjr3fc0Q7AXQ861FxytAqmCsHYnx1v9wzcy+/t+np3dosQ0I9v7RxuZ1rhQYDmugkJSpQAzRjTQwjOSzjnnwIA57zR5/W3AHzp72s5528CeBMAJk2apJAyVwokZu+5+8ayWh3QOwMwmTqP5eUJG3SQ6Kz7rf/ecbwFCs6BuOzAigcB+7nA72mt7Rq8uZMyxgkJgxhZ3AzA2wAqOeev+BzPdc9PA8ANAPbFeq1IcM7ReLQN5WuO49i+U3B0uKBL0WDIeVmYOLsAOYW9/e/ZHKWjR4/i3nvvxXfffYfU1FR8//vfx6uvvgqdSLW+Yxbpbu3BpKQCt98hzrmIf60npG5B+Oxh7GPuD2WMExKUGNFjGoAfAdjLGCt3H3sCwK2MsQkQhriPAviZCNcKi9Ppwrp3KnBkTwucdpc3Ljk6XDhc1oRj+1owdFwWZt1RAq1WnGJq9957L3JyctDQ0ACTyYTZs2fjtddewy9/+UtRzh+z4mJhlygx2KzinIcE1mdw/Iax5YIyxgkJKuboxDn/hnPOOOfjOOcT3P+t4pz/iHM+1n38ep/edFxxzoXgvLsFjg5Xj04j50KgPrK7BeveqQAXqVd55MgRzJ8/H2lpaRg4cCCuvvpq7N+/X5Rzi2L6ZeLNCVMJzvib9Qyg0Uvdivhi0pe7JETOVFeLu/FoG47saYHD7gr6PofdhSN7WtB09Kwo133ggQfw0Ucf4dy5c6irq8N//vMfXH311aKcWzRz5gIzZ3UG2IwM4fOSksjOQyU442/cfGDea8K6ZrW64HapW0CIrMlkglQ85Wtq4QwRnD2cdhfK1x7HVXedF/N1L7vsMrz11lvIzMyE0+nEggULMG/evJjPKzrftdG+x8KVmkrrlxNl3PzO5UkL+0jbFrFR3W9CQlJdD/rYvpawc6E4B47ubYn5mi6XC1dddRVuvPFGtLe3o6WlBWfOnMGjjz4a87kTyrd37S+5TacDpl2S2DYRgdp60gVTpW4BIbKnugDt6Aiv9+x9f5i97WBOnz6N2tpa3H///UhNTUX//v1xxx13YNWqxJUeF8WIkcBtPxKKi9x5V8/h8Esvo95zuMTc0nHPUsDWKlrTZOHz+2ibS0JCUN0Qty5FE1GQ1uljf0bJysrC0KFD8frrr+M3v/kNzGYz3nvvPYwfr/C6t/6Gw0lo/rZ0jKWi1rrfCtXB1MTZIdwXVRgjJCDV9aCHnJcV9hbPjAGFY7NEue6nn36Kr776CtnZ2Rg+fDh0Oh0WL14syrmJwvjb0tFTUSsUfz1vJa2JjoRa74sQkaiuBz1hdj6O7WsJqxet1Wsw4QpxyotOmDABGzduFOVcROECBZ5QASlQz9vQt7Met6pw4IU8oQqZijbWIEQsqutBDyjMxNBxWSGHrnV6DYaOy0JOYe8EtYwkjT6D/R9nmuBz0oF63g4boE0RvZmyYG8HwDsfRmhemhAv1QVoxhhm3VGCoeOzoEvR9BjuZkyYpx46XqgkJma5T0IACD1BvaHnce6ENxh9ehfw8tCuASlQ5TB7O1BwUVyaKivhTgMQkiRUN8QNAFqtBrPvHIOmo2dRtua4MORtd0Gn16BwbBYmzC7AgMJMqZtJ1MozTLvut8HLdVpOdyaPAQAYvFs1dhft9pHxotEBLof451V7eVNCIqDKAA0IPekBQzNx9d2xFyEhJGKeIiPP9Qtec9puEXrTTIuAwVmO4hGcCSFdqG6ImxBZCXdDCNo4ghDSDQVoQuKgttmCr3Y1K6lPTAiRGdUOcRMildpmC8qOtMEZe5G65MOoz0CIB/02ECKy/bVmCs7RuuAOqVtAiGxQgCZEZBafIjlN/S6iYe6wMNrhipBuVDvEzTmH+YwF9YdO4UyTGS4nh0bL0HdABvKGZyHDmCbaGujKykrcd9992LlzJ7Kzs7Fo0SLccMMNopybKI8hRYP+R5djXMXzSHGYAHTmZ9Oq+25S0oEn6qVuBYmD1hUr0LT4VTgaGqDLzUXOQw+iz5w5UjdLUVQZoF0ujupddThz8ixczs7+i8vJcar+LM40mtF3YG+MOH8QNJrY/mQ6HA7MnTsX99xzD9asWYNNmzZhzpw5KCsrw8iRtNFEMrrQshrGPY9Bi65Lkagn7UdHu9QtICJpeO45mJZ+Ajid8FaIcu/966ivR8MTTwIABekIqG6Im3P/wdmXy8lx5uRZVO+qAw938+gADhw4gPr6ejz00EPQarWYOXMmpk2bhn/+858xnZcoV//tL/UIzgD1ngPqXlGNKE7Dc8/B9OFHQnAGhMDc7W8rt9tR//AjqJ45C60rVkjQSuVRXQ/afMYSNDh7eIK02WRF775+yjKGyV+A55xj3759UZ+TKBzt0hQZy2lg+b3Cx7RZhux0H6pmvQywH6qJ+nyO+nrUP/wI6h9+BACgy8uj4e8AVNeDrq85FTI4e7icHPWHWmK63ujRo5GTk4NFixbBbrfj66+/xqZNm3Du3LmYzksULNBmGSQwl53qcMtQ64oVaHjiSTjq6wHO4aivjyk4++Oor0fD089Qr9oP1fWgzzSa4/r+7vR6PZYvX45f/OIXePnllzFp0iTMnz8fqampMZ2XKMiepcB/Hu3cElKfLm17lKq1FljYBzD0A773MvWmJeLtMdcnLnmPW62of+RRb6+aGY3IffKJpO9Vqy5Ah9t7jvb9/owbNw6bNnVuZnDxxRdjwYIFMZ+XKMSnd3X93E6JTzGxnAaW3yN8TEE6oY7ecQcs322V5uI+04XcZEL9I48CEJLKkjUjXHUBWqNlEQVdjTb21J09e/Zg5MiRcLlceO2119DQ0IDbb7895vMSGdqz1L1L1QnA0Ffq1qiXyymMSlCATpiG556TLjj7wznq3ZnfDU8/A261AugcEgfUnxGuujnovgMy4vp+f/75z38iNzcXOTk5WLduHdasWUND3Gq0Z6mwPWRrLQDeOaRN4oO+vwllWvqJ1E3oyW5Hw7MLvcHZg1utaFr8asgvb3juOVSOOQ+Vo4u9/ykpi1x1Pei8ov4402gOqxfNNIAmxwHTmbPQQQcHHLBrbcjOzPK+52jrUbT7DFmm69NR2Kewy3kWLVqERYsWhd1Gk82EpvYm2F126DV65KTnwJhqDPvro/H81ufxSdUncHEXNEyDm0behKemPhXXa6rOut8K20MSIpHWFSuEgOVJQmUMxltuRu6zz8Z+cqc8d1TjARJuHfX1qCwu8Q55A/AOg7M+fcDb2wG73e/XKWVNtuoCdEZfA/oO7B1yqRXTAL36p2Bg7wHeimI66KBz6nDWdA5pvVJwrP0obE5bl69rt7fjaOvRHkE6HCabCQ3mBrh4ZylIu8uOurN1OGc/h7yMPFgcFlzy4SVo7WgFABhTjXhs8mO4dti1EV/P4/mtz+Pjgx97P3dxl/dzCtIRaK2VugXJxdBP6hbISuuKFah/7PGugZRzYf0xEFaQVt1crjuzvOGJJ4Ulrw6h/gA3mYJ/md2OxhdelP29q26ImzGGEecPQt+BvQPOLzMNkNpPi2Gj8sC6VxJjAAOD7ZwdOpfe79e3R5EEZLKZUH+2vktw9nXGegZHW4/ijPWMNzh7vu7Jb57EysMrI76mxydV/oeuAh0nATCt1C1ILpbTwOLzqIiJW9PiVwP2ck0ffdzl89YVK1A9cxYqi0u8Q7oNzz2H+ocf6bJkqv7xJ5Qx3BuiLDO3273BOVxOk6nL90eOVNeDBgCNhmHkBYNgNllRf6jFO+TtqcXtyDmHQZl5IWtxGzX90O6MbRmWR1N7E3iIYo+BAr+TO/HS9pdw7bBrsfLwSvx5159xsv0kBqYPxAPnP9Cjd939PYEeCgIdJwFweQ4BqlprrTDvDyR9wpijoSHwiz4Z0K0rVvRIqqp//An/AczhQP0zz+Lcrl1iN1dcMVZ8DHZeOSedqTJAA0JPundfA0ZdmN/jtf0t+6EL49aDvefA6QNwupxhzyHbXT3nQiJhspl6DFU3tDdg4bcLAcAbpP29JxAN7b0bmT75NMwtBbtFmP9P8gCty80Na21y0+JXeyRVBe1dWizeYfJk5Uk6owAtA3qNHg44QgZph596yh5Ol9CbsrvsqDcLvzTBgrReo485SPsGXg+r04onvnkCj5c+jsyUzC7D46HcNPKmLp93TySbPGAyjp09FrS3nlRGXAnseFvqViSn1lrgy18l9XaUOQ896C3k0QNjaF2xAn3mzAne01YznS7iYW5fcvy+JWWAzknPgcl8Gv00WQF7kS7ugskV3jIPzjma2pu8Ado3S1ur0QJcGKaOBQMLOETuGaqOJDhPHTi1R4JY90SyrSc710T6660nneqvpW5BcvM8HCVpkO4zZw7O7drlv7fLuXeYNtyetuo4HIBGA7iim7pjffr0ONZlhy6tFsb5N4mTMR+mpBzjNKYaYWUWnHa1wMEd3gDq5E6AAw7uwGlXC9p5+PPPnt6xyWZCvbne+7nT5Yw5OAMIOX8dqZ1NO3HJh5dg3HvjMP2j6WF9jdVpxe+3/V7UdigKbYIhvZ3vSt2ChGtdsQIHpl6EytHFQYeiudXamQQWqRD5OIoRZXAGALS3d0kW67FDl9MJ04cfoeG552JsZPiSMkADwMD0gWjnZtQ5j+OY8zBOOI/hhPMYjjkPo855PKLg7KupvSnmLSwTwe6yo7WjFRwcJpsp7K9r7Wj1BvYrl10ZU3a54tAmGNJLskQ9T+Z1qGVDsWB6PYy33By38ytF9+0wAxVuSWRBl6QN0MZUI1gcduiNdZ5ZCTyBvaG9AY+VPobntz4vdZMSY9YzgDZF6lYktyRa6ta6YkWP5VPxwO32pE8S8+UtZBKocEsCC7qoNkBzztFQfRArXvk9/vyj/8GfbpmDP//of7Bi8UtoOHQQnHPk9c4T5Vr/+se/cPMVNyM1NRVP/+LpLq9t3bwVcy6ag0kFk3DHvDtQX6u+uaGPD36cHD3pcfOBuX+j3aqkdMHtUrcgYRpfeDF+y4tIUNxPBTKvBE4HqDJAOx0OrPrfRVj6uydQvf1bODpswnq3Dhuqt23B0t8+gVX/uwi9tbHX4QaA7IHZ+OXDv8RPfvITpOnSvOurz5w6gwdvfxD3P3Y/tlRtwZgJY/Cbu34jyjXl5rHSxzD2vbGY/MFkdQfrcfOBJ+uBG9+iSleJxLTApDuTJkGsdcUKOOM4rE2ixwyGhF1LdQGac46v/vYKDu3YBofN1mM+mHMOh82Gqv9+h49eeVaU+eLZ183GtKumoX///nC4HN5zrl25FkWji3DV3KuQmpaKex++Fwf3H8Th6sMxX1OuLE4LHi99XN1BGhAC9aNHpG5FctAbgBv+njTBGQDqn0lcpjCJTKDa4PGgugB98lAVDu3cJvSag3DZ7WjeW4HWY+Jl5lodVnQ4O7yfHzpwCKPGjPJ+3iu9F/IL81FzoEa0a8oRB8efd/1Z6mYkDvWm48tTqCSZWGhTFjlLVGlQ1QXoHV9+BmdHR+g3AnDaHTi6brNo1z7bcbbL5+faz6F3795djmX0zkC7OfJa3kpzsv2k1E1IHE9vetKdUrdEvaiCG5GRhqefSUiQVl2APrzrv+EPW3OO5n2VcWtLr/ReMJu7LtdqN7cjPUP9SUYD0wdK3YTE2rMU2PW+1K1QryTK3gagnnXJKhXuftSxUl2AdtjD6z17OO3Rl4YLZfjo4Ti476D383Pt51B7tBZFo4vidk25eOD8B6RuQmKt+y0QyRI7Wq4VmSRb/0zrkuUvEaVBVRegdfrI/vBp9bFXO3U4HLBZbXA6nXC6nLBZbXA4HJh1zSwcOnAIa1asgc1qw9//9HeMLBmJYSOGxXxNuUu6cqCRVBnrky8s16J56wiwpNp2MvfZZ2G89RZA6x450GphvPUW4RiRBX+lQcWmugA97PwLwx8eYgzZ5xXHfM03XnkDF+RfgLf/9218+cmXuCD/Arzxyhvol9UPi99ZjP998X9x8YiLsWfnHix6c1HM15M73/rmKw+vxJXLrlR/5bFwq4zpDULBE8+89cLw66cnNw58fp/UjUio3GefRfH+fSg+UIni/fuQ++yzCa0DTYJLRPBU3WYZk667ATW7toeVKKbR61A469KYr3nfI/fhvkf8//G46LKLsOI7eW4GHi+ezTtWHl6Jhd8uhNUpbH2n6g03Zj0DfHpX8Pf0ye8Mzr6YNumGcKPi7ADeux5Y8IXULSEEztb4P1yrrgc9cPhI5IwrgUavD/o+jV6PnLEl6DOE6iuLrZeuFwDgz7v+7A3OHlanFb/9ToVLZsbND5zFPelOoaf80D7/exonUXWsmB3ZBLyQl1TD3YCwrKd65ixUFpdI3RTipsvNjfs1VBegGWMY++P5yBlXAm2KvudwN2PQpOiRM64E4xbc7K36RcRzznEOsz6eFXCp1TnHOXXW777uFWFNdJ98AEz498a3QhfYuO4VIYh7MpWZFsgaHffmKpa9Hfj0Z0kTpFtXrEDD088Iu1RR6U95YAw5Dz0Y98uobogbADRaLcbfcStaj53AkbWb0bK/Ek67A1q9DtnnFWPoFZeiz5B8qZupak3WJqRoUtDh8j/V8EnVJz32o1aFcfP995JDue6VnoF8z1IhO5zWAPvhEr430XyvFaZp8avgVmvoN5KAWK9e4BaLaA84xltuRp85c0Q5VzCqDNBajRZOlxPGwnxM/OltUjcnaQUKzkDnPDUJwhPsX8gTeo2kqyTZnzuq/Z1JF2KX5zRv2ozWFSviHqTjPsTNGLuaMXaQMXaIMfZYtOeJpGa2FEUy9Bp9l+zlaHDOwZE8Q1iq31hDDF/+ioJzIEmwP3eiSkqqhsb9N1gb38I2jvp61D/yaNz//8Q1QDPGtAD+BuB7AEoA3MoYizjLQa/XwxJBbVpjqhGDeg+CVpO46kN2lz3mXiG3c7Q6kmfZjcVpwROlT1CQDmbnO1K3QL5GXCl1C+Ku4YUXpW6CsrhcMN56C4r374MuT5zthAPiPO6bmsS7Bz0ZwCHO+WHOeQeAjwDMjfQkOTk5qKurw7lz58LuSRtTjRjdbzTGZI1Busz37+Wcw9XhQlNDE5bVL5O6OQnlgiu5NtaIFE0FBLb7X6pPFOO05WTETB9+hMriksRMDcR5U5N4z0EPAuCb4XICwJRIT5KZmQkAqK+vhz3YRtoB1JvlPYfDIfScl9Uvwz7zPqmbk3BJtbEGEY9nl6skSBQjEVJJtnu8A7S/NUxdvnOMsbsB3A0ABQUFAU+UmZnpDdSRmv8e/QLLWdJtrBEJfTrNQQeTJIliRKbivEw33kPcJwD4rmcaDKBLd5Zz/ibnfBLnfFJ2dnacm0PkKOk21ojEnFeTbyenSKg8UYwZDFI3gQQR701N4h2g/wtgBGNsKGMsBcAtABJep2/qwKmJviQh4hg3H7jh7+7iJzEy9OssomLoB2iCV9uTPU9dczVLTZW6BSQAw0VT414bPa4BmnPuAHA/gNUAKgEs5Zzvj+c1/XnrqrcoSMsYJYmFMG6+UCZ0YatQmcx3F6xwd8TSpgDfe9l9HpOwUce812IP/EMvi+3rYzH+B6qff+YJqPdMomM/djzu14h7oRLO+SoAq+J9nVCG9BmCrSe3St0M4gcliUXAX6WyxecFrzZm6CcE5+5fF6jq2cIwt9Ez9BM2rnjveqFGdiDaFCHzJEjhmqjseDd0GVWF0+XmUqESmaL9oEX0SdUnUjeBBEBJYjGa9Yww3Nvd0MuEXvejR+LT07ScEf5d8EW3WuIaIbnNU4987t+AZ5rd7xHzT476dwBLRL1nEp1EbJahylKf/gQrImLQGmBxxnc9GwmMksRi5Am+634rZDX3Gex/W8twGfoBltOh3+eboOWvlnh3vu95rh9tsRmGPnPm4NyuXTB9+JHUTSG+tNqEPDwlTQ86UBlODdPg2YtpE3QpqW5vaCl456lNgbe1DNf3Xg6dQKbRx5agRVtshi332WeRt+gP0OXlgTOA0wZ8kmK9eiHvpd8nZLOMpAnQN428KeBxChDSuXlUfJcpkCiMm++TQObO+E7xqcZn6Ce8HstDwHWvxJ5glkRbcvaZMwcj1q+D/r//RvUjl8OlTa4ozXr1gvHWW6RuBvIW/QGjd+1MSHAGkmiI27O14SdVn8DFXdAwDW4aeZP3uIZpaIclP+L5fZk6cKo6t5xUg2i3zYzEgi+EUp3/ebRzSN2T0AZ0HbJ3OgCzT1JO1mjg/m3xbZ8MjcgoAW66H6e+PoTMslq/laDUiJ87J/kwv+GiqQkLzB5JE6ABIUgHCgg3jbwJHx/8OMEtkr94BeectBy8ddVbcTk3UZBgDwIqX0IVrYw/fQJHGe0RnjBaLYzzb4r7mmd/kipAB+Ovhz15wGSUN5fD6qTN0sXWbG2WugmEKJJpKa1ISQRmMGB02S5J25A0c9DheGrqU9j9493Yu2Avdv94N9666i0svHih1M1SJQ5O20wSEg0nZb9HSpeXh7xFf4joa3icd6oKBwXoECiBLH6oghghUdAGqM2u1SJv0R/A0tIS2x4FyHnowYTPH4uBAjSRDFUQIyRyxvn+V6QY59+EPnPmIPd3v4UuLw9gDLq8POiHFyW4hTKi1yNv0R+iCs7MaBS/PRGiOegwGFONMNlMUjdDdaiCGCGR8yQrmZZ+Igx3d0ti6jNnTo+A1LpiBZoWvwpHQwO0ffrABYCbTAlueXR0eXnQDymA5bvISjX7DcyMhbdXtE6H3CefiOh68UA96DA8Nvkx6JW+808CFWUWQRtii8Q0bRpVECMkSrnPPovi/ftQfKASxfv3hcww9qyjzvvDy3BZrQkPzqxXLxQfqBR69hFy1NfDWlYe8fX89ZoDbQ9puGhql1GHvN+/KIshcepBh8EzD/3nXX9GQ3v8C6QrXU1bDW4edTNW1KzAOcc57/Feul6wOCwYmD4QD5z/AM3vE5JgTYtfBbcmeFWKVovc5xYCEOaC6x9+JOKvj6TNTK/3Xq+7UKMPcsN4ON39BJk0aRLfsWOH1M0IauXhlXis9DGpmyG6fbfvw3nvnifa+dK0aVh48ULVB2HGGOT0O0RIMJXFJeEN8Yai0QCu0DUSdHl5PRK0KkcXB/kCHeBweD9laWkRBWd/11MCxthOzvmk7sdpiDtC1w67lvaWDoPVaaUsbUJkRqwdmHQDB6L4QKXfBDSWloa8RX9A8YFKjFi/LqJgmff7F7sMNXsT3oLRamG89Zaorid3FKCj8NZVb+HmUTcH3ICDCChLmxB5yXnoQVGWYXn2Qh7+5ZfejTx8g2qwIGm4yH8Hx1NKc8T6dSiurPAGW39t9n0ICGcOXqloDjpKvmVDx743VuLWyBNlaRMiL57A2bT4VTjq6ztfCDe72c23J+4vazyYwnfewdE77uiSlW24aCoK33kndJsbGqDLzVXkMHY0KECLIDc9l5LH/KAsbfFVbTuJ7z6vgfm0DRn9UnHR3CKMnEIPQiR8gQJq5ZjzwqpSxtLSYt4LOVAwDiTShwC1oDFaETxw/gNI01L1nu7e2k2bYYipattJbFhyAObTNgCA+bQNG5YcQNU2mkogsQtUAKX7EqRQQ9hEPNSDFgEtw/Kvpq0Gz299nraUFMl3n9fA0dE1c9bR4cJ3n9cIveg9S1H16Up81/Q9mF3ZyMhw4aKbxlIPm4RFaUuQkgEts4qDlYdXKi5Yi73MykPDNNj9492in1cuxFxm9fniXThx0OT9vO9AA+wdLm+POZj77m1B1UcfYcPpn8KBztEcnY7j8h+NoSBNiIzRMqsEunbYtfj6+18jN12cJQ1KFq/9pNXmXwu/6xKcAeDMSUtYwZlpgL+91h9rT/+8S3AGAIeDYe17FTQMTogC0RB3HD1w/gNY+O3CuO0nrYEGLnQNgGnaNMwdPhcfH/w4LteMVLIvRQuU1OV7XJ+qhd0W/RaCwjMQA4f/8qrcBax5pwINNSZc9oPRUV+HEJJYFKDjyHdu+mT7SfRJ7RNy0w0t0yJDn4G2jjYMTB+IIb2HYOvJnkXiNdDgxekvdjm/bwnNzSc2J2yIPTc9F720vVDTVtPjtZtG+k88SQZV205i3fuVcDmFIXDzaRvWvFOBNe9UdHlfLME5Evs21yO3yEjD3YQoBM1BJ9jKwysD9qpz03P91qi+a/VdfoM0A8P8UfP9JmFFWpI02jlo35Kez299Hp9UfQIXd0HDNLhp5E2qTxALNgf99q83w9ru8PuaVPSpWjjsTnCXMDQ+5pI86lUTIrFAc9DUg06w7r3qUBtHrDy8Ejubdvp9jYN7h7K7B8Jrh12LsqayiIa6pw6cisrTlWjtaA36PgYGDt7jgcK3eAuB7IIz0LW3zl1CrxoAcouMtL6aEJmhHrTMXbnsypBD1cEypVceXonnvn0OFqcl6Dn23b4PnHOsPLwST33zFBy8Z3BJll5xJIL1oP92z/oEtyZKDNDpNT2WcJ13KfWuCUkE6kErVDj1rINlSl877NqwdpRitzPv+4Hwe/gkMF0Kg6NDPg/AAXH0CM6A0Lv29LBpOJyQxKMALXMD0weG1YMWU7hBnQRWte2kMoJzmHyHwylIE5IYyb0GRgEeOP8B6DX6oO9J5kxpudq89KDUTYgLT5AmhMQf9aBlztOTfWn7Sz2WaAXL4ibSsrUnZukUIUS9KEArAA05E0JI8qEATYiIPBXC1Eqf6r9aGSFEfBSgCRFB1baTKF1aJcu1z2Ka8YNRUjeBkKRBAZqQGHUv6alWTAuULq3CmncqqJgJIQlAWdyExKh0aZXqgzMAcGdndTTzaRs2LDlAu2QREkcUoAmJkdqHtQNxdLhUPd9OiNQoQBNCohbOftWEkOjQHDQhJGpp6Tq898QW2mQjDpprTThe2QSbxYFUgw4FxTnIzjdK3SySQBSgCYlRWrouKYe5NVoG6zkH4DMvvfZ9Ya9rCtKRqSmvR+NxE8ABMCCznwFmk9Wb22CzOFCzWyj5S0E6eVCAJiRG0+ePxJp3KqRuRsJxcCGg+B5zCmVOkyVA79lwDGea26BLEXYD65udiXGXDwHQM+gOKDCiaEJej3Ps++YI2k757DbH0fVzN5eT43hlEwXoJEIBmpAYqbXudig8QDXTZClzumfDMbSdMXuLt+hTtTjbasbO1YdgHNALjcdMnW/m8H7uCdLNtSbU7G6IaAWAzZJ8IzXJjJLECImSZ4lRsgQk0tWZ5jZotKzLMcYYrBZb1+Dso/G4cLy51oRDZZEFZwDQ6lnoNxHVoB40IVH4fPEunDhokroZspSWnhx/VnQp/vs3jAUJohz49vPop0NcDiG40zB3cqAeNCERouAcmEbLMH3+SKmbkRCODlfCr8m5MA9NkgMFaEIiRMG5q4x+qd5/Z/24OGkSxPpmZ4LzxFeQs1kcaK41Jfy6JPGSYyyKkDB17x0PHmXE3IfOl65BCrDgxWlSN0ES4y4fgp2rD8FqsQUf1o6D6l31aDx2BuddMjSh1yWJRQGaEDd/Q9cnDprw+eJdFKSTWJflUj6YhmH4hFwc3tsApz3xPem2UxbUlNf7XbpF1IGGuAlxCzR03f344FHGuLdFKTzD22q1a221kJHtJ/5yF0f1rnpJgrNH4zETDXerWEwBmjG2iDF2gDG2hzH2GWPM6D5eyBizMMbK3f/9XZTWEiIDcx86n4K0W+F5/aVuQtzs++YIrO12qZsRUs3uBgrSKhVrD3oNgPM45+MAVAF43Oe1Gs75BPd/98R4HUJko2rbSZiae1Z6SkbVOxulbkJcNNea/FbzkiNPhbFgmmtN2Pl1Fb79vAI7v66igK4QMc1Bc86/9vl0K4Dvx9YcQqQzeJTR7zC3b2+5attJbFhyQJIlNnKk1iItSlvKZLM4sG1VJYaNze2xRrp7xTKbxYHqXfU4VF4P7gJtxCFjYiaJ/QTAxz6fD2WMlQFoA/AU57xUxGsRIrq5D50fMov7u89rKDgnASWW1HTaOarL6r2fh0pe4+4fY9qIQ75CBmjG2FoA/hY2Psk5/9z9nicBOAAscb/WAKCAc36KMXYBgOWMsTGc8zY/578bwN0AUFBQEN1dECKSUNnatP9xV6qtGsbgNzFM9jhwZG8jHA5nRO13OTkO722gAC0zIX+7OOdXBHudMbYAwHUAZnH3qn3OuQ2Azf3xTsZYDYCRAHb4Of+bAN4EgEmTJinxV4IkkYx+qRSkfQy/IEfqJsRHBH+JOOcJXwcdjMMe3bSD085p2ZbMxJrFfTWARwFczzk/53M8mzGmdX88DMAIAIdjuRYhcnDR3CKpmyAr+zbX470ntng3DlGDfd8ciej9cgrOsWo8ZkJNeX3oN5KEiDWL+68AegNY02051aUA9jDGdgNYBuAezvnpGK9FiORGThmIvgMNUjdDVsynbdiw5IBqgrRSsrcDiXXHKwrS8hFrFvfwAMf/DeDfsZybELn6wcKL8Ld71kvdDFlxdLjw3ec1SVOHW87EKJzSeMyEU/Vn4bA7KctbQlRJjJAoMPrN6YHm5tXFM5ftyfKmtdOJp9IUzDhqKAOqvgTs5/y/biwCJv00sW0icVO17STWL6mEs8PdK2HAedPzMOaSPOzbTMOAaiNGEOLgYFDPvDTQWQyFetGJRf2ASDSUARXLAgdnADDVAFsWJ65NJG6qtp3EmncrOoMzAHB4A/N5l1K2q5rUlNejelfsD11qC84eSlwbrnTUgw6loQyo+RqwmhD24khLk/B1uRPj3DgST999XhPwf/f+b+px72szgdsS2yYSHzXl9cKmGCQwdT53yBoF6GB2/EPoEXtFkHxxYDkFaIULNqfKqZiYqjQeN0ndBPnjwM6vq2CzOKDRMm/pUDBgQIGR1k/HAQ1x+9NQBqx7pltwjpCzA6hcLlqTSOIF20qRksR6UvTWk1QiKSyeYW5vcAYATkuz4oX+zHTXUAZUfgZwEbaZq9se+zmIZC6aWxRwWG/MJZ29BZqLBjRapuwiLjR8GzOaIhAfBejuar4GXGLtAcuBtY8DG38rBH6iKCOnDMTs20ugTfH5682EgHzZD0Z7D+UWGRPfOBlJS9dh1o+LFb0GekCBUeomqAL1osVFc9DdWU3in9NhAfYvBUzHgOJ54p+fxM3IKQNDBp4NSw4kqDXycd/fZ0rdBNHUlNfTHLRIPN/HxuMmYdqA5qdjQj3o7tKM8Tt33Taal1YhNW0/qdEyCFX0A1P0XHM33uxtmoMWh3s+2vv9dH/+7RcVVOgkChSguyu6Mr7nr9tGw91EtlxOjtQ0HVLT/UdpXYpG2XPNPpprTTRvmigcqC6rpyAdIRri7i53ojAcHU8HVwjX8SSkeee8GTBocnTD4JXL3Ulp7kdXjR4ovoGWesWRWjaH6M7a7gDTArPvKAEgrAc3n7Yho18qLppbpOi5Zo/mWhMOlTVI3Yzk4g7S1bvqqb53mChAS8FhATb9zk9FMi70sOu2CZ/qewEjrwsdZCuXd36Nh8suPGh4ypKmGYXRAQrYolm/pFLqJsQNdwKblx7ET/90mSoCcnfHK5vg3r6eJJL7W26zOFC9SwjWA4bQHHUgFKD90fcKXs5TDOGc335OCLL7lyJo7zrYci7PdawmoMK9wVigIN1QJhRYcXZ0Hhs0hRLbAuhSAlSFbO1OqZsgiuZaE45XNsFmcXh7buGWrUxL16PD6ui67peIyjPNQEG6J5qD9mfkdTKsRMGDJJmF+ceDO4UedSAVy7oGZ4AS2wLY9K/ky9xWouZaE2p2N3gDsmdnJqYJb+Gztd1OwTkBKIveP+pB++PpYcZ7Ljoaddtj69H69ty71BlH4PqVsV5TRXrsbqViaenK//NwvLKpR4ClgCtD9L/EL+X/BsZL7kQhmcthkbol3bh/krsH10j1SFAL45pJzrO7VTJ8OzRahunzR0rdjJjRDkwKQZXc/KIAHYxLpr/cax+P/ms1eqGyWaQPHmufiD7DXCU2Lz2o6uCc0S9VddnaqQZdQoK0Vs/gtKv4hyPOPJXcvEVjqMgJAArQwYlW8lNGXPYo74t3ZoonaZBWS9JUIAtenCZ1E0RXUJwjyh7PwWi0DAwaAOr++YiXtHQ9TE1mfPt5RdcXOCWQUYAmkanbDhiHdA6v0/ItVVBTdTBf2flGHNnbCIc9fsGzaHxu3B8C1MzaHrzD0HjclLQBWm6pyvKi7yV1C2SIC3PXnrlvq0n4PAmqoyk9aSqjXyrOuzQPupSuv/Zqqg7mz9CxA+J6/ux8I1INyv7ZkLUknjmgAB2MLJdbyUD3IXKXXVg/rXLT54+ERqvcbJYFL05DbpERWn3nPaSl63D5baNVMd8cSHZ+13uOh4LiHDCm3J8NWUvibytFn2ByJwIl36eedDicHapdLz1jxgzMmDEDI6cMxKwfF3uHg5U2LFy17STWvV/ZZS69w5oc86YGQ6+4VQ6rKa9Hdr4RwyfmQqcPsdMIiVgybwVK4zKh5E7snF/dshiwNEnbHjlLgvXS3befvP33EjYmQqVLq/yuCS5dWqXqHjQAlK05AeOAFGQN6SV6T7fxmAmZ/XshO9/orS3dXGuieWkRJHsZUArQ4apcTsE5JK6q5VgzZswAAGzatKnL5xs3bkTVtpMoXVolUcsiN3iUEScOmvy+Zm2X6XJCEZlP22A+bUPfvDToUsTv5R7e29A1OJdRcI4ZAzL7J/foJQ1xhytYvWviI1hJUnXY9K8DWPNOhWIC2+BRRsx96HypmyEpz3SEVh+fP3m+a6CPVzYldWKTaLjw4JPMqAcdNvqNi0jdNmE5loKXX23cuBFAz57zmncqAn+RDHmCc2q61u9a7kB7P6vJRXOLsGHJAditTqTEOeOaqpeJJ9mLv1APOmxJnEoYLRUuv/ru8xqpmxAR30S2S+ePAusWi5lWOK52I6cMxOW3jcapOitcLvH/6Psmh9GSK3E115qkboJkKECHa9BkqVugPC67UNBE4TZu3OjtTZtP26RtTAS6r28eOWUgrvhxSZcs9Ct+XKL6BDGPkVMG4n9+PRmjJg0KK9s61aDDgCHGsJbW+a61LijOiamdpKsjexulboJk6FEvXJ6kJ0+5S5UZMiATbPZLcTr7Y3E6r/T6ZcS3CEa0mAZ+1zd3z0JPRp5s61CZ1hdcKWwWktm/l3c/aX8y+xu8CWJEfA67E99+XuHdyzuZvtcUoCNRPE+1AfroB/fG58SeUqAVy7puZ2nIAaY9FJ9rxpES5qB1KRrVFx8RQ7AyoL7D1L7Lp8LZzCHZE5vixbOXN4CkCdI0xB2pNKPULVCWtP7Cvtrd95q2NAnryhVm5JSB0KbINx8hGSqDiWno2AE9hrA1WhZwmLpoQh4uvr4EF88twcXXl/hdo5vsiU3x5HJyIUs+SVCAjlTRlVK3QFlMQZKqFLquXC/jalE2K2UQRyI734ii8bneHnOqQYei8bmy76Fl9jdI3QTJJFOWPA1xRyp3otAjJElLzuufuVPINKcedPh8h7DFoNNr47p7FgC0nbKAaXoOTCWL5lqT7B+ixEA96GgY1bvzDwlN7jW4lZRprkZDxw5IyMYZyRqcASTNMDcF6GhM+inoWycCgzKXo1w0t0jWy+Ll/gChdp6NM3yHzZkmPj8wybqDVrIMc9MQd7TGfF8oxNF960USPgVmcQPwDh+vfb8CXGabQTEtVL23s1J0Hzb/9vP4ZP7Ha4cuuUuWYjDUDYxW7kSg+AapW6FsCq4yNnLKQNz7t5mYfUeJ1E3pIpkKj5DklSzFYJLjMSRecicKlbKsJqlbokw1Xwvfw8rl7s1I3ItLFbQb1sgpA7H2vQrZzAdScJYnrZ7R8isRMA3D8Anyz7IXC/WgY1V0JXoUOCbhsZrcwXkbOjcjUd5uWGMukcd+tYx+m2Vr2NhcWectKMGAIUZcNKc4aYIzQAE6drkTgZL/AfTJvW9p1AJVZlPQ9p6X/WA0zrtU+iAtlwcF0lN2vhEjJuZ1zp1KHKwHDDGGVY9cLgYM6VmxLRkwOSUZTJo0ie/YsUPqZkTvm5dpuFtMV/xe6hZErGrbSXz3eY2w1IkhIbuUMo0QnC/7wej4X4yIornWhJrdDXA5O39ANFqG7MF90FLfGtfhcN9gV1Nej8ZjpqDvTzXoJMma1uoZho1NjuFsxthOzvmk7sdpDlpMRVdSERPRKHM80LMZRSJqdp93KQVlpfIEHc8mHL4bQfj2FINlf2f2N6DtlKXrwWAPhX5qhzceNwVtp6fsaXVZfUIeNj2StcfcHQVoMVGVMfEoeHvPqm0nsWHJAVHPqUthSMtIgfm0DRn9UnHR3CJKCFO4cCqY+Q3CANLS9TjvkqForjX1CPJtp86F3NDDK0TQ9ZQ9bTt1LmRPWywUnDtRgBZTvJYNMS1kt+A2bpSVxe3Pd5/XwNEhblr35bcVU0BOQuddMhT7vjnSJUhn9jfgvEuGAvAf5Lv3woMK0uMeMKTz3EUT8uIeoJNxO8lQKECLqeZrcc6jTRGCssMi7J7Vf5TPMiQVMxa5q7Qpm9ilNlPTtRSck5gnGAcTzjaY/gwoMPoNvGnp+h5fP+L8vKD7Z8ci1aDz7r9NOlEWt5jEShBzdgjBedAU4JJHgZNlUH1wBoLvfKUgYpbaZFrg0vmjRDsfUR9vopfPSsXGYybUlIcOpkUT8jBgiLEz5YMJPefzrxjR473Z+UakpevFarZXsO09kx31oMWUZhQ3i7tuW+BlSES2LppbJEqCWGq6FpfOH0W9ZxJUoKHnxmOmsHrRRRPywh4SP/+KEfj2i4qQ/QXPMHyoEqc0rB0cBWgxFV1J9bkJRk4ZGH2AZsDs26lcJ5GvERPzeiwR8+U7Rx7MxXPlVSZXjmIK0IyxhQDuAtDsPvQE53yV+7XHAdwJwAngl5zz1bFcSxFyJwr/esp/phmBtP6qGbqNOxVt4xn1Xr2cynUSeQu2RKyHQEloylxFmXBi9KAXc87/6HuAMVYC4BYAYwDkAVjLGBvJeRKkIudO7AzUALD2CenaoiRMp4oEMY8xl+Rh3+b4JNQQ4ivQw2A8S7+Gs0QMCJyENqAg9NeS+CWJzQXwEefcxjk/AuAQAOUubI1JEiR3iYGra39Xb/lP6imQOBseYP440PFECpSERuucwyNGD/p+xtiPAewA8GvO+RkAgwBs9XnPCfexJJSgeo9Kl2aUugWiu+wHo72Vvqq2nUTp0ipY290PIgF+LAaPMiasfUQdIhpylkAkSWikq5ABmjG2FoC/SbEnAbwO4HcQ/tT8DsCfAPwE/vsNfqMUY+xuAHcDQEFBQViNVpRBkykTOxxFV0rdgrjylAD19fniXThx0OT9fPAoI+Y+dH6CW0bUINwhZ6IsIQM05/yKcE7EGHsLwJfuT08AyPd5eTAAvxNynPM3AbwJCJtlhHMtRfFUxEqGQiOx8J23TxLJFIyrq97HdlYPs06DDIcLk3keRoz8sdTNIkTWYpqDZozl+nx6A4B97o+/AHALYyyVMTYUwAgAytk/UGzF84ArXgTGzKe9o0nSqa56H+v1J2HWawHGYNZrsV5/EtVV70vdNEJkLdY56D8wxiZA6BoeBfAzAOCc72eMLQVQAcAB4L6kyOAOpfsyLJqf7rT28c6PVVLykwjW6xp6phQzhvW6BvSsV0UI8YgpQHPOfxTktRcAvBDL+VXJdxmWb1AinUw1wI5/UJBWCxYglZ0xYYOZJJzeICQcVElMSmKXBlUTKu6SFN6wrgGOrgUApLI0TOs/CyMyqMIUIQBtliGtoisBjfjF5wmRlyA9aJ/etY1bsaFlFarNsdcxJ0QNqActJc/Q3sEVwu5VhChctbkCW06vh80l/DynsjQYNOmwuMyBh7p9cHBsP1OKERklKG1Zg0rzbnBwMDAUZ4zH9KzZ8b4FQmSDArTUcicKSWMUoLtSUV1utas2V2D7mVKYnW09XrNxq/BBGMHZw+xsQ2nLGlSYy73HODgqzOUw2U9jTu7NsTaZEEWgAC0HNA/dFWVxK0K1uQKbT30NBxd/9zbf4Oyr3nYcbxxdhAxtJib3nU7z1UTVKEDLASWLCd+DSx6VuhUkDNXmCmw5ta6zdywBs7MNm08JG+RRkCZqRUlickDJYvSAohBCr3m1pMHZw8Ed2HJqndTNICRuKEDLQe5EoPgGVW4YQdRl+5lSOGS085iNW/Hm0T9R5jdRJRrilgvfAiYNZcD+pdK2RwpUtEL2/CWCSY3DhfUtK7G+ZSUYGDg4zVETVaAetBzlTgR0BqlbkXgHV0jdAhJChjYz7PfqkRLHlvjH3aVzzc42bGz5inrWRNEoQMvVqDlSt0AU1RkpWDKkD94o6oslQ/qgOiPIH21aaiZ7k/tOh46FN/BmR0ecWxOcC05sOb1e0jYQEgsa4par3InA/k+g5M00qjNSsDknHQ6NsAbWrNdic046AGCEWdo/3iS07tnaqRoDpvWbiUv7XyV5Fne4PAVTCFEiCtByNmgyULdN6lZEbXt/gzc4ezg0DNv7G/wHaH2vBLWMhFJtrsCGllXeIWNACHad87yEkHijAC1nxfOAhl2Ay08hCJ0B0KUKy5P0vQD7uUS3LiSzzv8Mit/jTAuMvC7OLSKB+FYDy9Bmwu7q6BKcfQU6Lkdanz9xDc89B9PSTwCnE9BqYZx/E3KffVbC1hESHAVouSu+Aaj8rGuQ1uiFOWpPxvM3L8syQGc4XDDrtX6PAwzQ6IT7SjMKa8Epg1sS1eYKbGz5Ci4IW7bLMVM7esIITuVTD4IvW925bYfTCdOHHwEABWkiWxSg5c4TtGq+FnrL/oKZTIt8TD5l6TIHDQA6F8fkUxbgihclbBnxteX0em9wlppnmZRYnLCjtGUN+n36td+MWNPSTyhAE9miAK0Evmuk/WKQYzKZZ555e38DzDoNMhwuTD5loQQxmZFTIlU8hs8rzOWY7gpwXqc8HkwI8YcCtCrILzh7jDB3UEAmkuMaBuYvSGt7TsEQIhe0DloNlJb9bMiRugXELVkKeTRcM6rHYywHYJx/kxTNISQs1INWuoYyWSaIBWTIAaY9JHUriNv2M6VSNyEhau6/GACQu+ogmIuDaxg0N15J889E1ihAK13N1/E7N9MCqb27JqcdXBG44pdG739JmHAySgyTIXVlbAdXc//FqLn/YqrTTRSDArTSiZLBrQHg6naMASX/4z85bf+ynu8fNEVYt1253H9xlUGTRWgniVX39c6pLE0RFcHEkpdagDm5N0vdDELCQgFa6dKMsQVpfa/OAiHBlnJ5hFr2VTxP+LduO4RZPiYEZ89xElelLWtQad4NDg4GhuKM8ZieNRtA517Onu0izc42aKAVfWmTnNXbjqPaXEG9Z6IIFKCVruhK/z3aUHSGrsVOgPALhYRa9lU8jwKyBEpb1qDCXO79nIN7P5+eNdvvXs4uOKGFHk4EmppQn+1nSilAE0WgAK10nkAZbG64uyt+H7/2EMn4Bufux6dnzQ4435xMwRlIrnl3omwUoNXAt0cbaA7YIxn3mSb4uPZtqZsgG5HsaU2IlGgdtNoUzwPGzAeY3s+LGtXsM00iY3KeDvgaS7I/A5P7Tpe6CYSEhXrQauTpUTeUhZf4RVRBx/Rw8MiHq3mk+QsKR/PPRCkoQKtZyBreRA2qzRXYcnp9VMGZECJfFKAJUbDuW0WS4FI1lINBlIMCNCEKtv1MKQXnCNhcFrxxdFGPNeKEyFFyZYcQojK0ZCg6njXipS1rpG4KIQFRgCZEwWjJUGwqzbulbgIhAdEQNyEK5FtTm0QvWUqcEmWiAE2IwnSvqU2ix8CkbgIhAdEQNyEK46+mNgmsJGMCSjIm+H2tOGN8YhtDSASoB02IQnjWO9tcYdZcT3Izs67tUZQk0E5fhMgRBWhCFIDWO0cmQ5vZIzhPz5pNAZkoCg1xE6IAtN45fDqmo3rbRBUoQBOiAJStHR4GBgd3YPuZUlSbK6RuDiExoQBNiAKEs97ZwNIT0BJ58yybMjvbsKFlFQVpomgUoAlRgHCGbC28PQEtUQ4Oji2n1kndDEKiRgGaEAUYkVEScKkQCczGrVI3gZCoUYAmRCGEDGQqrEFIsqAATYiiiFOaMkObibzUAlHOJWe0vSRRMloHTYiCMDBR6kebnW2qywzXQNtlKZoGWkzrN1PCFhESG+pBE6IgVJrSPx3TY0bW1d5s9wxtJmZkXd2jWAkhSkI9aEIUxFMJq8JcLm1DZISB4dL+V2JERgkFZKIq1IMmRGGmZ83GzwoflroZspChzcTlWddQYCaqFFMPmjH2MYBR7k+NAEyc8wmMsUIAlQAOul/byjm/J5ZrEUKIr5KMCVRbm6haTAGac36z52PG2J8AtPq8XMM5nxDL+QkhJBAKzkTtRJmDZowxAPMBUMokIXHm2XZS7TyFWfzNt1PRFpIMxJqDng6gkXNe7XNsKGOsjDG2iTEWsE4hY+xuxtgOxtiO5uZmkZpDiDp5tp1U+57QOqZHhbkcxy2HkZdaANatQEuFuRz/OPoq1domqhayB80YWwtgoJ+XnuScf+7++FYAH/q81gCggHN+ijF2AYDljLExnPMeCy85528CeBMAJk2aJE4VBkJUKlm2nXRwO4Dg67WdsGN9yyoAoCQxokohAzTn/IpgrzPGdABuBHCBz9fYANjcH+9kjNUAGAlgR0ytJSTJKa24iFiFVQLj2H6mlAI0USUxhrivAHCAc37Cc4Axls0Y07o/HgZgBIDDIlyLkKQWzraTchLf4CxQ2kMLIeESI0Dfgq7D2wBwKYA9jLHdAJYBuIdzflqEaxGS1MLZdjLZdJ+fJkQtYs7i5pzf7ufYvwH8O9ZzE0K6GpFRgpPWOqok5iMRvXRCpECVxAhRmOlZszEz61rvcHey9yCVNuxPSLioFjchCuSv7nRpy5qk61lroKVhf6Ja1IMmRCU8Petkkaox0I5VRNWoB02IiozIKMH6lpVSNyNuGBjuLvyN1M0gJCGoB00IUQzaD5skEwrQhKhMqsYgdRPignavIsmGAjQhKjOtn/r2rPlZ4cMUnEnSoTloQlTGkzS1qeVrOGGXuDWxS2VpUjeBEElQgCZEhXyXYb177C+wcavELYoOA8O0/rOkbgYhkqAhbkJUblr/WYosZpKhzcTlWdfQMiqStKgHTYjKeQKckpZf/azwYambQIjkqAdNSBKItReqY3qRWkIICRcFaEKSREnGhKi/1sHt0EIrXmOCUOsyMUIiRQGakCQxPWs28lILehzXQIuSjAnQhAjATjhFacfPCh/Gzwof9vvAoIFWlcvECIkGBWhCksic3Ju77ISVoc3EjKyrMT1rNmZkXZ2A3mtnslr3Xbk8baGkMEIElCRGSJLxtxNW9+NvHF0Up6t33bs5UFsIIdSDJoT4Ec0ey0pcykWInFGAJoT0MLnv9IgCbl5qQVgbWVBVMELCR0PchJAePMPOW06t81YhS9UYMK3fTBw4uxf1tuPe9+alFmBO7s3ezyvNu8G7DWUDVBWMkEgxznv+Ikll0qRJfMeOHVI3gxAigmpzBbafKYXZ2YYMbSYm951O882E+MEY28k5n9T9OPWgCSFxQQlghMSG5qAJIYQQGaIATQghhMgQBWhCCCFEhihAE0IIITJEAZoQQgiRIQrQhBBCiAxRgCaEEEJkiAI0IYQQIkMUoAkhhBAZogBNCCGEyBAFaEIIIUSGKEATQgghMkQBmhBCCJEhCtCEEEKIDFGAJoQQQmSIcc6lboMXY6wZwDGp2yGSLAAtUjciTtR8b4C674/uTZno3pQrnPsbwjnP7n5QVgFaTRhjOzjnk6RuRzyo+d4Add8f3Zsy0b0pVyz3R0PchBBCiAxRgCaEEEJkiAJ0/LwpdQPiSM33Bqj7/ujelInuTbmivj+agyaEEEJkiHrQhBBCiAxRgI4DxtgvGGMHGWP7GWN/8Dn+OGPskPu1q6RsYywYY79hjHHGWJbPMUXfG2NsEWPsAGNsD2PsM8aY0ec1Rd8bADDGrna3/xBj7DGp2xMLxlg+Y2wDY6zS/Tv2gPt4P8bYGsZYtfvfvlK3NVqMMS1jrIwx9qX7czXdm5Extsz9+1bJGLtILffHGHvI/TO5jzH2IWMsLZZ7owAtMsbY5QDmAhjHOR8D4I/u4yUAbgEwBsDVAF5jjGkla2iUGGP5AGYDOO5zTA33tgbAeZzzcQCqADwOqOPe3O39G4DvASgBcKv7vpTKAeDXnPNiAFMB3Oe+n8cArOOcjwCwzv25Uj0AoNLnczXd258BfMU5Hw1gPIT7VPz9McYGAfglgEmc8/MAaCH87Yj63ihAi+/nAF7inNsAgHPe5D4+F8BHnHMb5/wIgEMAJkvUxlgsBvAIAN/kBcXfG+f8a865w/3pVgCD3R8r/t4gtPcQ5/ww57wDwEcQ7kuROOcNnPNd7o/PQvgDPwjCPb3nftt7AOZJ0sAYMcYGA7gWwD98Dqvl3jIBXArgbQDgnHdwzk1Qyf0B0AEwMMZ0AHoBqEcM90YBWnwjAUxnjG1jjG1ijF3oPj4IQK3P+064jykGY+x6AHWc893dXlL8vXXzEwD/cX+shntTwz34xRgrBDARwDYAAzjnDYAQxAHkSNi0WLwK4SHY5XNMLfc2DEAzgHfcQ/j/YIylQwX3xzmvgzBiehxAA4BWzvnXiOHedPFoqNoxxtYCGOjnpSchfE/7Qhh6uxDAUsbYMADMz/tll0If4t6eAHClvy/zc0xR98Y5/9z9nichDKEu8XyZn/fL7t5CUMM99MAYywDwbwAPcs7bGPN3m8rCGLsOQBPnfCdjbIbEzYkHHYDzAfyCc76NMfZnKHA42x/33PJcAEMBmAB8whj7YSznpAAdBc75FYFeY4z9HMCnXFi/tp0x5oJQi/UEgHyftw6GMPwhK4HujTE2FsIP3m73H8LBAHYxxiZD4ffmwRhbAOA6ALN45/pDRdxbCGq4hy4YY3oIwXkJ5/xT9+FGxlgu57yBMZYLoCnwGWRrGoDrGWPXAEgDkMkY+wDquDdA+Fk8wTnf5v58GYQArYb7uwLAEc55MwAwxj4FcDFiuDca4hbfcgAzAYAxNhJACoRC6V8AuIUxlsoYGwpgBIDtUjUyUpzzvZzzHM55Iee8EMIv2vmc85NQ+L0BQpYzgEcBXM85P+fzkuLvDcB/AYxgjA1ljKVASFz5QuI2RY0JT4hvA6jknL/i89IXABa4P14A4PNEty1WnPPHOeeD3b9jtwBYzzn/IVRwbwDg/ntRyxgb5T40C0AF1HF/xwFMZYz1cv+MzoKQHxH1vVEPWnz/B+D/GGP7AHQAWODuje1njC2F8MPoAHAf59wpYTtFwzlXw739FUAqgDXuEYKtnPN71HBvnHMHY+x+AKshZJb+H+d8v8TNisU0AD8CsJcxVu4+9gSAlyBMKd0J4Y/lTdI0Ly7UdG+/ALDE/bB4GMAdEDqLir4/95D9MgC7IPytKINQRSwDUd4bVRIjhBBCZIiGuAkhhBAZogBNCCGEyBAFaEIIIUSGKEATQgghMkQBmhBCCJEhCtCEEEKIDFGAJoQQQmSIAjQhhBAiQ/8PH8QuNyXVmDMAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAegAAAHSCAYAAAAnsVjHAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAB330lEQVR4nO3deXxU1fk/8M+ZJcmQQAYkIQthC1sA2UwBi4DiLiLoV0FrW7QutS5F7Q/FHRUrVqvSzdZqK7Yq4gZitIogiAtoIKwJW8KaBBKWSUiYSWY5vz/u3MnMZPa5M3eZ5/168SJz5+beM0zIM+ec5zyHcc5BCCGEEGXRyd0AQgghhHRGAZoQQghRIArQhBBCiAJRgCaEEEIUiAI0IYQQokAUoAkhhBAFMsjdAG89e/bk/fr1k7sZhBBCSNJs2rTpOOc8x/+4ogJ0v379UF5eLnczCCGEkKRhjB0MdJyGuAkhhBAFogBNCCGEKBAFaEIIIUSBKEATQgghCkQBmhBCCFEgCtCEEEKIAlGAJoQQQhSIAjQhhBCiQBSgCSGEEAWiAE0IIYQoEAVoQgghRIEoQBNCCCEKRAGaEEIIUSAK0IQQQogCUYAmhBBCFEhR+0ETQpKnaeVKNLz0Mhz19dBnZ8PZ2grY7Z7nWZcuyH9yAbKnT5exlYSkLkl60Iyx+xhjOxljOxhj7zDGMhhj/RljGxlj+xhj7zLG0qS4FyEkfk0rV6L+scfhqKsDOIfTYvEJzgDAz5xB3fyH0LRypTyNJCTFxR2gGWOFAH4LoJRzPgKAHsD1AJ4D8BLnfCCAUwBuifdehJD4Na1cibr5D4HbbOFPdjrR8NLLCW8TIaQzqYa4DQBMjDE7gC4A6gFMBfAz9/NLACwA8IpE9yOEBNC0ciXqn/k9uMUCANCbzej1yMMAIAxn19VFfU1Hfb2UTSSERCjuAM05r2WMvQDgEAArgC8AbAJg4Zw73KcdAVAY770IIcE1rVyJuoceBhwOzzGnxYK6B+eD6fXgfkPYkTLk50vVREJIFKQY4u4OYAaA/gAKAGQCuCyK77+dMVbOGCtvbGyMtzmEpKyGl172Cc4eLlfMwRkAsqZMjr1RfuqffBJVw0egamgJqoaPQP2TT0p2bUK0RooksYsA7OecN3LO7QA+BDARgJkxJvbQewOoDfTNnPNXOeelnPPSnJwcCZpDSGpK1FB0y7qvgz7XtHIl9k69EFUlw7B36oUhE8rqn3wSlneWAk6ncMDphOWdpdh35ZVSN5kQTZAiQB8CMIEx1oUxxgBcCKASwFcArnWfMwfACgnuRQgJgmVnJ+S6gQJ/08qV2DPhXNTNe8CTCe6oq0PdAw/iwM03BwzalqXvBry+fV819aQJCYBxzuO/CGNPApgNwAGgAsCtEOaclwLo4T72c855W6jrlJaW8vLy8rjbQ0gqqX/ySSH4SfB/ORDWpQu41Rrz9ZnRiPzfP4O6eQ8EP0mvR8nOHTG2kBB1Y4xt4pyXdjouRYCWCgVoQsKrf/JJWJa9JwwVM5awwCwlvdksrLUOoeD5P3gKpxjy85F7371UJIWkBArQhGiAZx5XaxgDMxg6J7O5P4AYCgooYBPNChagqRY3IQoSLunKsuw9mVqWYJwHzjR3dyAcdXWom/cADtx8c5IbRoh8KEATohAHbr65U9JV/WOP+wZpMQNaZZjZLMl1rN9voIQykjIoQBOiAAduvhnW7zd0Os5tNsWX2mRdugC6EL9KDAbku6uZScHyzlIK0iQlUIAmRGZNK1cGDM4ixZbaZAyAkABW8NwimM6d0OkUQ0EBzNddi/pnfi/prSlIk1RAAZoQGTWtXIm6Bx4MeY4hP98zN60Yen2n+WFr+SaAMRgKClDw/B9QsqsKWVMmw/LOUk9tcClZ3lkaUYEUQtSKsrgJkUnTypWof/iR8GU4TSbAak1OoyTCMjKQffXMpGWcs4wM5D/9FGV5E1WiLG5CFKbhpZcjq5GtsuAMCHPnyVwOxm021M17AFVnj6TeNNEMCtCEyESxc8tqZrejbt4DFKSJJlCAJiSBQu3eRNs4Jo7SM98JiQQFaEISJNjuTWKQzr3vXjCjUcYWapejro62tCSqRwGakAQJVvVLPJ49fTryf/8M9BIV8SAB+H0oIkRNKEATEoWmlSuxa8K5Qu9saAn2TDjXZ77Tu1Rn0KpfXsezp0/H4A3fw3zD9QFPNQ4shqGgQNLXkIqCbXVJiJIZ5G4AIWrRtHIl6h56GHA4PMecFgvq5j2AunkPCNsynjkT0bWqhpYAEKpw5T+5QDjotzOV+Ybrkf/EEx33DrVdYzh6PVhamrBtZCpS0HJSQiJFPWhCItC0ciXq5j/kE5z9RRqc/b+nbt4Dwlx1ooKIToeCRc+C22yJuT4hJCEoQBMSRtPKlah/7PGkb1QhzlV77h8rlwv1TyyAPjtbopapkMkkdwsIiRoNcRPi1rRyJeoef6KjMAhjMF8/Gy3rvpan9+l0omnlSqGgSZz352fOwBlJURQtYgwFT1GSGFEfCtCEwKsmtvcwM+dJrYYVSKc2xSMVA7T7QxaVACVqREPchMBd2EKJiURKbJOacA7Le+9TZTGiStSDJgRUdlPTHA7UzXsApz78EPaDh+Cor4chPx9ZUybj+MpPoW9pBgCcTuuCltvm4sJ7filzgwkRUA+aEFDZzVRg/X4DHHV1AOdw1NXh1DtLYWhpBgPAAHRrP4Oef3sOq//8ptxNJQQABWhCAAhlN0lqYQGOpXEX0t74e9LbQkggFKAJASiJiHj0aD0ldxMIAUABmhCSDCxQf1WZTmZ2l7sJhACgAE0ISQaVZKNzAO033SF3MwgBQAGaEEJ8UBY3UQoK0IS4sS5d5G4CkZmOtv4kCkIBmhC3/CcXAHq93M0gMsq+/DK5m0CIBwVoQtyyp09HwaJnwQL1ovT6wMeJprSs+1ruJhDiQQGaEC/Z06dj6IbvUfD8H2AoKAAYg6GgAAWLnsXQDd8Lx9TAaJS7BapEFeWIklCpT0ICyJ4+PeDa6Nz77kX9Y48rf2/lVNwYQwJUUY4oCQVoQqIgBu2Gl14WelsZGR3bUxJ1MxioohxRFBriJiRK2dOnY9Ca1SipqkRJxWaYb7he7iaRaPkVTmFmMwqe/T1VlCOKQj1oQuKU/8QTsu8bTSLHdQzDKivlboZsymrKsHjzYhxtPYq8zDzMHTsX0wZMk7tZJADqQRMiBVqepR4udVQ1S4SymjIs+G4B6lvrwcFR31qP+evn4+wlZ2Pcf8ehrKZM7iYSLxSgCZGAedZ1CbmuPsWWdjGTKeH3aM/tmvB7KNXizYthcwZOcLQ6rXho/UMUpBWEAjQhEsh/4glhLjrYphA6XdS9bJaRAZcEbVMNgwFITw/+fAwbbvj3lZ3pBmTc86uor6MV9a2hl5FxcCz6YVGSWkPCoQBNiETyn3gCJVWVKHj+Dz5FTfRmMwqeW4SCRc961lZHEqy5zQZusSSuwQoiJmnxpqbgJ0W74QZj0D09F225XcEZ0JbbFYZH78LQ61JzM4xIe8aWNgsWbliY4NaQSDCuoF1mSktLeXl5udzNICThqkqGqWaHJ0no9TDPug4t676Go74ehvx85N53b6es6b1TL4Sjrk6SWxoKCjBozWpJrqUFl7x/SdgetLfZQ2bj0QmPJrBFRMQY28Q5L/U/LkkPmjFmZoy9zxjbxRirYoydyxjrwRhbxRjb6/6bNlklxC0RBTGUWuWMdemCgkXPIv+JJzzL0watWR20EAwLVAXNEOWCE8ZoTbOfaIIzALy3570EtYRESqoh7sUA/sc5HwpgFIAqAPMBrOacDwKw2v2YEAIhEEUddEJgGRmJD0jeQ/N6ffiELr0eJbuqMHTzpojXF2dPn4783z/jkxwnDn9HzGRCwR+eozXNEIa1L3n/Epy95Oyov9fFXZ2GxcXrjVwyEpe8fwkllCVY3EPcjLFsAFsADOBeF2OM7QZwPue8njGWD2At53xIqGvREDdJJU0rV6Ju3gNRf5+hoAC5993rqWbmPVx84OabYf1+Q3QXNBph7NsH9n3VIU8z33A98p94wqf9ocqe+p8fr6qhJUGf05vN6PXIwxSUvZTVlOGxbx+D3RV72VcddMgwZOCM40zA5w3MgIXnLaR11HEKNsQtRYAeDeBVAJUQes+bAMwFUMs5N7vPYQBOiY+DoQBNUs2useeAnwn8yy8ggyFsxatogrTp3Ano9+9/h/4+9/xxoGDbtHKl8EHBe944xPnx2DPhXDgDJM2xLl0wdPMmSe+lBZOWToKlzZLw+2SnZeObG75J+H20LJEBuhTABgATOecbGWOLATQDuMc7IDPGTnHOO81DM8ZuB3A7APTp0+ecgwcPxtUeQtQkml40M5uRH2Uvsf7JJ2FZ9h7gdCYscCZL08qVqH/4EXCvjUCY0Yj83z9DPecAYhnWjtX2OduTdi8tSmSAzgOwgXPez/14EoT55oGgIW5Cwqp/8sngpUIZg/n62aoNqlLz9NhDZIITQTIDdBdDFzx+7uM01B2jYAE67iwVzvlRxthhxtgQzvluABdCGO6uBDAHwCL33yvivRchWpT/xBPoMnYs6p/5vWfdM82pBhZsG1DSWXZaNpraQ6wrl9AZxxk8tP4hAKAgLSFJ1kG756FfA5AGoAbAzRAyxJcB6APgIIBZnPOToa5DPWhCCJFGWU0Z5q9P7uIZmo+OTcJ60ADAOd8CoNPFIfSmCSGEpIBk9dhTBZX6JIQQjRF3rSLqRgGaEEI0JtSuVUQ9pCtlRAghJCkWbliI9/a8Bxd3Qcd0uG7wdT51s4+2HpWlXeZ0syz31SoK0IQQoiK3fX4bNhztKCjj4i68u/tdrKxeCavDCpPBBN5po83kmD+OKjpLiQI0IYSoRFlNmU9w9iaW4wxWlpOoD81BE0KISizevFjuJoQ0f/18TFo6iTbRkAgFaEIIUQm55pajYWmz4LFvH6MgLQEK0IQQohJ5mXlyNyEidpdd8b19NaAATQghKjG592S5mxAxNfT2lY6SxDRm3du7sPObOnAXwHTA8PMKMOVnQ33OWfHSZhzZbfE87j3EjBn3jU1ySwkh0SirKcOKferZ0oAxhrKaMqrNHQcK0Bqy7u1d2PF1x7683AXPYzFI+wdnADiy24IVL20OG6T3bDyK71dUo+VkG7J6pOPcGcUYPF4dQ26EqJ3aio+4uMtTzYyCdGwoQGuId3D2Py4GaP/gLDqy24IlD38bNPj6B/+Wk21Y9e9K1FdbfHroFMQJkU5ZTRkWb16Mo61HZVvbHA+b04bFmxdTgI4RBWiV8w6Iofz1jjVgYTIOxGv4B989G4+GDP4APOetfrMKLif3XGf1m1UAQEGakCiJ9bTV1GsOhOaiY0cBWsX2bDyKL9+sBHdGdj53RXf9HV/XIb/YjO9XVIc9DwB2rK+D/4d8l5Nj7du7MXh8XkTz44QQgdqGtINRS+a5ElGAVrGvl+2OODjHKpLeORB8eB0A7G1OvHLXV56eNRB4fpwQ0kErPc+5Y+fK3QTVomVWKtbWmuDoDHjmkuPlHZy97VgfPLATksq00POcPWQ2zT/HgQI0CSuSHnTMuJCARgjxNXfsXGToM+RuRkzyM/OxaNIinx22SPRoiFvFMjINsLU65G5G3MS5bkokI6SD2PN8duOzaGpvkrk10fni2i/kboImUA9axXr2zpK7CZIJl4hGSCqaNmAavrnhG2SnZcvdlKgs3LBQ7iZoAvWgVSbSZVVq03KyDX+9Yw3SM/WYPGsI9aYJcSurKQNjTO5mROW9Pe/R8LYEqAetIns2HsVXb+3SXHD21tbqxKp/V+Kvd6yhuWmS8spqyvDoN4/C0maRuylRcUW7ppMERAFaRb5fUQ1He+r84O/4uo6CNElpz258Fg6uvjwTXbiqSCQi9K+oEns2HtV0zzmYnd/QMiySutSWHCa6bvB1cjdBE2gOWuH2bDyKNf+pgtOhvjq8UqCRMpKqymrK5G5CTIq7FdP8s0SoB61gezYexZdLUjc4i95e8L3cTSAkqcQ63Gq0//R+uZugGRSgFez7FdXgrtQOzgBw6qiV5qJJyli4YSHmr5+v2jrclCAmHQrQCpaKc87BhKr1TYhaLNywEKPeHIWzl5yNUW+O6rReeOGGhXh397sytU4alCAmHZqDVrCsHukUpAlRuLKaMiz6YVGnpVD5mfmYO3aupyKYf/B1cZfnsThn+96e95LT6ASiBDHpMM6VM4RaWlrKy8vL5W6GYohz0DTMLbjr71N9CrVkZBrAwdHW6kRWj3ScO6OYCpyQpCqrKcNj3z4Gu8se8rzstOygGdk6psPWX24FAJy95GzJ25gsOqbDdYOvowSxGDDGNnHOS/2PUw9awcRgs/bt3bC3JX7nKqXz37LSuw55y8k2fPWWME9NQZoky+LNi8MGZyD0cinvOVsd06luDteoM+LpiU/TrlUJQJMFCjd4fB5uXzwFd/19Ki6+eRiYXu4WJQ7TAYa04CUNg21ZKXK0u6imN0kqKfZs9p6zVdvwsDndTME5gagHrTIGgx52pzZ709wFDJ2QH1dCGM3Zk2TKy8xDfWt9XNfwDsrec9Eu7lJkj3rRpEUUkJOE5qBVQqzDrfVSn4Y0HQAOR3vsP5dZPdLRb8RZ2LvpGNpahQ8zGZkGTJo1mIa/iaQinYMWMTAwxjzBN9ScbVlNGRZvXhz3BwCpbZ+zXe4maA7NQatcqtThluI1tpxs69QLt7U6sOqNSgA0R02kI/YkA2VxB8LBse2X28KeJxYqUeJa6Evev8QnO50kDs1BqwQN3UqAA18v2y13K4jGTBswDeuvX4/tc7Zj0aRFMOlNQc/Nz8wPe72ymjI8/M3DigzOAFDfWo8F3y1QbSlSNaEetErQmmhpiEPehCTCtAHTMG3AtIA94Ax9BuaOnYvbPr8NG45u8Bw3MiMc3IG8zDxM7j0ZK/atUNy8sz+b04bFmxdTLzrBqAetEufOKHbPzxJClG7agGlY8NMFyM/MBwNDfmY+Fvx0Af659Z8+wRkA7NwODo761nq8u/tdxfac/UmRwU5Cox60SojzpmKRDhIbY3p069TWvb0LO7+pA3cJy8CGn1eAKT8bGvQ4ISKxNy0qqylDdbN2lgHmZeZ5EtmOth5FXmYezU1LjAK0igwen4fB4/Pw1zvWyN0U1dJF8RO/7u1dPslm3CXUBN+5vg7eix/E4wAoSJOgFm9eLHcTJNW3a1/MXz/f81icmwZAQVoiFKBVZs9GGlaKR1urE3+9Y42nNCgQ/ahEsJWJO76ug+XYGcy4b6wUTSUao6Uh4eJuxZ2G6gGam5aaZJOajDE9Y6yCMfaJ+3F/xthGxtg+xti7jLE0qe6VqvZsPIov36yUuxma0HKyDaveqMSXb1ZKOmVwZLcFK17aLNn1iHbkZWpjed+EvAkhh+rrW+s77dJFYiNl1tFcAFVej58D8BLnfCCAUwBukfBeKenrZbvBKQlZOhwJ+fc8stsi/UUV4sS3/4X1uRLwBWZYnyvBiW//G/9Fty0DXhoBLDADz/UX/iwwC8e2LYv/+goxd+xcZOgz5G5G3AL1nP29u/tdCtISkKSSGGOsN4AlAJ4BcD+A6QAaAeRxzh2MsXMBLOCcXxrqOlRJLDSae1YfLVUwO/Htf5G9+ncwuDqyjDkAru8C3YzFwMhZ0V902zJg5W8Bu7Xzcxmjga6XAgYzkNUVGDceGDQ41uYrQllNGR795lE4uCP8ySrnvUsXCS3RlcReBvAAgK7ux2cBsHDu+Sk8AqBQonulpHVv75K7CSQGtlYHVv27EvXVFvUlkG1bBqy8F7C3AgB6APDfyoQBYM4zwIe3AYc2AFe+GN09Vj8VPDhnXwPo3DNjLS3A1+uEr1UcpCsaKlIiOAPCLl0jl4yk7O44xD3EzRi7EkAD53xTjN9/O2OsnDFW3tjYGG9zNGvnN7FvIEHkt+PrOnUl+G1bBnx4uyc4A52DcyflrwOf3B/dfZqOBD7e9dKO4CxyOIAfNkZ3fYV5b897cjchqcT13VR5LDZSzEFPBHAVY+wAgKUApgJYDMDMGBN76L0B1Ab6Zs75q5zzUs55aU5OjgTN0SaFFxYiEVDVVpifPQhhADtK5a/7zhtvW+aeU84W/jzX3/f57N6Br6M3Bz7e0hJ9mxSirKZM8RXCEkXM7ibRiTtAc84f4pz35pz3A3A9gDWc8xsBfAXgWvdpcwCsiPdeqYxRETHVU1WBGevJ2L/3sweFv7ctA5bf6Xst60lgxV0dQfrCxxGwb+60BL52Vlbs7ZLRbZ/f5rNmOBVpaZlZsiTy1/6DAO5njO2DMCf9egLvpXnDzyuQuwkkTlk90uVuQnJYTwoBePVTQKBtGJ3twnPiOYF66qc/B1ztvsdc7UKimMos3LAwosxnrdPKMrNkkrRQCed8LYC17q9rAIyT8vqpTEww2rG+LqaRRyI/sTCKKph6xNeLXnGXEIiDaTosJJYFY9si/N31UmG422kRgvagubG3SSapNu8czOTek+VugupQJTEVmfKzoZjys6G03EqlVLXU6vLnhOHpQD3gSIQKzpGybekI1CqWqvPO/r4+8rXcTVAdmtnUKNr5SllUl0MwchYw829yt0ITdKp78xOjvrVe7iaoDv3kaFBWj3RccONQ9QUFiRjSwi4ISjpV5hCMnAXoFVahN9plXApw3eDr5G4CUSka4lahjEwDbK1Bih0wYa5THE5d9e/Uqt0tboLx5ZuViiiLqoqtKMVkrabDANML9U+zi4AeA6QZqpbSpn9HXwxFJgs3LMSy3cvAKWmExIgCtApNmjUYq9+sgsvp+x+f6YGLfjnME5wHj8/D2rd3w96mgEiVJC0n2xTxoWTEZIUHZdG2Zb4JXeKnmqbDwh+l4S6hzbGUFU2ihRsW4t3d78rdDEVh4UvdED8UoFVIDMDiNolirzFQEtL5PxsSMJiTxDGkMXUEZ0BYs6y0XnI4H94eW1nRJKLM7c60sFFIslGAVqnB4/Miygr2D+ZaxHTKqbRmSNPhghtVEpyB+JZSyYYD5f8C+kxQbE+aMrc7szlt4U8iPihApwDvYL7ipc2a2g7RkKaDo13aX4b6NAZne/QjDumZekyeNURdy6lUiwvz5goN0KQzKlQSvRTN801dM+4bi95DzD7Heg8xdzqmZMZ0PYCObPX0TL2k17/jTxfg4puHISOz4/OrPkxmeEamAbf+cYr6grOaU/2DbbRBFCdDn4G5Y9VXZEZu1INOQTPuG4s9G49i/bI9sLU6cGS3BemZelx88zBVDIWLSW+JTAgLNIWw7u1d2PF1gF3FmJC4p0pqHooNttGGAuRn5gdd92tkRth5jAVgVIiBYcFPF9B2kzFQ8cdnEqs9G49i1b8rfZZqtbU68eWbleg34iwwaTukqhKqQznlZ0MxYnKBz94OhjSGi28apr6esyi7SO4WxO7Cx+VuQVBzx84NmhSVSsEZELacpOAcG+pBp6DVb1YFPM6dwIEdJzB8YkHgnmIKCNehFMutqp732mcwqLLAu4Lnn8WAtHjzYqqgRWJGPegUFGrJVcvJNhzYcSKJrVEWcX5b07YtA5bf4bXO2evnQc1z0gozbcA0fHHtF3I3g6gY/W8kPrJ6pCt+DjqR7G1OrHhps9zNSIxty4CXRgi7SLkCFK/RpwEGlWyJaeohdwtIhGYPmS13E1SLAjTxce6M4tTZtziII7st2LNRxZvLi4F4gVn4e9sy4c/K34auDuZsB+zWpDUzZjqjsNuWSpjTzXI3ISmy07Jh0ps8jxkYZg+ZjUcnPCpjq9SN5qBTUO8h5oBrobvnmTzJTl+9tUvy9cVq8v2KanUmfvmX7mw6LDxOy1JH8A0nu0hIDlPw/LO/+ePm47FvH4M91q07VaK5vRnb5myTuxmaQj3oFBRsLfTPFpwLQFhilMq7YQFQ7zB/oNKdznaVVgzzk10E3LdDVcFZZGDa7wtRIRLpaf+nhgQ0476xIZ+PpCet0zNwcEXsGiU11Q7zayEQB6IzKnpZVTCpsmmGgRmoEEkCpHAfiYQj9qTFYJWeqfdU18rqkY4Lf1mCzGyVBrIQDGk6nDujWO5mEG/pXVXXcy6rKUuJ4Jydlo2F5y2ktc4JQD1oElK4TTliquTFgBGTCnBgxwnZh5LFrHVxw41QO4Mp3pKr5G5B4lhPAk92D7xQPS0TuPJlxQXwZzc+K3cTOpGqiplRZ8TTE5+moJxgFKBJXKJdluW9ocQUAEse/la2IJ3VIx1zfj9RlntLbslVwP51crcisYJVkWlvFbagBBQTpMtqytDU3iR3M3wwMEmCszndjPnj5lNwTgIK0CQu584ojjjje8Tkgk5VuOQKzpoZxvbP2k5ZXEiQU0iAXrx5sdxN6ITHUC1Ox3RwcRfyM/Mxd+xcCspJRgGaxCXS/aa755kClsgM1wOPdevHUDIyDZg0a7A6h7G9bVvm7jmqsExnIigoQe5oq/rW0TMISZ86psN1g6+j9csKQAGaxM17nnrPxqP48s1Kn8zu3kPMQbPGz51RHHQeW5wPjnqeO0hpaWO6Huf/TEP7NX/2IDQTnHVpgEs7owB5mXmqqsFd3K0Yy69eLncziB8K0ERS4ZLKAp1fX23ptDmHOAQ9eHxeRAFaE0le0VJQjzFueiMADsRTzENB5T8n954sawZ3dlo2GGOwtFkiOp+CszJRgCaym/Kzobjxdxej9ugR3yf+3PncHlm98NSNb3seG9J0uODGoakRkKOmol2q7K1AVj7QEmOvU5+mqPKfXx/5WrZ7Z6dl45sbvsHIJSMjOj8/Mz/BLSKxonXQRBFqjx4B5zzon7VvVeGvv1mNky3HPN+T1SM9tYNz2B6jSoKzKNbgzHTAjL8qJkEMkHcOWswej7SyFxUYUS7GuXL+E5eWlvLy8nK5m0FkwBiD98+i2WwGAFgslpDnpbRty4SdqVLdNf9UVHAGgEvev0TWOejtc7ajrKYMD69/GC4EX2FBm1koA2NsE+e81P849aAJUSuFBSXZKPDfYe7YuTDqjLLdv6ymDNMGTMPvJ/0eabq0Ts/nZ+Zj0aRFFJwVjuagiaKIPeempiafx/49aUIAKCoxzJu4XnjRD4siTtSS0uLNizFtwDTPH6JO1IMmRM2yi+RugbwUlBjmb9qAaVh//XrMHjI76feub61HWU1Z0u9LpEUBmiiKxWKBxWJBdnY2srOzPY9JEBc+DhhNcrdCHqW3KHJ429+jEx6VJUgv+G4BBWmVowBNiJqNnAWM+hnA9HK3RHqltwgJYJ0+gDDhuStflKVZEdm2DHhpBLDADLw0Ao92GYztc7Zj0aRFSWuCzWlTZMlREjmagyaKRL3mCG1bBmx9G5rblNs/AK9+Cmg6AmT3FkYNlNxz3rYMWPlbwG4VHjcdFh4DmDZyFpbvXY4NRzckpSlqLDlKOlCAJkTNVj/VEQi0wtTDNziPnKXsgOwv0HtitwrHR87CzEEzsenYJkl2lgon0rXQRJkoQBNF6Nu3LxhjEZ1HvDQdCX+O2ig48SsiQd6TMsdJPPXWeJxxnElaU6gIibpRgCaKcODAAbmboE6m7hqryZ2urt5yINm9hWFtL2WZXfBYTg/YkxicZw+ZTUusVI6SxAhRq23LAJtF7lZIiAEz/iJ3I+IXILN+cY/usEcwQhSt7LRszB4yG9lp2Z5j5nQzFSHRCOpBE6JWq58StvDSDI2UcBVHALwS244aAgfnnxgn4uqMG9BDdxZOuk7gI9s7+NH+bUS3MelN+OaGbwCAgrFGxd2DZowVMca+YoxVMsZ2Msbmuo/3YIytYoztdf/dPf7mEkI8tDj//OFtwCf3y92K+I2cBdy3A1hgAe7bgbwAO0b9xDgRv+hyO87S54AxHc7S5+AXXW7HT4wTw17eqDPiiZ8+kYCGEyWRYojbAeB3nPNhACYAuIsxNgzAfACrOeeDAKx2PyaESCW7t9wtSIzy14Xhew0JVJv76owbkM4yfI6lswxcnXFDyGvlZ+bj6YlP0/xyCoh7iJtzXg+g3v31acZYFYBCADMAnO8+bQmAtQAejPd+hBC3Cx8Hlt8BuDS2BhoAPntQ/cliXsRg+tD6h8DdQ/k9dGcFPDfQ8fzMfMwdO5eCcoqRNEmMMdYPwBgAGwH0cgdvADgKoJeU9yIk5Y2cBYy9Se5WJIaWMtPdpg2YhmcnPet5fNJ1IuB5/sdnD5mNL679goJzCpIsQDPGsgB8AOBeznmz93Nc2MA3YAYIY+x2xlg5Y6y8sbFRquYQon1iFTGiGtMGTPPU5f7I9g7auM3n+TZuw0e2dwAADIz2a05xkmRxM8aMEILzW5zzD92HjzHG8jnn9YyxfAANgb6Xc/4qgFcBoLS0VCNpnIQkgRariIkUuo2kFB6d8CjG5I7BQ+sfAs6gUxb3Xt1ObJ+zXe5mEgWIO0AzofzT6wCqOOfe1es/BjAHwCL33yvivRchxIsWs7hFaq8mFoY4XP3Yt4/hx9Mdy6qMOiOenvC0XM0iCiPFEPdEAL8AMJUxtsX95woIgflixtheABe5HxNCpKLELO7sImEHqnioZBvJeE0bMA1PT3wa+Zn5YGCUnU06YcL0sDKUlpby8vJyuZtBiLJtWyZkOQdMpNIBkKt4CQOueVUIrgvMiKnwSP8pwJyPpW4YIYrGGNvEOS/1P06lPglRk23LgA9/HSQ46yFfcAZ8AnLpr6L/9p5DKTgT4oUCNCFq8tmDCB6EFbAeevVTwt9XvigMVSOK+tN3b0xIkwhRKwrQhCjdtmXAc/2BBdnKXx/snbh25YtCqctI5qT7T0lYkwhRKwrQhCjZtmXAiruUH5hFgRLXRs4SkseCoXlnQgKiAE2Ikq1+CnC2y92KyF34ePDjflswwmgSetcUnAkJiAI0IUr1yf1A02G5WxE5U4/gy6NGzgKm/8ndk2bC39P/lBLLqQiJFe0HTYgSfXK/sKuTWhhN4YuLjJxFAZmQKFAPmhAl2vSG3C2IDvWGCZEcBWhClIgrYMlUpJiegjMhCUBD3IQoxbZlQlKYXDW2dWmAK4aEtHNukrwphBAK0IQog7icSs6M7ViCc/8pwnpnQojkKECT2O3dA3z7LdDm3tM2PR2YeB4waLC87VKjzx5U13KqtEzgypdpaJuQBKIATWKzdw+wZrXvsbY24Ks1wtcUpKOjhkIkTAdwl7BE6sLHKTgTkmAUoEl4e/cAP2wEWlqArCxg3PjOwVnEudCrpgCtLUzfkbjWdBhY+VvhawrShCQMBehE0cLw7/p1QGWl77GWluDBWdRmE16/ml4rCc0/q9xuFYblKUATkjAUoKXi3ctMTwfa24XepKitzTew+fdIYwlmgXq28QbF9euAqirftsfih40UoCO1bVnH8LGaWE8KbacgTUhCUICWwt49wtyrGNTa2oKfu24twBjgcAiPW1qAr9cJX++qAurqOs4tKACmzwh+T++A792zjTUwBuoxx6qlRZrraNm2ZUIvVA3zz8GsfooCNInZlpom7G+w+Rxj6NhZnAHol5uB0QOyk900RaAAHY9YApozQAEKh8M3wIvq6oCVKwIH6XXrAl//qzWhA3SgXjfgOxwvhaws6a6lRduWCfO4dqvcLYmPXGu2ieoFCs5AR3AWvxbPScUgTQE6VlL2NoHgQ8p1dYGDqtMR/Dr/eEXopXPuO/Tt39MXe93iuVLq00fa62nN6qeiC846I9CjGDi+K3FtikWg7SUJicCBAME5mP0NNpzVNQ1FOaag5xxutGLn4RZY210wpekwvCgr5PlqQAE6VlVVybuX/1C2uJQpFO8gLA6hf/tN4EAsdXAGgD17gLx8mocOJpqepzETmP6yMJSstE00gm0vSYgf7wCqY7495UiUVzejvLoZPbsaMGn4WZ2uXbG/GU53Goe13YXy6macON2u6p4344n45Ryj0tJSXl5eLnczIvOPV+RuQXSyspI/LxyoF08EL42IbitJMYnMe7mTEixokrsFRAX8A2i8/IP0/zY3wtoe/OKmNB3yzGk4amlXZA+bMbaJc17qf5x60LFKxLBwIsmRtBWoF09BWjDokuh6wmKGt5KCc+ktcreAyMh/SDlUANx5uEWy4AwAx0/7TvGFCs7i897z3WIPu7y6GYByk9EoQPuLdOlSSYm0c9Ba53DQ0ivRtmVAxX/kbkUcGFD6K6rBnaION1qx9UAz7F6fFQMFwM01QvAryjGFDaDxMqXp4rqHmIx2oMHmGXo36oFR/brJ2sumAO1t7x6hp+e9BGrNauFPVpaQ+HToUEfwLijwXRZFQqOlV4LVT6mr7rbIaNLWvs/1FcCeTwD7Gd/jGWag+BIgf0zwcwwmYMh04RwN21LT5BO0vJdAhePiwCavXmoi5ZnTAmaER8v7tdmd8Oll95ehh00B2tsPGzuCs7+WFt8ec0sL0NqanHZpBS29EqhlaRLTCYHIfkbI1tZS/e36CqDyg8BTBjYLUPURYDkI1JUHPsdhBXa+L3yt0SAdaBlUtJN6iZoE7Nm1I3QdbrTi0HEJl4gGIcdyLwrQ3qLt4alpDloJxDXXqS67d3QJYnI5azBw90a5W5EY1V+Ens932YHaHxA6xLiE62g0QEezDCqZstKZT4KY1PPboexvsFGAlsXePepL/FKTggKafwaAJVepIzgDyltzLSWbJYKTIvhdENF11EnO34RGvTBE7h94Aw0zJ3p+W04UoIGOuWcKzon11n+krRuuNkuuAvYHqQBHkosZAW6P/zoZ5vivQTqxO4UgrTcwtDt4yGVR8SaIKRkFaCD03DORhncynXexlVQK0hSck6e+QphHdnkFYWYEhl0tzC1LEZwBIZlMg9bvPCF3E2B3AgwcpcWhM6mHF2UlJRFNDqkboKXatYnEhnMhO/6HjanZm1aDnkPlbkFs6iuAne+h0yAttwM7l0l7Lw3NP3uva1YKDmDrgeaQAfrE6eSuiPh44zGMGZCc5VfaDtDBNoZYty54LWuSXFTERJl6DlVvglj1F0jaDGrVcqBkZnLulUBSV/qSkj1ILl+g9djJ4ORAxf6ONd6JpEvo1eUkbscoZmZ7r2mm4KwsYhETres/Re4WhGc0Adf8U73BGUhu4lbtD8m7VwIlMxNaCuIHimQHZ5HTJfybJZp2A7T3BhNE+VpagDf+JXyw0qo5Hys7SGcXaaMQSVITt7QxRaakYW1/aQbW6ZgSPlAk499MmwF65Qq5W0Bi0dYmJI9pPUgrcYOJ7CLgvh3qD85A8hO36iuSe78EMKUpNxR0M+k7HVPCB4pk/Jtpcw6aym+qF+dUszvZjCZtbRuZP0bI1K5N0jB91UeqSBbzLtvpvzlEZrpylyqdON15SlLupVV6nZA9nmjaDNBEMRozcnAoawDa9OlId7ahT0sNcmyNIb+Ht5xGwz//iLphvTFm4uwktTSFaWFY25+5L3Bsm1CSM9FcdsUni/mX7RQ3hwCE0pWBgqBScAAfbTgGQBjuHtm3K4YXZWFzTTNcMswwMABj+lMWd2y0PDyqMo0ZOajuNgQunTBE1WbIQHW3IQAQMkgzMPRydUHOjhM4YHkT/ab9MintTYhP7gc2vSGUlWQ6gBkAl4I2ysgu0l5wDrQGOtFqNwofChTakw5WtvOAu3SlWmbS2x0cm6qbcU5xN+h1gEuGJDGOxGdvi5Q78RCrVMgGVolDWQM8wVnk0ulxKGtARN+vA0PfIypOHvvkfmHPZ7HmM3cpKzjrjNoa2gY61kAnMziLqr9I/j0jFCwAqyUwe+MAth08LVsGdzLn67XXg6YtDRWjTZ8e8XEODobO2ZoMTEgeU+Na6fJ/yd2C4Ew9gMuf007vOdi2kMmk4LrcwbaJZBCWLKmNWP4zkfPQpcXdOq0NT9bcs0h7ATori4K0QqQ729BmyAh43F+g4OxDXCutpgCttP5J6S3AlS/K3QrpyTGkHYiC63L3y80IuF9yZjpTbZnM4UVZCSuu0j83wzOMLVZXC1UPPFESHqAZY5cBWAxAD+A1zvmihN5w3HhaA60QfVpqfOagAUDncqJPS03Q7wmZVEYfvGKn1eAMCEPLcgdnQNF1ucVsbe8s7sx0hpY2hX2IjMKJ0+0JCc5Z6czz71WUY0pqQPaX0ADNGNMD+CuAiwEcAfAjY+xjznllwm46aDAFaIUQA2ukWdxhk8qykje0pCnZRdoNzvUVChlaZopNEBONHpDts1XjcndmtFoFGhEINpQfjZY2ji01TUnd9zmYRPegxwHYxzmvAQDG2FIAMwAkLkATRcmxNYZdViUKlVSW4zjVUUudRE5ra5wBZcw3+zPlyN2CqKm37xycVK9pf4MNZ3VNk7X3DCQ+i7sQgPfu9EfcxwjpJGRS2eQpKpt/BpCWKe/9tVK601t9BVD5gbKCMwBYGzRRUYx0SEat7XBkTxJjjN0O4HYA6NOnT9Dzmpub0dDQALs9grmm0nGAU6Yc/BgZ7e3IPXQQ3ZrVmbAhhaBJZbwdGDRchhbFSZ8OoFWee4ulO7Wm+ouOZWtKs3OZ4oe5SeSUUFkt0QG6FkCR1+Pe7mMenPNXAbwKAKWlpQFHKJqbm3Hs2DEUFhbCZDKBsTAZvwBgsQB2Ba05DYFzDqvdjtr0DGDv7pQN0kGTynp3DtqqYD0lz321OKwtUsR8cwjrfg9MeVjuVkRE7nKZSmfsXAI86RI9xP0jgEGMsf6MsTQA1wP4ONqLNDQ0oLCwEF26dIksOAOA2QyEW7qjEIwxdElLQ2F+Hhr69JW7ObLJsTWiuHk30h02gHOkO2zoaa3HDwfs+Hb5TpS9tw2frd8vdzMjl907efdi7t8mWhzWFlUtl7sF4dlPq2aoO5nredUo4liTQAntQXPOHYyxuwF8DmGZ1b845zujvY7dbofJJO9kfTKYjEbYjWlyN0NW3kllDRk52NNtCLq7e9Td0wxoa2zFZ+v34/JJ/eVsZmQufBz48LbE36f/FGGXLK1Ty97L1V+oYqi7KMek2jXQydDukD+NLuE1yzjnn3LOB3POiznnz8R6ndg+zcj/DxwNJXxiUwzGsCtrIHR+Wd3peh1cR0/L1KgojZwlrD+WUs+hvo9TJTgDUM3/Z6UPw3uRomylTqO/tpSwBafsSWKE+Pj1bzxf6pcHHmzJVsLkUKTE9cflr0tzvbtTuda8FKtck0DBFcX85ZnTAq4njgZXwVsSrWSX9AxG/o8ICcI5R8XRM7hz5T6ULN6E/n/8ESWLN+Gulfuwpb4FXMKfqpOnTuHqOTchs18/9B17Dt7+4APJrp3KLEGq4TfJVSU/Vle+CFzzT7lboX6F4+RuQXg6o6Irivk7aok/kVYL8bm0uJunx2xK0yVtO8lwNNmDtjtduH/ZFnxZeQxtDpdnz1Crw4XP9p7CmpomXDTQjBcv6w+jPv7PKHfNn4+0NCOO7diJLTt2YNqNN2LU8OEYPnRo+G8mHYYN83moy+uKtsZWpHu9R21OF3R5XZPdsviNnAV89iBgPRn7NUw9pGuPGpXMBFqPA5ZquVsSWIZZCM4qmH8WJSOLW+njHmkGJntJz2A014PmnOP+ZVuwqvIYrHZXpw29XVwI1Kv2ncL9/9vv1ZOObSKltbUVH3xShqfnz0dWVibOmzAeV116Kf7z3nvxvZBUM2wYMGmKz6HLJ/WHLScTp9odcHGOU+0O2HIy1ZEgFsjlzwk9rFjo04TvT3WltwLDZc5Q13slchpMQnsuehY470FVBedk7WKl5OAMACP7KvcDv+Z60FsOW/BlZQNs9tCfDG0Oji/3WbD1aCtG53cFunYVNmPg0X2i3FNTA4PBgMHFxZ5jo4YPx7rvv4up/SlFpwPOvyBkhTDVBuNAxKVPq58Cmo4ATBe66AbTCT+P2UVCRrgWl07FwnJQ3vsbuwAXPClvGySw7aBKki0T7MTpdkX2ngENBujX1u9HmyOyOco2pwuvbTqGv9xQAGS4i2GcPo1On/mMaUGLnrS0tqKb3yYO2d264nSLTBWklGzqhcKWkS0twsYX48arr3xnvEbO6gi025YBK+4CnH4/WzojMPNvFJD9VS13L7WSuU+moiztUKReRqRj6DRiqQZKqbsdiOYC9JpdDRH/kLg4sLqmqSM4i3+3tgIuJ6DTA5mZwnGbDTjdec1gVmYmmv22QWw+3YKuWTLXYVYaxoRgnGoBORQxAHvPTZt6CEPZFJx9VS0HahWUwV61XJgTJx4urvz55mAq9gu/25UWpDUXoG1RZvja/HvbGRkdgdr/uN0O2HznbQYPGACHw4G9NTUYNGAAAGDrzp0YPmRIVO3QvJISuVugTN49aiJU4ar+QuilGrsIa3gcyZkrjYr4YUHFQdqoB6ReEKHG4AwAThewqVp5QVpzSWIZUa6RzTBEcX7XrkDXbkLPGgB0emSau+OaaVfg8eeeQ2trK77d+ANW/O9/+MV110XVjpilZwB6CT9nMSasRY61aIre79+TsYAJYIR0Ul8B7Hy/YwjZfkaZwVmklspmQYzq103uJigKB7C5pjlpyXOR0FwPeurQXHy2oz6iYW4dAy4syY3uBgF62H/769/wq1tvRe7w4Tirew+88qc/Yfiw4cIweaIVDwAqJdxeW8xqLykJfF2zWZhDdjh8jzMmfA8FYhKr3SsBqGnzBrX2FwVU6rMzFxeS55TSi9ZcgL51Un+s2dUAawRjN+kGPW6dNCC6G9hsneaoexQUYPmnn3Y+L1DCmZSzNHoDcOiQNNfy9o9X3NfXd2zbSQGYJIo4rK3k3nJA6q9xqdcJw7ukgxJqcIs0F6BHF5lx0bBcrKo8FnKpVYZRh4uG5WJU7+zIL+4fdF1O92N0nrcOlnAGBEw2ixpjwJQpwJrV8V8rGKczoqVQhITlPbfsXdCjvgKo+ghwRbDPe9JE+CFaDZXNQjjcaKXgHMT/NjfC2u6CKU2H4UVZsvWoNTcHzRjDi7NG4+JhvWAy6jsVctcxwGTU4+JhvfDirNHRbVDR2orO/3G5+ziEAH7iBNDYIPwRA3HXbsBZZ3UMj3ftJqxxjcbUC4WlSYDw9wVThaCZleB6sS6XsDSKkFiJQVicW7ZZhMdi0FZUcIYQeCMpKFP7A/DlQ8A3z6lmi0lvOw+3hD8pRYkV1qztLmyqlm9eWnM9aAAw6nX40/VjsPVIE/75dQ3W7GqAzeFEhkGPC0tycdukARhVZI7+wsHmlF3O4EPagXrZ/vPYQZZweWRlBV+iNG58YnvRgDDnTEg0vHvMgbjsoZ+XU8lMwNwX2LkszInu/+viBw5AVZXEklHmUws4gK0HmmXpRWsyQANCT3p0kRl/vXGsdBfV6QMHaZ0+SO9a5O5lB1q+BfgVSfFjMAhBOJD166RNEAsm0b10oi2RDluLw91KCtLiTlTRVisTP3CoKECb0nQUpCNkdwpTAskO0poN0AmRmRmgl8zcx8PMK3sH9gCJZp5edX29EBBDVduKNTB7J31FSqcL/gGBkECiGbZWUnAGOnaiimUJldJeSxjDi7IoizsKchQzoQAdjVCVxsRjwYhrpwMmmjV3BHibLXQJzEiDc7Agv3cP8PW6zsukgqEEMRItlQUqH7tXur+IIZNXRftAA7TMKlpOlzBvTwFayYJVGktL61RlzIeYwd3SgrD/+cU55UCBsaoqombixl8EPi5e89tvgLa20NeYeiEFZxI9pQ1bR8Nhdc8nx7AcUkX7QMeif24G9jfY5G6GrKztLmypacLoAVGs/omD5rK4ZWGzCX9CaW0Ves6R7pYVLHOaR/BLI1xm+qDBwE2/6rT/so+CAgrOJDZnqbzMrcsOsBj6Liqaf45Fqgdn0f4GG7bUNCXlXhSgpRAyQczN5Qzdw/YXLHM6kmVhkda9njRF6CX7lwodNgyYPiOyaxDirb4CqN8sdyvix+1A4XhooRhJKP1zgySupigdA9IM4d/zZH1Y0ewQN+ccp1oc2FvfimOWNjhdQtWcXuZ0DCrIRPdMQ3RroANxJ3v95Z+v4o2l72J7VRVuuPpqvPHnP8X/AoJlTgcrwSmKtu417TBFpBBuWZXaGEzCcquSmcJa50jOVyFxqJZ6x4J0ow6Xjc3xFCqRmyYDtMvFsam6GfWnbD6VcpwuoO5kG45Z2pDfPQPnFHeDzr+SSaROn/b0iAt65eHR++7F51+thTXcUHekgmVOi8HXO0jr9cCU8ynQkuSrrwB2Le+8p7XaOazCa8sfE9mc+pDpyWhVQlCQ7mBtd+GTH49FtMvXqooGXDwmyr0coqS5AM154ODszekC6k/ZsKkaKB3YLfqetM3mM1x9zZXTAADlW7fiSF19rE3vEC45a9IUqolN5FdfAVR+APAkbAojh53L3MVKtD3MDSgjSDMA/XIzcNrqwPHTEa4ySYBIt+BsaeMJXxutuTnoUy2OkMFZJAbpU60x/CAEKigSNyaUAO3alXrCRB2qv9BucPYRQWKmZ3mWeiUrMzkYDuDQcXX14hNdLlVzAXpvfWvEBeCdLmBfXWt0Nwi4Q5UUvGp6E6IGWplvloI4JK5ykSRIJZLTBVl7z9FK9Dy15gL0MUuYtb1+jkZ5flSZ2NFKxv7RhEhFZYU5Ek6sx61iStpqUQ1MaYkNoZoL0NFun6ao7dbEamOEqEHGWXK3IPmMXYI/p7RduaKUrLW9WsEglEtNJM0FaH2Uryja8wNxOByw2WxwOp1wOp2w2WxwRFpK04N1VBsjRA0sNXK3ILn0acCUx+RuRcIcoCzuqJxT3C3hZT81F6B7mdOjOj8vyvOR0fkNWfjiSzD16YtFf/oz/vv++zD16YuFL74U/Bo6vXAdsces0wvJYcF2uyJEkVJsOLRrkfuLYPO06s72TrF3My5GfXI2zdDcMqtB+ZmewiTh6HXAwIIoe61duwp/e81FL3hgHhY8MC/ya5yVgkODRINiqFetZpZq4NuXEPQ1F45LanOkFs27qdcpbHowyUb165aU+2iuB909y4D87hlhh671OiC/ewa6Z8bwGUUM0oSkMpUHpJhYGwIfLxwvVB1TsX5RlP3snmnwJEipe9wgeqVJGNoWaa4HzRjDOcXdsKkaQddDi8H5nOIYipQA4TfGCNlAzX0mIgEsr6jF85/vRp3FigKzCfMuHYKZYwoDHgcQ8FzFM/cFaoNs6pJSmOqDM9CxDvpAgw0coXvUJ047MHNCL2ypaUqpCmTJDM4AwHgkuyMlSWlpKS8vL+90vKqqCiWRbgDhxjnHqVYH9tb51uLOE2txZxlja6TN1rF3cyy6dgs51xzLayWJEyzQ+nt0+Xa8vfEQXFH+d9IxBPyedIMOz/3fSOUG6qrlFJy9XfSs3C1IiI82HAv6XP/cDE8wTxVXT+iVkOsyxjZxzkv9j2uuBy1ijKFHlhHjB5ulvXCwXaYiwigRTCWWV9Riwcc7YbF2LJ2ptVgx7/2tAOATOB9dvh3/3XAopvsEC+htDhfufXcL7n13CwqV1quur6Dg7EO7g7yhetGp1HMGEr/mORDNBuiEsNki3885EJq7VoxQPePlFbV46MPtsAYoymt3cty/TAicyRLsg4Fsqr+QuwXKouG5+H65GSkXiIHOI1t6XeLXPAdCAToasZbi1OmFNc7Ue1aE5RW1mPfeVtjd/wNrLVbcv2wLHvpwG6z28B/Aoh3GloLdyfHkyp3KCNCpWuJz+CzAchCo/QEQZ2kLx2li/jkYJWyiIYexA7ph5+EWWNtdMKXpMLwoK6lzzyIK0NGIthRnhol6zQq04OOdnuAscnFEFJzldOqMQipVRbL9otYUjhe2nswfo+mAHMjoAdkpFaBNaToU5ZhkCcj+KEBHQ6ePPEgb0yg4yyDY0HWsSVwkgOJLhLrTKi9tGZEMs/B688fI3RKSJHIMZQdDAToamZmRZXBTz1kWyytqcf+yLZ4gXGux4t53t+CvX+3F3gb17xRmVMoKPTFYVX8h9KQNJsDl0GbAPu9BuVugCP1TZC46WRXCIqXdAM05ULsJ+O5PwN4vALsNMGYAgy4FfvpboHAsEO0a6IwMIYvbK1Gsra0Ndz74IL78ej1OWiwoLi7Gs88+i8svv1ziF0TCefjDbQF7yGoJziajDt0yDDh2uj3g83YXcOM/v8dbt52b5JYFIA73equv6AjaWlFfQb1npM5cdLIqhEUqrs/kjLHnGWO7GGPbGGMfMcbMXs89xBjbxxjbzRi7NO6WRsNpBz64FVgyHahaCditALjwd9XHwJIrheedMXziz8qC97IKh8OBooJCrPvsMzQ1NWHhwoWYNWsWDhw4INWrIRE6o/A55HCsdheOnW5HlxBd5W+rT+LR5dsxcdEa9J9fhomL1mB5RW0SWxlC/hjt9TgpY91j9IBsWZYaJZOSes9A/D3oVQAe4pw7GGPPAXgIwIOMsWEArgcwHEABgC8ZY4M554nf8Jhz4KM7gN1l7sDs/7wLsJ8BdpUJ5/3fa9H1pMVM7NZWwOVEZtduWPD0057jV155Jfr3749NmzahX79+8b8eEpT/fLNWhPug4b3mWsxABxSwBEvsQWuJlkYDJDC8KAsV+5s1WYe7Z1flDSjH1SLOuff/xg0ArnV/PQPAUs55G4D9jLF9AMYB+D6e+0WkdhOw+9PAwdmbwyqcV7sZ6H1OdPfIyAi6ZOrYsWPYs2cPhg8fHt01SUQeXb4db208BP8CeLWWMO+3hrm4MLwva4CurwB2vg9AY7+5M8xyt0BRxB7m1gPNCFAmQLWy0hkmDVfeJkZSjlf8CsBn7q8LARz2eu6I+1gnjLHbGWPljLHyxsbG+Fvx3Z8BR4TzJA4b8P1f4r+nm91ux4033og5c+Zg6NChkl2XCMSKXVJXpzUZdfj5hD7QqbgglOzD+7tXQnPBGQAylPdLW25FOSZc+ZNeKC3upvohbz0T6mtfPCZX7qYEFPZflzH2JWNsR4A/M7zOeQSAA8Bb0TaAc/4q57yUc16ak5MT7bd3tvfzyKt9cRew53/x3xOAy+XCL37xC6SlpeEvf5Eu6GvR8oramOZQ39l4OPxJUZpY3ANVT1+Or3Y10hKseDg0OoJhqRbqjpNOinJMuGysBL+zZaTXM8XNO3sLO8TNOb8o1POMsZsAXAngQt6x80YtgCKv03q7jyWePcosQwl+sXDOccstt+DYsWP49NNPYTTGuBFHCvAvo1lrseKhD7cDgGe3pydX7vQpytG9ixFPTB8Op8Rd54nFPTwZ0XUqHyKPZVO2uNVXCD1nrQZnUe0PKVecJFKHG+V/7+PZlbzdoexP5XHNQTPGLgPwAIApnPMzXk99DOBtxtiLEJLEBgH4IZ57RcyYEX7+2Zsh/k9Pv/nNb1BVVYUvv/wSJpNyP43J5dHl2/HOxsNBA6zV7sSCj3d2CsyiU2fsnlrUUvq2+iT6zS9DodkEcxejcip1xeDG8X2Se0OtzjkHpOxf4nLaeTiezYOkoeV3J94JhL8A6ApgFWNsC2Ps7wDAOd8JYBmASgD/A3BXUjK4AWGdc6R7LjMdMPiyuG538OBB/OMf/8CWLVuQl5eHrKwsZGVl4a23oh7t1yRx3jhc79ditYcMkHZn4v4b1lqsqg7OP5/QBwtnnp3cm1Z/gdQIzm71FXK3QJGs7er+GTDq5W5BaPFmcQ8M8dwzAJ6J5/ox+ek97sIkZ8Kfa8gAzr07rtv17dsXStpTW2kSMW9MfCU9OAOpt/yo+gsqWBKAKU2n2iDNoLzCJP6Ut/ArXoXnAEOuENY5h5obM5iE8wrHJq9tKcB/bbLU88ZEIVJtw4xUeq1RGF6Uhc01zapMsDynuJuiE8QAaZdZKQNjwNV/B4ZOA4xdOg93M51wfOg04TxZsmu06dHl23Hvu1tQa7GCI7XXJmte8SXQ4q+P4Oj3RCBFOSaMHdANaQZ1/fuIO1YpnfZ60ACgNwoVwmo3d9TidliFXvPgy4Cf3i30tIlkllfU+lS4IhonDvfuXCZvO5JGhV3EJBG3ZjzcaMWm6uaI/6XkGh7X65S1Y1Uo2gzQgNAz7n0OMGuJ3C1JCY98tF3uJqSkQjlLnOaPASwHgdqN8rUhWaiiWFhijzTSIC1HcDal6TC8KEsVvWdAywGaJFVru4bq/qmEUc8w79Ih8jaiZCbQelwo6KFlxZfI3QJVEANfeXUE2/LKQG2FVShAk6CWV9Riwcc7YbEKS5Ay0/Qw6nVostpRYDZ5gsPzn++Ws5kpSSzeIvsGGQBQeiuw7unIVk6oUeF4yuCOQlGOCSdOtytua0o1liWlAE0CEtcvexN6yR0VwO59d0vyG0aQmaaH5Ywd897b0uk9KHR/cEpa4BZ3sNJycKYqYlEbPSAbZ3VNw87DLbC2u8LON189oRcON1oTtlOWjqln3tkbBWjSCSV8KZs4nRBofwz/0qkJVV8BVH0EuNRb5CWshu0UoGMkJo+JPvnxWMAdsMRiITsPtyQkOOsZMGaA8pdUBaK+Pj9JOBqyVjer3Zmc97D6C20HZ0C7IwMyGNWvW6fFat7FQhKVNHbV+F6qDM6AlnvQnAPNh4GD64Hju4VfJDoj0HMo0HcS0K23ZGugf/7zn2P16tVobW1FXl4eHnjgAdx6662SXFsOat84giRpDToV7yBREIOk97C3d0Z1IpZd9c/NkPR6yabNAO1yCuszG6sAlwOeNYwuO9CwAzi+C8gpAYbPAnTxF2N96KGH8PrrryM9PR27du3C+eefjzFjxuCcc9S51lrtG0dEw6gDwFhCa30ny/mHN+Gmys+QY7Wg0WTG6sITuPCeXybuhqlQTUyCzXRIB/9hb2/Di7Ikn4MePSBbuovJQHtD3Jx7BWc7OhcY4MLxxirhPAlKUQ4fPhzp6ekAAMYYGGOorlbnspPlFbVoSpHgDAjzuA6NBOe5W95HL6sFOgC9rBb0+PsLWP3nNxN301RYetRrpNwtSBlFOSaM6d95GDxWSt8IIxLaC9DNh72CcwhikG4+Islt77zzTnTp0gVDhw5Ffn4+rrjiCkmum0zLK2rxu2VbU2mPIgDaqBF1U+VnyHD6/sxnOO1Ie+Pvibtp/hghy1nLTlA+RjIV5ZhwTnE36COMTF2/W4Xi383GkJsuQPHvZqPrd6s8zzENlHHWXoA++I17WDsCLgdwaL0kt/3b3/6G06dPY/369bjmmms8PWq1WF5Ri3nvb6XNLVQqx2oJeLxH66nE3rhkpjBVZOyS2PvIRetD+Aok9qTD6frdKuS/8QKMJ46BgcN44hjy33jBE6TbHer/Xaa9AH18FyLvE3GgcZdkt9br9TjvvPNw5MgRvPLKK5JdNxmeXLlTE/OwqarRZA54/GRm98TfPH8MMOUx4KJnhWCtpbKYWnotKlKUYwo7RJ37wWvQtbf5HNO1tyH3g9cAqLMwiT/1vwJ/0S77iLS3HQWHw6G6OehUSQrTqjeGXQ6b3uhzzKY3ov2mO5LbkPwxwHkPaiOw6YypMc+uUIGWZXkznGgIeVyNhUn8aS9A64zhz/E5P75E9oaGBixduhQtLS1wOp34/PPP8c477+DCCy+M67qERGNt0TlYPPpaHDOZ4QJwzGTGyTv+X2KzuEPRQmAruZpKfMpInI8OFqQdZ+UGPV6qgr2eI6G9ZVY9hwpLqSIa5mZAztC4bscYwyuvvII77rgDLpcLffv2xcsvv4yrrroqrusmm9lk9NTcJuq0tugcrC0SlvYVmk349p6p8jUmf4z6t6Kk4Cw7McgGWn7V8H+3Iv+NF3yGuV1p6ci68x5NBGdAiwG673nCPHQkQ906A9BnUly3y8nJwbp16+K6hhIsuGo41dbWCKNOAbtcqZ1Wk95UKGiBkwk/R00vE1pf+TP0xxvg7JmLzN/cgwE3/p/MLZaO9gJ0tyKhCEm4pVY6o3Bet97Ja5uCzRxTiAfe34p2ShRTNQbg+etGKWOXqwD2HMrD9zsGouVMBrK62HDuiH0Y3Oeo3M3qzKD++UstCVbgZMCN/wdoKCD7094cNGNCJmlOiXs+OkD1VzE4D58lWblPLfjDtaPkbgKJ00uzRysnOJuLfR7uOZSHrzYNQ8sZEwCGljMmfLVpGPYcypOnfaFYG4Dy1+RuBUlx2gvQgFC+c8T1wDm3AbkjOgK1zgj0GiEcP/sGScp8asnMMYUwm6JMsksCPX2IiojJqFNOcAaEfaK9fL9jIBxO3/9zDqce67fEMxyfwJ8Ni7pWYhDt0d4Qt4gxILsIGPkzuVuiKkqci54woDu+rT4pdzMUzahjePYaBZal9KrX3XIm8MYFtnYj9hzKi36oO8MMnDUEqN3Y+bnC8UIVMCo0QlRMmz1oErOZYwoxsbhH0OcH5WYmss8SEAXn0ArNJuXOOxdf4ln6mNXFFuQkhu93DIzuuuIa5ZKZ7nKj4k8lEx6XzPS5t4/C8dovUUo0Qbs9aBKzt247F48u3453Nh6Gk3PoGcMN44uwcObZAISyoM9/vjs5WxqSoExGPZ695mxlBmaRuFSp+gucO2IfVv0wAoGGpYP1rn0xAFzoORdf0nHtkpnCnxD3hs3S+fsAoPYHBF2S6TeHTkiyMa6g2sulpaW8vLy80/GqqiqUlJTI0KLkU9NrnbhojeKCtJ4xODkXf5VrVqHZhHmXDlF2cA7gtblfoq2t88BdVhcr5lzxTehvvujZBLUKQkKY95yzubjTHDohicIY28Q5L/U/Tj1oErN5lw7Bfe9uUUwgFHuUWu/dv6ykTO0oTf7ZCHz130o4vFZAGvROnDtiX+hvTPS+zBSMiQLRHDSJ2cwxhbhxQp+kz0kHIw731mk4OCsuUztKg8fn4YKfD0NWj3QAHFldrLjgnEoM7nPMPaQc6FcSA4ZMT3JLCZGfZnvQnHNsP74db+x8A+uPrEebsw3p+nRM7j0ZNw2/CSN6jpB8v9C9e/fi7LPPxrXXXov//ve/kl5bqRbOPBulfXvgyZU7A264YdQB9jg3mJ5Y3AObDzXBaneGPE8MXAVmk2Z70IrM1I7S4PF5GDw+yNrn+gpg90rA4X7/jF2AwVdS2U2SkjQZoO0uOx5Z/wi+OvwV2p3tcEGIEDanDV8e/BLra9fj/N7n45lJz8AY7eYaIdx11134yU9+Itn11GLmmELMHFPoSR6rs1hR4DVHuryi1ieAm4w6ZBj1OHXGHnau+MCiaQCExLT7lm1BJCkT8y4dgoc+3B42oKtN9y5GVfeeI5I/hoIxIW6aC9Ccc09wtjk7L+twwQWrw4qvDn+FR9Y/gucmPydJT3rp0qUwm8346U9/in37wsynaZQYqCM9DgiB93fLtsIZIPIWmjvmHcXvD7ZG23tpWLhzlSjcZiV6HcMT04cnsUWEELlpbg56+/HtWHtkbcDg7M3mtGHtkbXYcXxH3Pdsbm7G448/jhdffDHua6WamWMK8cdZo2Dy253dZNR32vBh5phCvDx7NIx+P7UTi3vgrdvO7XSuWphNRiy4ajiMusAfFDPT9PijUtc5E0ISRnM96CU7l6DN0Rb+RABtjjYsqVyCF6a8ENc9H3vsMdxyyy3o3Zs23oiFGHgCDY8HOldrgUocin/+ulER/RsQQlKD5gL010e+9sw5h+OCC18f+Tqu+23ZsgVffvklKioq4rpOqtNi4I1Um8OFee9vxfPXjsK382Xcw5kQoiiaC9Btzsh6zyKbI/RQeDhr167FgQMH0KdPHwBAS0sLnE4nKisrsXnz5riuTVKH3cnx/Oe7U/ZDCiGkM83NQafr06M6P8MQSYnB4G6//XZUV1djy5Yt2LJlC+644w5MmzYNn3/+eVzXJfFL1M5cL88enZDrann9NiEkepoL0JN7T4Yuwpelgw6Te0+O635dunRBXl6e509WVhYyMjKQk5MT13VJ/AIlXukYgiZjReLnE/pg5phC/HxCn3ib10mBOcHVsgghqqK5AD1n+BykGyLrRafp0zBn2BxJ779gwYKUKVKidDPHFOL560ah0GwCg7Bs68VZozF7XFFM1/v5hD6eDUMWzjwbL88eDZN/Snkc/LPWCSGpTXNz0Gf3PBvn9z4/6DpoUYY+AxcUXYARPUcksXUk2QIlnz3/+e6or1NoNnmCc6Bre+/w5V98xWwyYnhB15DbZoo9c0IIEUkSoBljvwPwAoAczvlxJlT+WAzgCgBnANzEOU9KxhRjDM9MegaPrH8Ea4+sRZujzSerWwcd0vRpuKDoAjwz6RnJy30S5Ytlrjdc7zaSLPRHl2/Hfzcc6nTcu2dOCCGiuAM0Y6wIwCUAvH/zXA5gkPvPeACvuP9OCqPOiOcmP4cdx3cItbhr18PmsCHDkOFTi5ukpmhrdUvVuxXrltNaZ0JIJKToQb8E4AEAK7yOzQDwJhc2m97AGDMzxvI55/US3C8ijDGcnXM2/nj+H5N1S6IS8y4dgnnvb4XdGb6wt9S921Re700IiU5cGS6MsRkAajnnW/2eKgRw2OvxEfcxQmQ3c0whnr92FLp3Cb0MK03PaOiZECKbsD1oxtiXAALtDfcIgIchDG/HjDF2O4DbAXiKfRCSaP4JXr97byucro4etV7H8IdrR8nVPEIICR+gOecXBTrOGDsbQH8AW92JVr0BbGaMjQNQC8B7LUtv97FA138VwKsAUFpaGsFmgoRIK5pa4IQQkiwxz0FzzrcDyBUfM8YOACh1Z3F/DOBuxthSCMlhTcmcfyYkWjQ3TAhRmkStg/4UwhKrfRCWWd2coPsQQgghmiRZgOac9/P6mgO4S6prx4Jzjob2emxr+hGHrDVwcAcMzIA+pmKMyv4JctLyJFsDff7552PDhg0wGIR/zsLCQuzeHX0xDEIIIUSkuUpiAODkTnx1/FMcPFMNJ3eAu+s6ObgD+8/swSFrDfp2KcYFPa+Anukluedf/vIX3HrrrZJcixBCCNFcLW7OOb46/ikOnNkHB7d7grPneXA4uB0HzuzDV8c/hdDZJ4QQQpRFcwG6ob3e03MOxckdOHimGo3tRyW570MPPYSePXti4sSJWLt2rSTXJIQQkro0F6C3NZWHDc4iJ3dga9OPcd/zueeeQ01NDWpra3H77bdj+vTpqK6ujvu6hBBCUpfmAvQha3WnYe1gODgOWWvivuf48ePRtWtXpKenY86cOZg4cSI+/fTTuK9LCCEkdWkuQDsi7D13nG+XvA2MMZrbJoQQEhfNBWgDiy4x3cBC12MOx2Kx4PPPP4fNZoPD4cBbb72Fr7/+Gpdddllc1yWEEJLaNLfMqo+pGPvP7IlomJuBoY9pQFz3s9vtePTRR7Fr1y7o9XoMHToUy5cvx+DBg+O6LiGEkNSmuQA9MrvUXZgk/NC1nukxKvsncd0vJycHP/4Yf6IZIYRIbf3Bt1HlOgIOgAEo0fXGpL4/k7tZJEKaC9C5afno26UYB87sC5nNrWcG9O0yEDlpgTbqIoQQae1tqcQPp9ajxdmMLH03jOs+CQACHvv2xGq0cRsAIF1nwsQeUzEoa1hU91t/8G1Uuo4A7oqJHBAeH3ybgrRKaC5AM8ZwQc8rAlYSA4RhbT3To2+Xgbig5xWSlfskhJBg9rZU4usTn3uSWFuczVh7/H/gcHl+P7U4m7HmeFmn721zWbHmeBnWHC9DOssAGEObywoGBg7uCez+AbzKKzh7MIZK1xFUH/oL2lxWn6eCXYfIR3MBGhCGri/seSUa249iq6cWtx0GZkQf0wCMyv4JctPz5W4mIURh1h9fhaqWreDgYGAoyRqFST0vjvo6/r1lu6u90woTF5xRX7eN2yD2N7wD+9cnPgcAn+AaKgvHPziL1/nq+KedrkPko8kADQg96dz0fFyce5XcTSGEKJh3MPXGwVHZsgV7WnfCwe0R9zD3tlQKZYS9AmiiObgDP5xaH1lgDTFqyMHx7YnVFKAVQrMBmhBCQtnbUukz1xuMmHAqDkGLw9D+AXtvSyW+PbkmYO80GcQPAuIoQKhAHEq4fw+SPBSgCSEpx39OOBZiwP725BoUdxniGRqX0z8OPC/r/Ym0KEATQlLOD6fWxxWcvbW5rKhs2SLJtZQgXWeSuwnETXOVxAghJJxkzAurlcNlx96WSrmbQUA9aEKIhgRaaxwo4SlL342CdBBOOLDmeBk2n/oes4tukbs5KU2zPWjOOaxbt+LI3Huxa/QYVJUMw67RY3Dk3vtg3bZN8s0sli5dipKSEmRmZqK4uBjr16+X9PqEkMD2tlTircP/wD8OPI81x8s8gVdcfhSoNziu+6So6/anGovzJFbWvyt3M1KaJn9Cud2OuvnzcXrNV+BtbYDLJRy32XD6iy/Qsm4duk69AAWLFoEZ49ssAwBWrVqFBx98EO+++y7GjRuH+vr6uK9JCAnfI/Zf0uTPwR2ezGvv7xevEWh5FelQ13ZI7iakNM0FaM65EJxXrwG3BVgu4HKBW604vXoN6ubPR8ELL8RdTeyJJ57A448/jgkTJgAACgsL47oeISRw9S0x2IpFRKpbd0WcOe1f0MM7UO9tqQxYxYsQOWkuQNu2bRN6zoGCsxdus+H0mq9g274dppEjY76f0+lEeXk5rrrqKgwcOBA2mw0zZ87E888/D5OJsiEJCSVY5a5wPWOxiEi0/At6ePfQ01kGrQEmiqK5OegT/35DGNaOAG9rw4l//zuu+x07dgx2ux3vv/8+1q9fjy1btqCiogILFy6M67qEaN3646tQ2bLFE4TFoPvu4dex5nhZwtYUi0PaYg9dfEzBObB3D78udxNSluYCdMvatZ4557BcLrSsXRfX/cRe8j333IP8/Hz07NkT999/Pz799NO4rkuI1lW1bA143OI8mdD7Zum7AZB2LbSWWZwnKUjLRHMBOtLes+f8MEPh4XTv3h29e/f2mcemHbIICU+uqlvilo6UHBa5RH9oIoFpbg6apadHFXRZRkbc97z55pvx5z//GZdddhmMRiNeeuklXHnllXFfV2vKaspwYqsNxWyocIAB2Wd1wYjz+svbMCILcbvEZBPnn2ktdHTWH18V085eJHaaC9BZ55+P0198Edkwt06HrPOnxH3Pxx57DMePH8fgwYORkZGBWbNm4ZFHHon7umrXeNiCQ1UNaLMKe3KbeT+Yme8IQ9OJM/huhdc6VQb06mNG8egCGVpMEsUnGUtnAjiXrQf91uF/YFz3SRjXfVLc9bhTiZiUR0E6eZjUBTviUVpaysvLyzsdr6qqQklJSUTXsG7dioM33QxuDb+jDDNloO+SJXFlcUstmteqZI2HLdhXUR9XQRiDUY/+Z/dCTpG507X3VtT5bHjb7SwT9cQVSoqNKaRmYAZMPutSAAiZLU58MTDc3u//yd0MzWGMbeKcl/of11wPOmPkSHSdekHwddBuLCMDXadORcbZZyexddrh3TsGA8CBdJMBfUpykVNkxv7tx+Ku1uawO7GvQij60nziDI4dsgTdhb75hBU7vtlPQVphwi2XkouDOxTZLqWjf6/k0lyAZoyhYNGigJXEAAA6HVh6GrpOnSpUEqOErqg1Hragems9XE73f1b3X21WB/ZursPezXWS3YtzHvH1mk9YfT44eH9gIMkn9pyV+ktdqe1SMgb6fZlMmgvQAMCMRhS88AJs27fjxL/+jZZ168BtNrCMDGSdPwVn/epXMFHPOWaHqho6grPCeAfzNqsD1VuFHjgF6eSjZUzaU5I1Su4mpBRNBmhA6EmbRo5E75dfkrspmtNmVc8vXZeTY2+F0KunHnVyUYa0+jh3dgdfVwg0pwHd2sGm1EI//JRPlTeSPJoN0CRx0k0GVQVp/yH4YwdP0Vx1EtAyJnVx7uwO/llfwKEXDjSng3/WF0adCb+6/EZ5G5eiNFeohCQB10m+XWcyNZ+wonqLdPPkJLBuBrPcTSBR4OsKO4KzyKGH9ase8jSIUA+aRGfPxqM4fcqKNJM+/MkKduygBZaGFkomS6D6tsNyN4FEozktuuMk4agHTaLy/YpqGDMU8GMjQTKpOEwvJpM1HrbEf1HiQVnSKtOtPeDhDLO6P4yrmQJ+0xI1aTnZBrvNKXczAA706muW7HIuJ8ehqgbJrkdoSY7asCm1gMH3/7bOCEy6eqhMLSLaHeLmHGhoALZtAQ4dAhwOwGAA+vQFRo0CcnIBidZAZ2Vl+Ty2Wq2488478ec//1mS6yvJoHN7wJihB+fcZw25/+NkOHbQIun1wiW+NR62oGZ7PZx2oWcYrNIZEZRkjYppz2YiD/3wU3ACPlncF/7fGAwenyd301KWNgO00wl8tQY4eED4WkxocjiA/TXAoYNA337ABVMBffzDNy0tLT5f5+Xl4brrrov7ukqz45v9yDIHno/SSsGXHd/sR6++3X2KnZhzs3Ci7jQcdt/ehcPuxN7NdWg+cYZqhwcwqefFqLMeop2QVEQ//BQw/BQAYFjWaAzuScFZTtob4uZcCM4HDggB2T/bmHPh+IEDwnkSZyN/8MEHyM3NxaRJkyS9rhI0nwhf31ztmk9YsXdznc/89LGDlk7B2duxgxaavw5idtEtGJY1moa7VYZBR2ueFSDuHjRj7B4AdwFwAijjnD/gPv4QgFvcx3/LOf883ntFpKHB3XMOs07X6RDOa2wAcntJdvslS5bgl7/8pWZ6lCQyezfX4VBVg082OJUdFUzqebHnl/1bh/9Ba6NVgCOC3QBJwsUVoBljFwCYAWAU57yNMZbrPj4MwPUAhgMoAPAlY2ww5zzx2UXbtgrD2pFwOoGtW4GLL5Hk1gcPHsS6devw+uuvS3I9oi5tVgf2VtRh//ZjnXrcYpGUVB8Opy0eCYlcvEPcvwGwiHPeBgCcczENdgaApZzzNs75fgD7AIyL816ROXQw8mFrzoXzJfKf//wH5513Hvr312iVKhoUCI8j7HB4KhdJGZQ1DJPPuhRZ+m4A4PmbENJZvAF6MIBJjLGNjLF1jLGfuI8XAvCuUnDEfawTxtjtjLFyxlh5Y2NjnM2BML+cyPNDePPNNzFnzhzJrqc0g8akbs9PSqk+Zz0oaxhuLPo1ft1vHm4s+jUFaQUaljVa7iYQRBCgGWNfMsZ2BPgzA8IQeQ8AEwDMA7CMRTn5yjl/lXNeyjkvzcnJielF+DBEOWof7flBfPfdd6itrdVk9rYop8iMQWMLkG7SZvJ/Mu3dXIdNX+xJ6UAtGtd9EnSgYhjxSteZMCxrtOcDT6jEvHSdCb/uNy9gIB6WNZoSxBQi7G9azvlFwZ5jjP0GwIdcKMz8A2PMBaAngFoARV6n9nYfS7w+fYWlVJEMczMmnC+BJUuW4JprrkHXrl0luZ5S5RSZkVNkxg+f7g45lEvCo807BIOyhgEAvj25Bm0u7a8UkFo6y8BNfe/pdHxvSyW+Ov5pp4puDAwTe0wF4JvAR5Qn3q7QcgAXAPiKMTYYQBqA4wA+BvA2Y+xFCEligwD8EOe9IjNylDCvHMnQtV4vFC2RwD/+8Q9JrqMWZxV0lbxQSKpqPmHFdysqPY/1RoYBZ+enVMb3oKxhGJQ1jLK8Y9DGbQGPez74nFjtOSddZ8LEHlM9zxFlizdA/wvAvxhjOwC0A5jj7k3vZIwtA1AJwAHgrqRkcANAbq5QhOTAgdBLrfQG4byc3KQ0S0saD1vQeKRJ7mZoltMu7GENIKWCNEBZ3rHa21IZMOiKH3yIOsWVJMY5b+ec/5xzPoJzPpZzvsbruWc458Wc8yGc88/ib2qEGBMqhPXrJ8wv+0+JMyYc79dPOI/WK0ftUFUDXE7aCCGhOFKyNrh/lne6zoR0lpH0dqitsMq3J1bL3QSSANrM9tHrgQsvEoqQbN3aMeTtqcU9Wuhpk5iEq1lNpJGq/87Ben2vHnghaTtkqW0nrmDD3ETdtBmgAaFnnNtLsiIkpEO6yZCywSOZKFveVzSbb6SzDApaRPW0V4ubJFyfklzo9PIMAer0DBmZRlnunWzm3KzwJ6WQST0vjryud4pNXaXrTHI3gSQAfUQnURMTl8Q608nSq68ZxaML0HjYgr2btV+Ny9Ig7JJGNb07eC8LWn98VdAedZvLimFZo1Niu0sd9J5lU0RbKECTmIjroQH4LBFKpGMHLeh2VpeUSZ5qszo6/duKa6f3bakHd3GfgJ1qgXxSz4uxp3UnHNze6bksfTdM6nkx8jIK8cOp9WhxNiNL3w19TANwyFqjqaVc5/e8jDK1NYoCNFGVZPfalYq7hCSmNqsD1VvrcXh3I2ytHYFKPA5oe6nW5LMu6bQsy8AMGNdd2O411DKjvS2VWHO8LCntTJQsfTcKzhpGc9AkaVwujuOHz0Cni/3Hrs3qANOl1vxiOC4n9wnO3se1PtoQaPONyWddGlHQGpQ1TNVzt94fRIg2abYHzTnHsQPN2LLqEA7uOAFHuwuGNB36juiJMRf3QW6/rpLt2XzgwAHceeed+P7775Geno5rr70WL7/8MgwS1flWuoxMY+AA4XJ5/o2ddheOVJ7GqXobTtW1Yc7vJ3rOi3aIXOw9kvBSYbQhnmIcE3tMDdgDH5w5IuKhcAaG/PQi1LUd6vSciWXCyltjalsoWfpuGNd9EvWeNU6TEcTpdGH1vyuxf9txOO0uT1luR7sLNRUNOLjjOPqP7IkLbx4GvT7+QYQ777wTubm5qK+vh8ViwcUXX4y//e1v+O1vfxv3tdVg7EWDsPnLvT5BOiPTiO/fPxzw/JaTbclqWsqjpVqhiQHOe57aO/CFSkQTpbF01LcF/lm38lYMyxqNPa07JKuORptZpA7N/e/lnAvBeetxOOyuAM8LgXr/1uNY/e9KXHzL8Lh70vv378fdd9+NjIwM5OXl4bLLLsPOnTvjuqbajL1oUKdj29c0BAzGWT3SfQ8wQGV1IVSDlmqFF6oHLgbCUEE63HrrQ9YaTD7rUs+HAH96GDGl5yVBnxcxMJRkjaLgnEI0F6CPHWjG/m2Bg7M3h92F/duOo+HAafTqH99+tPfeey+WLl2K888/H6dOncJnn32Gp59+Oq5rasG5M4rx1Vu74GjveC8MaTqcO6PY57xefcy08UaCiJnvWk4US7RJPS8OGaCz9N3Q6jwdtPpYi7M54mH4QLtP6aCnTO0UpbkksS2rDsMZJjiLnHYXtnzZed4oWpMnT8bOnTvRrVs39O7dG6WlpZg5c2bc11W7wePzcMGNQz095qwe6bjgxqEYPD7P57zi0QVyNC9l1Gyvl7sJqmfW9wj63Ljuk1CSFXxXPDGBLZxBWcNwQc8rfGqPp+tMFJxTmOZ60Ad3HI9oK2hAGO4+sP14XPdzuVy47LLLcPvtt+O7775DS0sLfvWrX+HBBx/EH/7wh7iurQWDx+d5AnLjYQv2VtTh+IqTPucke55Up2dgOmHXqFTgtHNPIl5GpjHgdAQJbXbRLXj38OuwODt+dhl0uKDn5Z7escV+slOiWLSZ1rT7FPGmuQDtPZwa0fkR9raDOXnyJA4dOoS7774b6enpSE9Px80334xHH32UArSXUNW/kpFpLFYh85esIitKYWu1Y/OXeylIx2B20S0hn5+ePxt7WyqDJpwREi3NBWhDmi6qIG0wxjfK37NnT/Tv3x+vvPIK/t//+39oaWnBkiVLMHLkyLiuqzVyr8dtPNJEc7FugZbEEWlQD5hISXNz0H1H9Iy4Tj5jQL+ze8Z9zw8//BD/+9//kJOTg4EDB8JoNOKll16K+7paIvd63FQo2kEI0RbN9aBHX1yEgzuOR9SL1ht1GH1Rn/jvOXo01q5dG/d1tEwJW1QGur/eyFJmLpoQoi6a60H36tcN/Uf2DDt0bTDq0H9kT+T265qklqW2PiW5cjchYDLagLPzEcnuhVrTeNgidxMIIWFoLkAzxnDhzcPQf1RPGNJ0nYa7GRPmqfuPEiqJSVXuk4SWU2TGoLHyLafS6VnADwk5RWYMGlOQchW3qrfWU5AmROE0+VtJr9fh4luGo+HAaVSsOiQMedtdMBh16Hd2T4y+uA969YuvOAmJnrhFZeNhC6q31sPlTM7QcritF8XjyWyT3MQ5eUqaI0S5NBmgAaEn3at/N1x2+wi5m0L8eO8lLZJ8uRMDBo0piDgAHapqSJngLJI7J4AQEppmAzRRl6iSyJhQHtTa0obmE9aAp0QTnAHpg5V3MRQlJ6KJH4wMRj36n92LetSEKAgFaKIIfUpysa+iHjxIGbhghUaqt9T51PFmOmDg6OiCMyB9lrnLyQGn8LXTzsEYQ26fbMXWHHfYndhXIZQEpSBNiDJQgCaKIAaF/duPwWF3eo7rjQwDzs4PGjSKRxdIUsu7T0lu0EpnUuCc40Td6YRdXwqcc+zffowCNCEKQQGaKEaguWktcdidilgPHorD7kTjYYum3wdC1EJzy6wIiUUkVcbSTYa4l4opYT14OFRxjRBl0GyA5pzj9Mkz2P3DYWz4pArfrajEhk+qsPvHwzh9yhp0rjMWVVVVmDp1KrKzszFw4EB89NFHkl2bJEckvVpxqVY8a6ZziszodpYp5u9PBiX38AlJJZoM0C4Xx55Ntdj53UGcqD/tWT7jcgrzgDu/PYA9m2rhcsUfpB0OB2bMmIErr7wSJ0+exKuvvoqf//zn2LNnT9zXJskTSdAVh337lORCp4+9wM2I8/qjV19zRwUzBkVVM9MbFdQYQlKY5gI05xx7N9fi1NHTQde1upwcp46ext7NtXH3pHft2oW6ujrcd9990Ov1mDp1KiZOnIj//Oc/cV2XJFefktzQVeW8nsopMqN4VL4nqKebDEKvOExc8/4QUDy6AD+9ahh+OmMYfnrVMAwaU9Dp/owxWYIl096vBUJUSXNJYi2nrCGDs0gM0i0WG7p2l3bIkXOOHTt2SHpNklhi73jflnrwACMrvfqYO50fLJEqUKW0YKVG/e9/qKoBbVaHp/oZkPwKZ95Z9IQQ+Wjuo3Jd9YmIf5m5nBx1+47Hdb8hQ4YgNzcXzz//POx2O7744gusW7cOZ86cieu6JPlyisw4d3pJp+HnYGuwQ13Hv4ddPCr4UjHv7zvnksH46YxhOOeSwZ7z5ahw9t2KSny3ohLVWxK39IwQEprmetCnjrUk9Hx/RqMRy5cvxz333IPnnnsOpaWlmDVrFtLT0+O6LpGPFGurpVgy1njY4ikeIhexsIoUa80JIdHRXA862t6GFL2TkSNHYt26dThx4gQ+//xz1NTUYNy4cXFfl6S2Q1UNkq42iNWxQxa5m0BIStJcgI42uzaebFzRtm3bYLPZcObMGbzwwguor6/HTTfdFPd1SWpTzHIn+T8jEJKSNDfE3b1XVlQlFbv3yor7nv/5z3/w2muvwW63Y9KkSVi1ahUNcZOYNB62dCp3qgTfragMu20nIURamgvQBcVn4dSxloiGrnV6hoKBPeO+5/PPP4/nn38+7uuQ1CbOOSthWDuQNqsDeyuEpDEK0oQknuaGuLO6m9A9r2vYoWudnqF7XldkmTOS1DJCQlPKnHNIHKjZLm/iGiGpQnMBmjGGQWMLQwZpMTgPGlsYujgFIUmkmDnnMJS6tzUhWqO5IW4A0OkYBp9TiBaLDXX7jnuGvHV6hu69slAwsKfkxUkIiZfSd7oihCRXXAGaMTYawN8BZABwALiTc/4DE7qliwFcAeAMgJs455vjbGu0bUPX7iYM+UlRMm9LSMzMuVmedcdKR1tSEpJ48Q5x/wHAk5zz0QAedz8GgMsBDHL/uR3AK3HehxDNszTEVzQnmWhLSkISL94AzQF0c3+dDUCsCzgDwJtcsAGAmTGWH+e9CNE0NQ1vq6mthKhVvHPQ9wL4nDH2AoRg/1P38UIAh73OO+I+RumfhAShpjnoePbEJoREJmwPmjH2JWNsR4A/MwD8BsB9nPMiAPcBeD3aBjDGbmeMlTPGyhsbG6N/BYRoRNgtL/1IUQUvVubc+Av8EEJCC/sxmHN+UbDnGGNvApjrfvgegNfcX9cC8M7O6u0+Fuj6rwJ4FQBKS0tp/QZJWWLSlXclMaYD9Ho9HHZnwEpe362olKGl6povJ0St4h2nqgMwBcBaAFMB7HUf/xjA3YyxpQDGA2jinCd1eJtzjqP79qB85YeoqSiHw94OgzENA8b+BKXTr0Ze8WDJ1kD/5S9/wRtvvIHt27fjhhtuwBtvvOF5bvXq1bjrrrtw6NAhjB8/Hm+88Qb69u0ryX2J9kSzC1bjYUtC2xKKWobiCVGzeAP0bQAWM8YMAGwQMrYB4FMIS6z2QVhmdXOc94mK0+HA//76IvZt2ghne7unOpOjvQ17N36LmoofMfCc8bjsrvuhN8Q/l1ZQUIBHH30Un3/+OaxWq+f48ePHcc011+C1117D9OnT8dhjj2H27NnYsGFD3PckRM5MapqDJiTx4vpfxjn/BsA5AY5zAHfFc+1Ycc6F4Fy+EY72toDPO9rasK98A/731xdxxW/nxd2TvuaaawAA5eXlOHLkiOf4hx9+iOHDh+O6664DACxYsAA9e/bErl27MHTo0LjuSYhcvVidnqFPSa4s9yYklWiu1OfRfXuwb1Pg4OzN0d6OfZs24mj1noS1ZefOnRg1apTncWZmJoqLi7Fz586E3ZOkDjl6sekmA4pH5VOREkKSQHPjVOWffARne3tE5zrb21H+yXJMv/fBhLSlpaUFOTk5Pseys7Nx+nTk22ESEkyfklxUb62PaOe2ePTqa0bx6IKE3oMQ0pnmAnTN5h8j3hGIc46azT8krC1ZWVlobm72Odbc3IyuXbsm7J4kdYi92Jrt9SE3sNDpGdIyDLC12gM+36uvcB3/MqOMMQwcQ71lQuSiuSFuhz2y3rPn/Ah727EYPnw4tm7d6nnc2tqK6upqDB8+PGH3JKklp8iM8VeUYNDYAuiNnXMpxCHpsRcN8gRib2LvuHh0AQaNLfAMm6ebDBScCZGZ5nrQBmNa2Plnn/PT0uK+p8PhgMPhgNPphNPphM1mg8FgwNVXX4158+bhgw8+wLRp0/DUU09h5MiRlCBGJBfJ8iwxEMdzDUJI8miuBz1g7E8izspmjGHA2HFx33PhwoUwmUxYtGgR/vvf/8JkMmHhwoXIycnBBx98gEceeQTdu3fHxo0bsXTp0rjvRwghRPs014MuvfJq1FT8CEdb+F60Pi0NpVfOjPueCxYswIIFCwI+d9FFF2HXrl1x34MQQkhq0VwPOm/gYAw8Z3zYoWtDWhoGnjMeecWDk9QyQgghJHKaC9CMMVx21/0YWDoBhvT0TsPdjDEY0tMxsHQCLrvrfsnKfRJCCCFS0twQNwDoDQZc8dt5OFq9B+UrPxKGvNvbYUhLw4Cx4/CTK69G3kDqORNCCFEuTQZoQOgp5w8cgun3zZe7KYQQQkjUVDPEHWnxETVLhddICCEkMqoI0Eaj0WeXKK2yWq0wGo1yN4MQQogCqCJA5+bmora2FmfOnNFkL5NzjjNnzqC2tha5ubRLECGEEJXMQXfr1g0AUFdXB7s9cD1htTMajejVq5fntRJCCEltqgjQgBCkKXgRQghJFaoY4iaEEEJSDQVoQgghRIEoQBNCCCEKRAGaEEIIUSCmpGVLjLFGAAflbkcUegI4LncjkiwVXzNArzvV0OtOLXK/7r6c8xz/g4oK0GrDGCvnnJfK3Y5kSsXXDNDrlrsdyUavO7Uo9XXTEDchhBCiQBSgCSGEEAWiAB2fV+VugAxS8TUD9LpTDb3u1KLI101z0IQQQogCUQ+aEEIIUSAK0FFijL3LGNvi/nOAMbbFfbwfY8zq9dzfZW6qpBhjCxhjtV6v7wqv5x5ijO1jjO1mjF0qZzulxhh7njG2izG2jTH2EWPM7D6u6fcbABhjl7nf032MsflytydRGGNFjLGvGGOVjLGdjLG57uNBf+a1wv07bLv79ZW7j/VgjK1ijO11/91d7nZKhTE2xOv93MIYa2aM3avU95qGuOPAGPsjgCbO+VOMsX4APuGcj5C5WQnBGFsAoIVz/oLf8WEA3gEwDkABgC8BDOacO5PeyARgjF0CYA3n3MEYew4AOOcPpsD7rQewB8DFAI4A+BHADZzzSlkblgCMsXwA+ZzzzYyxrgA2AZgJYBYC/MxrCWPsAIBSzvlxr2N/AHCSc77I/cGsO+f8QbnamCjun/FaAOMB3AwFvtfUg44RY4xB+A/8jtxtkdkMAEs5522c8/0A9kEI1prAOf+Cc+5wP9wAoLec7UmicQD2cc5rOOftAJZCeK81h3Nezznf7P76NIAqAIXytkpWMwAscX+9BMKHFS26EEA151yxxbEoQMduEoBjnPO9Xsf6M8YqGGPrGGOT5GpYAt3tHur9l9ewVyGAw17nHIF2f7n9CsBnXo+1/H6n0vvq4R4ZGQNgo/tQoJ95LeEAvmCMbWKM3e4+1otzXu/++iiAXvI0LeGuh28HS3HvNQXoABhjXzLGdgT4492DuAG+b249gD6c8zEA7gfwNmNMVRtYh3ndrwAoBjAawmv9o5xtlVIk7zdj7BEADgBvuQ+p/v0mvhhjWQA+AHAv57wZGv6Z93Ie53wsgMsB3MUYm+z9JBfmQDU3D8oYSwNwFYD33IcU+V4b5G6AEnHOLwr1PGPMAOAaAOd4fU8bgDb315sYY9UABgMoT2BTJRXudYsYY/8E8In7YS2AIq+ne7uPqUYE7/dNAK4EcKH7F5Ym3u8wVP++RoMxZoQQnN/inH8IAJzzY17Pe//MawbnvNb9dwNj7CMIUxvHGGP5nPN69/x8g6yNTIzLAWwW32OlvtfUg47NRQB2cc6PiAcYYznupAMwxgYAGASgRqb2Sc79H1V0NYAd7q8/BnA9YyydMdYfwuv+IdntSxTG2GUAHgBwFef8jNdxTb/fEJLCBjHG+rt7G9dDeK81x51P8jqAKs75i17Hg/3MawJjLNOdFAfGWCaASyC8xo8BzHGfNgfACnlamFA+I6BKfa+pBx0b/7kLAJgM4CnGmB2AC8AdnPOTSW9Z4vyBMTYawnDXAQC/BgDO+U7G2DIAlRCGgO/SSga3218ApANYJfwexwbO+R3Q+Pvtzlq/G8DnAPQA/sU53ylzsxJlIoBfANjO3MsmATwM4IZAP/Ma0gvAR+6fawOAtznn/2OM/QhgGWPsFgi7C86SsY2Sc38YuRi+72fA329yo2VWhBBCiALREDchhBCiQBSgCSGEEAWiAE0IIYQoEAVoQgghRIEoQBNCCCEKRAGaEEIIUSAK0IQQQogCUYAmhBBCFOj/A1UgoBIlfNCkAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 576x576 with 1 Axes>"
       ]
@@ -1433,33 +2309,34 @@
     },
     {
      "data": {
+      "text/html": [
+       "<style>#sk-container-id-7 {color: black;background-color: white;}#sk-container-id-7 pre{padding: 0;}#sk-container-id-7 div.sk-toggleable {background-color: white;}#sk-container-id-7 label.sk-toggleable__label {cursor: pointer;display: block;width: 100%;margin-bottom: 0;padding: 0.3em;box-sizing: border-box;text-align: center;}#sk-container-id-7 label.sk-toggleable__label-arrow:before {content: \"▸\";float: left;margin-right: 0.25em;color: #696969;}#sk-container-id-7 label.sk-toggleable__label-arrow:hover:before {color: black;}#sk-container-id-7 div.sk-estimator:hover label.sk-toggleable__label-arrow:before {color: black;}#sk-container-id-7 div.sk-toggleable__content {max-height: 0;max-width: 0;overflow: hidden;text-align: left;background-color: #f0f8ff;}#sk-container-id-7 div.sk-toggleable__content pre {margin: 0.2em;color: black;border-radius: 0.25em;background-color: #f0f8ff;}#sk-container-id-7 input.sk-toggleable__control:checked~div.sk-toggleable__content {max-height: 200px;max-width: 100%;overflow: auto;}#sk-container-id-7 input.sk-toggleable__control:checked~label.sk-toggleable__label-arrow:before {content: \"▾\";}#sk-container-id-7 div.sk-estimator input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-7 div.sk-label input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-7 input.sk-hidden--visually {border: 0;clip: rect(1px 1px 1px 1px);clip: rect(1px, 1px, 1px, 1px);height: 1px;margin: -1px;overflow: hidden;padding: 0;position: absolute;width: 1px;}#sk-container-id-7 div.sk-estimator {font-family: monospace;background-color: #f0f8ff;border: 1px dotted black;border-radius: 0.25em;box-sizing: border-box;margin-bottom: 0.5em;}#sk-container-id-7 div.sk-estimator:hover {background-color: #d4ebff;}#sk-container-id-7 div.sk-parallel-item::after {content: \"\";width: 100%;border-bottom: 1px solid gray;flex-grow: 1;}#sk-container-id-7 div.sk-label:hover label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-7 div.sk-serial::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: 0;}#sk-container-id-7 div.sk-serial {display: flex;flex-direction: column;align-items: center;background-color: white;padding-right: 0.2em;padding-left: 0.2em;position: relative;}#sk-container-id-7 div.sk-item {position: relative;z-index: 1;}#sk-container-id-7 div.sk-parallel {display: flex;align-items: stretch;justify-content: center;background-color: white;position: relative;}#sk-container-id-7 div.sk-item::before, #sk-container-id-7 div.sk-parallel-item::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: -1;}#sk-container-id-7 div.sk-parallel-item {display: flex;flex-direction: column;z-index: 1;position: relative;background-color: white;}#sk-container-id-7 div.sk-parallel-item:first-child::after {align-self: flex-end;width: 50%;}#sk-container-id-7 div.sk-parallel-item:last-child::after {align-self: flex-start;width: 50%;}#sk-container-id-7 div.sk-parallel-item:only-child::after {width: 0;}#sk-container-id-7 div.sk-dashed-wrapped {border: 1px dashed gray;margin: 0 0.4em 0.5em 0.4em;box-sizing: border-box;padding-bottom: 0.4em;background-color: white;}#sk-container-id-7 div.sk-label label {font-family: monospace;font-weight: bold;display: inline-block;line-height: 1.2em;}#sk-container-id-7 div.sk-label-container {text-align: center;}#sk-container-id-7 div.sk-container {/* jupyter's `normalize.less` sets `[hidden] { display: none; }` but bootstrap.min.css set `[hidden] { display: none !important; }` so we also need the `!important` here to be able to override the default hidden behavior on the sphinx rendered scikit-learn.org. See: https://github.com/scikit-learn/scikit-learn/issues/21755 */display: inline-block !important;position: relative;}#sk-container-id-7 div.sk-text-repr-fallback {display: none;}</style><div id=\"sk-container-id-7\" class=\"sk-top-container\"><div class=\"sk-text-repr-fallback\"><pre>TSNE(init=&#x27;random&#x27;, learning_rate=&#x27;auto&#x27;, random_state=42, verbose=1)</pre><b>In a Jupyter environment, please rerun this cell to show the HTML representation or trust the notebook. <br />On GitHub, the HTML representation is unable to render, please try loading this page with nbviewer.org.</b></div><div class=\"sk-container\" hidden><div class=\"sk-item\"><div class=\"sk-estimator sk-toggleable\"><input class=\"sk-toggleable__control sk-hidden--visually\" id=\"sk-estimator-id-7\" type=\"checkbox\" checked><label for=\"sk-estimator-id-7\" class=\"sk-toggleable__label sk-toggleable__label-arrow\">TSNE</label><div class=\"sk-toggleable__content\"><pre>TSNE(init=&#x27;random&#x27;, learning_rate=&#x27;auto&#x27;, random_state=42, verbose=1)</pre></div></div></div></div></div>"
+      ],
       "text/plain": [
-       "TSNE(random_state=42, verbose=1)"
+       "TSNE(init='random', learning_rate='auto', random_state=42, verbose=1)"
       ]
      },
-     "execution_count": 122,
+     "execution_count": 166,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "visualize(fps, fingerprints_to_highlight = [fps1, fps2])"
+    "def train_and_fingerprint(epochs, learning_rate, files_to_fingerprint) :\n",
+    "    if epochs>0:\n",
+    "        learn.fit_one_cycle(epochs,slice(learning_rate))\n",
+    "    fingerprints = fingerprint_all(files_to_fingerprint)\n",
+    "    return visualize(fingerprints, fingerprints_to_highlight = [fps1, fps2]) \n",
+    "\n",
+    "train_and_fingerprint(0, .0005, fnames)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2a137789",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:fastai.v5]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-fastai.v5-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1471,7 +2348,14 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.10.4"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Thanks for the excellent tutorial! 
Made a couple of changes and got the embeddings of the stars to be close enough they are the first match. Also:

- Fixed the issue that required the %%capture (progress bars on the predict were causing it).
- Added display_data parameters to a couple of functions to display the images along side the embeddings.
- Removed some unused imports
- Added an additional FClayer in the head and decreased the size of the embeddings

Thanks again for sharing the tutorial, learned quite a bit from it!
All the best